### PR TITLE
Generate schemas to build/generated/dataframe/

### DIFF
--- a/docs/StardustDocs/topics/gradle.md
+++ b/docs/StardustDocs/topics/gradle.md
@@ -39,7 +39,7 @@ teens.print()
 
 ### Schema inference
 Specify schema's configurations in `dataframes`  and execute the `build` task.
-For the following configuration, file `Repository.Generated.kt` will be generated.
+For the following configuration, file `Repository.Generated.kt` will be generated to `build/generated/dataframe` folder
 See [reference](gradleReference.md) and [examples](gradleReference.md#examples) for more details.
 
 #### build.gradle

--- a/docs/StardustDocs/topics/gradleReference.md
+++ b/docs/StardustDocs/topics/gradleReference.md
@@ -18,7 +18,7 @@ dataframes {
         sourceSet /* String */ = "…" // [optional; override default]
         packageName /* String */ = "…" // [optional; override default]
         visibility /* DataSchemaVisibility */ = "…" // [optional; override default]
-        src /* File */ = file("…") // [optional; default: file("src/$sourceSet/kotlin")]
+        src /* File */ = file("…") // [optional; default: file("build/generated/dataframe/$sourceSet/kotlin")]
         
         data /* URL | File | String */ = "…" // Data in JSON or CSV formats
         name = "org.jetbrains.data.Person" // [optional; default: from filename]
@@ -36,7 +36,7 @@ dataframes {
 In the best scenario, your schema could be defined as simple as this:
 ```kotlin
 dataframes {
-    // output: src/main/kotlin/org/example/dataframe/Jetbrains_repositories.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/dataframe/Jetbrains_repositories.Generated.kt
     schema {
         data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
     }
@@ -45,7 +45,7 @@ dataframes {
 You can set parsing options for CSV:
 ```kotlin
 dataframes {
-    // output: src/main/kotlin/org/example/dataframe/Securities.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/dataframe/Securities.Generated.kt
     schema {
         data = "https://raw.githubusercontent.com/Kotlin/dataframe/1765966904c5920154a4a480aa1fcff23324f477/data/securities.csv"
         csvOptions {
@@ -54,11 +54,11 @@ dataframes {
     }
 }
 ```
-In this case output path will depend on your directory structure. For project with package `org.example` path will be `src/main/kotlin/org/example/dataframe/Securities.Generated.kt
+In this case output path will depend on your directory structure. For project with package `org.example` path will be `build/generated/dataframe/main/kotlin/org/example/dataframe/Securities.Generated.kt
 `. Note that name of the Kotlin file is derived from the name of the data file with the suffix `.Generated` and the package is derived from the directory structure with child directory `dataframe`. The name of the **data schema** itself is `Securities`. You could specify it explicitly:
 ```kotlin
 schema {
-    // output: src/main/kotlin/org/example/dataframe/MyName.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/dataframe/MyName.Generated.kt
     data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
     name = "MyName"
 }
@@ -73,7 +73,7 @@ dataframes {
 Then you can set packageName for specific schema exclusively:
 ```kotlin
 dataframes {
-    // output: src/main/kotlin/org/example/data/OtherName.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/data/OtherName.Generated.kt
     schema {
         packageName = "org.example.data"
         data = file("path/to/data.csv")
@@ -83,7 +83,7 @@ dataframes {
 If you want non-default name and package, consider using fully-qualified name:
 ```kotlin
 dataframes {
-    // output: src/main/kotlin/org/example/data/OtherName.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/data/OtherName.Generated.kt
     schema {
         name = org.example.data.OtherName
         data = file("path/to/data.csv")
@@ -95,11 +95,11 @@ By default, plugin will generate output in specified source set. Source set coul
 dataframes {
     packageName = "org.example"
     sourceSet = "test"
-    // output: src/test/kotlin/org/example/Data.Generated.kt
+    // output: build/generated/dataframe/test/kotlin/org/example/Data.Generated.kt
     schema {
         data = file("path/to/data.csv")
     }
-    // output: src/integrationTest/kotlin/org/example/Data.Generated.kt
+    // output: build/generated/dataframe/integrationTest/kotlin/org/example/Data.Generated.kt
     schema {
         sourceSet = "integrationTest"
         data = file("path/to/data.csv")

--- a/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
@@ -125,9 +125,8 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
         result.task(":generateDataFrameData")?.outcome shouldBe TaskOutcome.SUCCESS
     }
 
-    @Ignore(TRANSITIVE_DF_DEPENDENCY)
     @Test
-    fun `generated schemas and extensions resolved`() {
+    fun `generated schemas resolved`() {
         val (_, result) = runGradleBuild(":build") { buildDir ->
             val dataFile = File(buildDir, "data.csv")
             dataFile.writeText(TestData.csvSample)
@@ -135,15 +134,7 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
             val kotlin = File(buildDir, "src/main/kotlin").also { it.mkdirs() }
             val main = File(kotlin, "Main.kt")
             main.writeText("""
-                import org.jetbrains.kotlinx.DataFrame
-                import org.jetbrains.kotlinx.read
-                import org.jetbrains.kotlinx.typed
-                import org.jetbrains.kotlinx.filter
-                
-                fun main() {
-                    val df = DataFrame.read("$dataFile").typed<Schema>()
-                    val df1 = df.filter { age != null }
-                }
+                import org.example.Schema
             """.trimIndent())
 
             """
@@ -169,8 +160,7 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
                 dataframes {
                     schema {
                         data = "$dataFile"
-                        name = "Schema"
-                        packageName = ""
+                        name = "org.example.Schema"
                     }
                 }
             """.trimIndent()
@@ -181,8 +171,14 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
     @Test
     fun `generated schemas resolved in jvmMain source set for multiplatform project`() {
         val (_, result) = runGradleBuild(":build") { buildDir ->
-            val dataFile = File(buildDir, TestData.csvName)
+            val dataFile = File(buildDir, "data.csv")
             dataFile.writeText(TestData.csvSample)
+
+            val kotlin = File(buildDir, "src/jvmMain/kotlin").also { it.mkdirs() }
+            val main = File(kotlin, "Main.kt")
+            main.writeText("""
+                import org.example.Schema
+            """.trimIndent())
             """
                 import org.jetbrains.dataframe.gradle.SchemaGeneratorExtension    
                     
@@ -211,8 +207,7 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
                 dataframes {
                     schema {
                         data = file("${TestData.csvName}")
-                        name = "Schema"
-                        packageName = ""
+                        name = "org.example.Schema"
                     }
                 }
             """.trimIndent()

--- a/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.dataframe.gradle
 
+import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Ignore
@@ -86,7 +87,9 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
             """.trimIndent()
         }
         result.task(":generateDataFrameData")?.outcome shouldBe TaskOutcome.SUCCESS
-        File(dir, "src/main/kotlin/dataframe/Data.Generated.kt").exists() shouldBe true
+        File(dir, "build/generated/dataframe").walkBottomUp().toList().asClue {
+            File(dir, "build/generated/dataframe/main/kotlin/dataframe/Data.Generated.kt").exists() shouldBe true
+        }
     }
 
     @Test

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/GenerateDataSchemaTask.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/GenerateDataSchemaTask.kt
@@ -156,19 +156,6 @@ abstract class GenerateDataSchemaTask : DefaultTask() {
 
     private fun buildSourceFileContent(escapedPackageName: String, codeGenResult: CodeGenResult): String {
         return buildString {
-            appendLine(
-                """
-                @file:Suppress(
-                    "RemoveRedundantBackticks",
-                    "RemoveRedundantQualifierName",
-                    "unused", "ObjectPropertyName",
-                    "UNCHECKED_CAST", "PropertyName",
-                    "ClassName", "UnusedImport",
-                    "MemberVisibilityCanBePrivate"
-                )
-                """.trimIndent()
-            )
-
             if (escapedPackageName.isNotEmpty()) {
                 appendLine("package $escapedPackageName")
                 appendLine()
@@ -184,7 +171,6 @@ abstract class GenerateDataSchemaTask : DefaultTask() {
             appendLine("import org.jetbrains.kotlinx.dataframe.io.readJson")
             appendLine("import org.jetbrains.kotlinx.dataframe.io.readCSV")
             appendLine()
-            appendLine("// GENERATED. DO NOT EDIT MANUALLY")
             appendLine(codeGenResult.code.declarations)
         }
     }

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
@@ -61,11 +61,9 @@ class SchemaGeneratorPlugin : Plugin<Project> {
             ?: run {
                 appliedPlugin ?: propertyError("src")
                 val sourceSet = appliedPlugin.kotlinExtension.sourceSets.getByName(sourceSetName)
-                val path = appliedPlugin.sourceSetConfiguration.getKotlinRoot(
-                    sourceSet.kotlin.sourceDirectories,
-                    sourceSetName
-                )
-                target.file(path)
+                val src = target.file(Paths.get("build/generated/dataframe/", sourceSetName, "kotlin").toFile())
+                sourceSet.kotlin.srcDir(src)
+                src
             }
 
         val packageName = schema.name?.let { name -> extractPackageName(name) }
@@ -73,6 +71,12 @@ class SchemaGeneratorPlugin : Plugin<Project> {
             ?: extension.packageName
             ?: run {
                 (appliedPlugin ?: propertyError("packageName"))
+                val sourceSet = appliedPlugin.kotlinExtension.sourceSets.getByName(sourceSetName)
+                val path = appliedPlugin.sourceSetConfiguration.getKotlinRoot(
+                    sourceSet.kotlin.sourceDirectories,
+                    sourceSetName
+                )
+                val src = target.file(path)
                 inferPackageName(src)
             }
 

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
@@ -296,7 +296,7 @@ internal class SchemaGeneratorPluginTest {
             """.trimIndent()
         }
         result.task(":generateDataFrameTest")?.outcome shouldBe TaskOutcome.SUCCESS
-        File(buildDir, "src/main/kotlin/org/test/Test.Generated.kt").readLines().let {
+        File(buildDir, "build/generated/dataframe/main/kotlin/org/test/Test.Generated.kt").readLines().let {
             it.forOne {
                 it.shouldContain("val a")
             }
@@ -328,6 +328,6 @@ internal class SchemaGeneratorPluginTest {
         project.file("src/main1/kotlin/org/example/test").also { it.mkdirs() }
         project.evaluate()
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).dataSchema.get()
-            .shouldBe(project.file("src/main1/kotlin/org/example/test/dataframe/321.Generated.kt"))
+            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/org/example/test/dataframe/321.Generated.kt"))
     }
 }

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskDataSchemaPropertyTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskDataSchemaPropertyTest.kt
@@ -30,7 +30,7 @@ class TaskDataSchemaPropertyTest {
             project.evaluate()
         }
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).dataSchema.get()
-            .shouldBe(project.file("src/main1/kotlin/org/example/my/321.Generated.kt"))
+            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/org/example/my/321.Generated.kt"))
     }
 
     @Test
@@ -56,7 +56,7 @@ class TaskDataSchemaPropertyTest {
             project.evaluate()
         }
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).dataSchema.get()
-            .shouldBe(project.file("src/main1/kotlin/org/example/my/321.Generated.kt"))
+            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/org/example/my/321.Generated.kt"))
     }
 
 }

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskSourceSetPropertyTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskSourceSetPropertyTest.kt
@@ -34,7 +34,7 @@ class TaskSourceSetPropertyTest {
             project.evaluate()
         }
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).src.get()
-            .shouldBe(project.file("src/main1/kotlin/"))
+            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/"))
     }
 
     @Test
@@ -69,7 +69,7 @@ class TaskSourceSetPropertyTest {
         }
         project.evaluate()
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).src.get()
-            .shouldBe(project.file("src/main/kotlin/"))
+            .shouldBe(project.file("build/generated/dataframe/main/kotlin/"))
     }
 
     @Test
@@ -90,7 +90,7 @@ class TaskSourceSetPropertyTest {
         }
         project.evaluate()
         (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask).src.get()
-            .shouldBe(project.file("src/main1/kotlin/"))
+            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/"))
     }
 
     @Test


### PR DESCRIPTION
Working with generated code in a codebase turned out to be annoying: linter complains, also they getting mixed with other files and IDE handles them as usual files. But for files in "build/generated" it warns users not to edit it and do not require suppressing warnings