### PR TITLE
Fix JvmName

### DIFF
--- a/docs/StardustDocs/topics/gradleReference.md
+++ b/docs/StardustDocs/topics/gradleReference.md
@@ -13,6 +13,11 @@ dataframes {
         
     withoutDefaultPath() // disable default path for all schemas
     // i.e. plugin won't copy "data" property of the schemas to generated companion objects
+
+    // split field names by delimiters (arguments of this method), lowercase parts and join to camel case
+    // enabled by default
+    withNormalizationBy('_') // [optional: default: ['\t', '_', ' ']]
+    withoutNormalization() // disable field names normalization
     
     schema {
         sourceSet /* String */ = "…" // [optional; override default]
@@ -25,6 +30,10 @@ dataframes {
         csvOptions {
             delimiter /* Char */ = ';' // [optional; default: ',']
         }
+
+        // See names normalization
+        withNormalizationBy('_') // enable field names normalization for this schema and use these delimiters
+        withoutNormalization() // disable field names normalization for this schema
         
         withoutDefaultPath() // disable default path for this schema
         withDefaultPath() // enable default path for this schema
@@ -36,12 +45,13 @@ dataframes {
 In the best scenario, your schema could be defined as simple as this:
 ```kotlin
 dataframes {
-    // output: build/generated/dataframe/main/kotlin/org/example/dataframe/Jetbrains_repositories.Generated.kt
+    // output: build/generated/dataframe/main/kotlin/org/example/dataframe/JetbrainsRepositories.Generated.kt
     schema {
         data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
     }
 }
 ```
+Note than name of the file and the interface are normalized: split by '_' and ' ' and joined to camel case.
 You can set parsing options for CSV:
 ```kotlin
 dataframes {

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/GenerateDataSchemaTask.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/GenerateDataSchemaTask.kt
@@ -79,7 +79,8 @@ abstract class GenerateDataSchemaTask : DefaultTask() {
                         DefaultReadCsvMethod(defaultPath, delimiter)
                     }
                 }
-            }
+            },
+            normalizeFieldNames = true
         )
         val escapedPackageName = escapePackageName(packageName.get())
 

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorExtension.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorExtension.kt
@@ -15,6 +15,7 @@ open class SchemaGeneratorExtension {
     var sourceSet: String? = null
     var visibility: DataSchemaVisibility? = null
     internal var defaultPath: Boolean? = null
+    internal var withNormalizationBy: Set<Char>? = null
 
     fun schema(config: Schema.() -> Unit) {
         val schema = Schema(project).apply(config)
@@ -30,6 +31,20 @@ open class SchemaGeneratorExtension {
     fun withoutDefaultPath() {
         defaultPath = false
     }
+
+    fun withNormalizationBy(vararg delimiter: Char) {
+        withNormalizationBy = delimiter.toSet()
+    }
+
+    // Overload for Groovy.
+    // It's impossible to call a method with char argument without type cast in groovy, because it only has string literals
+    fun withNormalizationBy(delimiter: String) {
+        withNormalizationBy = delimiter.toSet()
+    }
+
+    fun withoutNormalization() {
+        withNormalizationBy = emptySet()
+    }
 }
 
 class Schema(
@@ -41,6 +56,7 @@ class Schema(
     var sourceSet: String? = null,
     var visibility: DataSchemaVisibility? = null,
     internal var defaultPath: Boolean? = null,
+    internal var withNormalizationBy: Set<Char>? = null,
     val csvOptions: CsvOptions = CsvOptions()
 ) {
     fun setData(file: File) {
@@ -68,6 +84,20 @@ class Schema(
 
     fun withDefaultPath() {
         defaultPath = true
+    }
+
+    fun withNormalizationBy(vararg delimiter: Char) {
+        withNormalizationBy = delimiter.toSet()
+    }
+
+    // Overload for Groovy.
+    // It's impossible to call a method with char argument without type cast in groovy, because it only has string literals
+    fun withNormalizationBy(delimiter: String) {
+        withNormalizationBy = delimiter.toSet()
+    }
+
+    fun withoutNormalization() {
+        withNormalizationBy = emptySet()
     }
 }
 

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
@@ -96,6 +96,7 @@ class SchemaGeneratorPlugin : Plugin<Project> {
             }
 
         val defaultPath = schema.defaultPath ?: extension.defaultPath ?: true
+        val delimiters = schema.withNormalizationBy ?: extension.withNormalizationBy ?: setOf('\t', ' ', '_')
 
         return target.tasks.create("generateDataFrame${interfaceName}", GenerateDataSchemaTask::class.java) {
             group = GROUP
@@ -106,6 +107,7 @@ class SchemaGeneratorPlugin : Plugin<Project> {
             this.schemaVisibility.set(visibility)
             this.csvOptions.set(schema.csvOptions)
             this.defaultPath.set(defaultPath)
+            this.delimiters.set(delimiters)
         }
     }
 
@@ -121,14 +123,6 @@ class SchemaGeneratorPlugin : Plugin<Project> {
     }
 
     private val delimiters = "[\\s_]".toRegex()
-
-    private fun String.toCamelCaseByDelimiters(delimiters: Regex): String {
-        return split(delimiters).joinToCamelCaseString()
-    }
-
-    private fun List<String>.joinToCamelCaseString(): String {
-        return joinToString(separator = "") { it.capitalize() }
-    }
 
     private class AppliedPlugin(
         val kotlinExtension: KotlinProjectExtension,

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
@@ -111,11 +111,23 @@ class SchemaGeneratorPlugin : Plugin<Project> {
 
     private fun getInterfaceName(schema: Schema): String? {
         val rawName = schema.name?.substringAfterLast('.')
-            ?: fileName(schema.data)?.capitalize()
+            ?: fileName(schema.data)
+                ?.toCamelCaseByDelimiters(delimiters)
+                ?.capitalize()
                 ?.removeSurrounding("`")
             ?: return null
         NameChecker.checkValidIdentifier(rawName)
         return rawName
+    }
+
+    private val delimiters = "[\\s_]".toRegex()
+
+    private fun String.toCamelCaseByDelimiters(delimiters: Regex): String {
+        return split(delimiters).joinToCamelCaseString()
+    }
+
+    private fun List<String>.joinToCamelCaseString(): String {
+        return joinToString(separator = "") { it.capitalize() }
     }
 
     private class AppliedPlugin(

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/toCamelCaseByDelimiters.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/toCamelCaseByDelimiters.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.dataframe.gradle
+
+fun String.toCamelCaseByDelimiters(delimiters: Regex): String {
+    return split(delimiters).joinToCamelCaseString().decapitalize()
+}
+
+fun List<String>.joinToCamelCaseString(): String {
+    return joinToString(separator = "") { it.capitalize() }
+}

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
@@ -103,6 +103,38 @@ internal class SchemaGeneratorPluginTest {
     }
 
     @Test
+    fun `delimiters configured with Groovy`() {
+        val buildDir = Files.createTempDirectory("test").toFile()
+        val buildFile = File(buildDir, "build.gradle")
+        buildFile.writeText(
+            """
+                import java.net.URL
+                import org.jetbrains.dataframe.gradle.SchemaGeneratorExtension    
+                    
+                plugins {
+                    id "org.jetbrains.kotlin.jvm" version "$KOTLIN_VERSION"
+                    id "org.jetbrains.kotlin.plugin.dataframe"
+                }
+                
+                repositories {
+                    mavenCentral() 
+                }
+    
+                dataframes {
+                    schema {
+                        data = new URL("https://raw.githubusercontent.com/Kotlin/dataframe/8ea139c35aaf2247614bb227756d6fdba7359f6a/data/playlistItems.json")
+                        name = "Test"
+                        packageName = "org.test"
+                        withNormalizationBy('-_\t ')
+                    }
+                }
+            """.trimIndent()
+        )
+        val result = gradleRunner(buildDir, ":generateDataFrameTest").build()
+        result.task(":generateDataFrameTest")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    @Test
     fun `plugin configure multiple schemas from URLs via extension`() {
         val (_, result) = runGradleBuild(":generateDataFrames") {
             """

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskNamePropertyTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/TaskNamePropertyTest.kt
@@ -88,6 +88,6 @@ class TaskNamePropertyTest {
             }
         }
         project.evaluate()
-        project.tasks.getByName("generateDataFrameCity_population") shouldNotBe null
+        project.tasks.getByName("generateDataFrameCityPopulation") shouldNotBe null
     }
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
@@ -30,7 +30,8 @@ public interface CodeGenerator : ExtensionsCodeGenerator {
         isOpen: Boolean,
         visibility: MarkerVisibility = MarkerVisibility.IMPLICIT_PUBLIC,
         knownMarkers: Iterable<Marker> = emptyList(),
-        readDfMethod: DefaultReadDfMethod? = null
+        readDfMethod: DefaultReadDfMethod? = null,
+        normalizeFieldNames: Boolean = false
     ): CodeGenResult
 
     public fun generate(marker: Marker, interfaceMode: InterfaceGenerationMode, extensionProperties: Boolean): CodeWithConverter

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
@@ -31,7 +31,7 @@ public interface CodeGenerator : ExtensionsCodeGenerator {
         visibility: MarkerVisibility = MarkerVisibility.IMPLICIT_PUBLIC,
         knownMarkers: Iterable<Marker> = emptyList(),
         readDfMethod: DefaultReadDfMethod? = null,
-        normalizeFieldNames: Boolean = false
+        fieldNameNormalizer: (String) -> String = { it }
     ): CodeGenResult
 
     public fun generate(marker: Marker, interfaceMode: InterfaceGenerationMode, extensionProperties: Boolean): CodeWithConverter

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/SchemaProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/SchemaProcessor.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.codeGen
 
+import org.jetbrains.kotlinx.dataframe.impl.DELIMITED_STRING_REGEX
+import org.jetbrains.kotlinx.dataframe.impl.DELIMITERS_REGEX
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.SchemaProcessorImpl
+import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
 internal interface SchemaProcessor {
@@ -16,6 +19,24 @@ internal interface SchemaProcessor {
     ): Marker
 
     companion object {
-        fun create(namePrefix: String, existingMarkers: Iterable<Marker> = emptyList()) = SchemaProcessorImpl(existingMarkers, namePrefix)
+        fun create(
+            namePrefix: String,
+            existingMarkers: Iterable<Marker> = emptyList(),
+            normalizeFieldNames: Boolean = false
+        ): SchemaProcessorImpl {
+            return if (normalizeFieldNames) {
+                SchemaProcessorImpl(existingMarkers, namePrefix, fieldNameNormalizer)
+            } else {
+                SchemaProcessorImpl(existingMarkers, namePrefix)
+            }
+        }
+
+        private val fieldNameNormalizer: (String) -> String = {
+            if (it matches DELIMITED_STRING_REGEX) {
+                it.lowercase().toCamelCaseByDelimiters(DELIMITERS_REGEX)
+            } else {
+                it
+            }
+        }
     }
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/SchemaProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/SchemaProcessor.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.codeGen
 
-import org.jetbrains.kotlinx.dataframe.impl.DELIMITED_STRING_REGEX
-import org.jetbrains.kotlinx.dataframe.impl.DELIMITERS_REGEX
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.SchemaProcessorImpl
-import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
 internal interface SchemaProcessor {
@@ -22,21 +19,9 @@ internal interface SchemaProcessor {
         fun create(
             namePrefix: String,
             existingMarkers: Iterable<Marker> = emptyList(),
-            normalizeFieldNames: Boolean = false
+            fieldNameNormalizer: (String) -> String = { it }
         ): SchemaProcessorImpl {
-            return if (normalizeFieldNames) {
-                SchemaProcessorImpl(existingMarkers, namePrefix, fieldNameNormalizer)
-            } else {
-                SchemaProcessorImpl(existingMarkers, namePrefix)
-            }
-        }
-
-        private val fieldNameNormalizer: (String) -> String = {
-            if (it matches DELIMITED_STRING_REGEX) {
-                it.lowercase().toCamelCaseByDelimiters(DELIMITERS_REGEX)
-            } else {
-                it
-            }
+            return SchemaProcessorImpl(existingMarkers, namePrefix, fieldNameNormalizer)
         }
     }
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -206,9 +206,10 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FqNames)
         isOpen: Boolean,
         visibility: MarkerVisibility,
         knownMarkers: Iterable<Marker>,
-        readDfMethod: DefaultReadDfMethod?
+        readDfMethod: DefaultReadDfMethod?,
+        normalizeFieldNames: Boolean
     ): CodeGenResult {
-        val context = SchemaProcessor.create(name, knownMarkers)
+        val context = SchemaProcessor.create(name, knownMarkers, normalizeFieldNames)
         val marker = context.process(schema, isOpen, visibility)
         val declarations = mutableListOf<Code>()
         context.generatedMarkers.forEach { itMarker ->

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -207,9 +207,9 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FqNames)
         visibility: MarkerVisibility,
         knownMarkers: Iterable<Marker>,
         readDfMethod: DefaultReadDfMethod?,
-        normalizeFieldNames: Boolean
+        fieldNameNormalizer: (String) -> String
     ): CodeGenResult {
-        val context = SchemaProcessor.create(name, knownMarkers, normalizeFieldNames)
+        val context = SchemaProcessor.create(name, knownMarkers, fieldNameNormalizer)
         val marker = context.process(schema, isOpen, visibility)
         val declarations = mutableListOf<Code>()
         context.generatedMarkers.forEach { itMarker ->

--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
@@ -11,7 +11,8 @@ import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
 internal class SchemaProcessorImpl(
     existingMarkers: Iterable<Marker>,
-    override val namePrefix: String
+    override val namePrefix: String,
+    private val fieldNameNormalizer: (String) -> String = { it }
 ) : SchemaProcessor {
 
     private val registeredMarkers = existingMarkers.toMutableList()
@@ -30,11 +31,12 @@ internal class SchemaProcessorImpl(
 
     private fun generateValidFieldName(columnName: String, index: Int, usedNames: Collection<String>): ValidFieldName {
         var result = ValidFieldName.of(columnName)
+        result = ValidFieldName.of(fieldNameNormalizer(result.unquoted))
         if (result.unquoted.isEmpty()) result = ValidFieldName.of("_$index")
         val baseName = result
         var attempt = 2
         while (usedNames.contains(result.quotedIfNeeded)) {
-            result = if (result.needsQuote) baseName + ValidFieldName.of(" ($attempt)") else baseName + ValidFieldName.of("_$attempt")
+            result = if (result.needsQuote) baseName + ValidFieldName.of(" ($attempt)") else baseName + ValidFieldName.of("$attempt")
             attempt++
         }
         return result


### PR DESCRIPTION
Android's DEX format doesn't support whitespaces in names in version < 40, but code generator can infer names with whitespaces from data. Added an option to normalize field names (enabled by default) which splits them by delimiters (' ', '_', '\t') and joins to camel case, effectively removing whitespaces. 