### PR TITLE
Pad records with nulls if it has fewer columns than header

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -274,7 +274,12 @@ public fun DataFrame.Companion.readDelim(
         val colType = colTypes[colName] ?: defaultColType
         var hasNulls = false
         val values = records.map {
-            it[colIndex].ifEmpty {
+            if (it.isSet(colIndex)) {
+                it[colIndex].ifEmpty {
+                    hasNulls = true
+                    null
+                }
+            } else {
                 hasNulls = true
                 null
             }

--- a/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDateTime
@@ -135,6 +136,23 @@ class CsvTests {
         val df = DataFrame.readCSV(durationCsv)
         df["duration"].type() shouldBe typeOf<String>()
         df["floatDuration"].type() shouldBe typeOf<String>()
+    }
+
+    @Test
+    fun `if record has fewer columns than header then pad it with nulls`() {
+        val csvContent = """col1,col2,col3
+            568,801,587
+            780,588
+        """.trimIndent()
+
+        val df = shouldNotThrowAny {
+            DataFrame.readDelimStr(csvContent)
+        }
+
+        df shouldBe dataFrameOf("col1", "col2", "col3")(
+            568, 801, 587,
+            780, 588, null
+        )
     }
 
     @Test


### PR DESCRIPTION
It seems sometimes CSV doesn't have trailing commas at the end of the record
Fix for https://github.com/Kotlin/dataframe/issues/101