### PR TITLE
Explicit ArrowFormat parameter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinDatetime = "0.3.1"
 junit = "4.13.2"
 kotestAsserions = "4.6.3"
 jsoup = "1.14.3"
-arrow = "7.0.0"
+arrow = "8.0.0"
 
 [libraries]
 ksp-gradle = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }


### PR DESCRIPTION
Because of Arrow has two encoding types (Random Access aka Feather and IPC Stream) both of which can be accessed via File, URL and other ways, including raw existing Channel (functions were converted to public), and we should have methods for reading any of them.

Also this patch includes Boolean (BitVector) support and Arrow version upgrade