### PR TITLE
More Converting operations

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlinx.dataframe.io.toDataFrame
 import java.math.BigDecimal
 import java.net.URL
 import java.time.LocalTime
-import java.util.*
+import java.util.Locale
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlinx.dataframe.type
 import java.math.BigDecimal
 import java.net.URL
 import java.time.LocalTime
-import java.util.*
+import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlin.reflect.KType
@@ -206,7 +206,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Byte::class -> convert<Number> { it.toByte() }
                 Short::class -> convert<Number> { it.toShort() }
                 Long::class -> convert<Number> { it.toLong() }
-                Boolean::class -> convert<Number> { it != 0 }
+                Boolean::class -> convert<Number> { it.toDouble() != 0.0 }
                 else -> null
             }
             Int::class -> when (toClass) {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -206,6 +206,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Byte::class -> convert<Number> { it.toByte() }
                 Short::class -> convert<Number> { it.toShort() }
                 Long::class -> convert<Number> { it.toLong() }
+                Boolean::class -> convert<Number> { it != 0 }
                 else -> null
             }
             Int::class -> when (toClass) {
@@ -215,6 +216,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Short::class -> convert<Int> { it.toShort() }
                 Long::class -> convert<Int> { it.toLong() }
                 BigDecimal::class -> convert<Int> { it.toBigDecimal() }
+                Boolean::class -> convert<Int> { it != 0 }
                 LocalDateTime::class -> convert<Int> { it.toLong().toLocalDateTime(defaultTimeZone) }
                 LocalDate::class -> convert<Int> { it.toLong().toLocalDate(defaultTimeZone) }
                 java.time.LocalDateTime::class -> convert<Long> { it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime() }
@@ -228,6 +230,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Long::class -> convert<Double> { it.roundToLong() }
                 Short::class -> convert<Double> { it.roundToInt().toShort() }
                 BigDecimal::class -> convert<Double> { it.toBigDecimal() }
+                Boolean::class -> convert<Double> { it != 0.0 }
                 else -> null
             }
             Long::class -> when (toClass) {
@@ -237,6 +240,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Short::class -> convert<Long> { it.toShort() }
                 Int::class -> convert<Long> { it.toInt() }
                 BigDecimal::class -> convert<Long> { it.toBigDecimal() }
+                Boolean::class -> convert<Long> { it != 0L }
                 LocalDateTime::class -> convert<Long> { it.toLocalDateTime(defaultTimeZone) }
                 LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone) }
                 Instant::class -> convert<Long> { Instant.fromEpochMilliseconds(it) }
@@ -271,6 +275,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Int::class -> convert<Float> { it.roundToInt() }
                 Short::class -> convert<Float> { it.roundToInt().toShort() }
                 BigDecimal::class -> convert<Float> { it.toBigDecimal() }
+                Boolean::class -> convert<Float> { it != 0.0F }
                 else -> null
             }
             BigDecimal::class -> when (toClass) {
@@ -278,6 +283,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Int::class -> convert<BigDecimal> { it.toInt() }
                 Float::class -> convert<BigDecimal> { it.toFloat() }
                 Long::class -> convert<BigDecimal> { it.toLong() }
+                Boolean::class -> convert<BigDecimal> { it != BigDecimal.ZERO }
                 else -> null
             }
             LocalDateTime::class -> when (toClass) {
@@ -286,6 +292,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Long::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone).toEpochMilliseconds() }
                 java.time.LocalDateTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime() }
                 java.time.LocalDate::class -> convert<LocalDateTime> { it.date.toJavaLocalDate() }
+                java.time.LocalTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime().toLocalTime() }
                 else -> null
             }
             java.time.LocalDateTime::class -> when (toClass) {
@@ -294,6 +301,7 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 Instant::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime().toInstant(defaultTimeZone) }
                 Long::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime().toInstant(defaultTimeZone).toEpochMilliseconds() }
                 java.time.LocalDate::class -> convert<java.time.LocalDateTime> { it.toLocalDate() }
+                java.time.LocalTime::class -> convert<java.time.LocalDateTime> { it.toLocalTime() }
                 else -> null
             }
             LocalDate::class -> when (toClass) {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -273,11 +273,11 @@ internal object Parsers : GlobalParserOptions {
         return parser.applyOptions(options)
     }
 
-    internal fun getDoubleConverter(locale: Locale? = null): TypeConverter {
+    internal fun getDoubleParser(locale: Locale? = null): (String) -> Double? {
         val options = if (locale != null) ParserOptions(
             locale = locale
         ) else null
-        return parserToDoubleWithOptions.toConverter(options)
+        return parserToDoubleWithOptions.applyOptions(options)
     }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -171,7 +171,9 @@ internal object Parsers : GlobalParserOptions {
         return null
     }
 
-    private fun String.parseDouble(format: NumberFormat) =
+    private val posixNumberFormat = NumberFormat.getInstance(Locale.forLanguageTag("C.UTF-8"))
+
+    private fun String.parseDouble(userNumberFormat: NumberFormat) =
         when (uppercase(Locale.getDefault())) {
             "NAN" -> Double.NaN
             "INF" -> Double.POSITIVE_INFINITY
@@ -179,10 +181,13 @@ internal object Parsers : GlobalParserOptions {
             "INFINITY" -> Double.POSITIVE_INFINITY
             "-INFINITY" -> Double.NEGATIVE_INFINITY
             else -> {
-                val parsePosition = ParsePosition(0)
-                val result: Double? = format.parse(this, parsePosition)?.toDouble()
-                if (parsePosition.index != this.length) null
-                else result
+                fun parseWithFormat(format: NumberFormat): Double? {
+                    val parsePosition = ParsePosition(0)
+                    val result: Double? = format.parse(this, parsePosition)?.toDouble()
+                    return if (parsePosition.index != this.length) null
+                    else result
+                }
+                parseWithFormat(userNumberFormat) ?: parseWithFormat(posixNumberFormat)
             }
         }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
@@ -105,6 +105,27 @@ class CsvTests {
     }
 
     @Test
+    fun `read standard CSV with floats when user has alternative locale`() {
+        val currentLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.forLanguageTag("ru-RU"))
+            val df = DataFrame.readCSV(wineCsv, delimiter = ';')
+            val schema = df.schema()
+            fun assertColumnType(columnName: String, kClass: KClass<*>) {
+                val col = schema.columns[columnName]
+                col.shouldNotBeNull()
+                col.type.classifier shouldBe kClass
+            }
+
+            assertColumnType("citric acid", Double::class)
+            assertColumnType("alcohol", Double::class)
+            assertColumnType("quality", Int::class)
+        } finally {
+            Locale.setDefault(currentLocale)
+        }
+    }
+
+    @Test
     fun `read with custom header`() {
         val header = ('A'..'K').map { it.toString() }
         val df = DataFrame.readCSV(simpleCsv, header = header, skipLines = 1)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
@@ -2,12 +2,14 @@ package org.jetbrains.kotlinx.dataframe.io
 
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDateTime
+import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.junit.Test
 import java.math.BigDecimal
+import java.util.*
 import kotlin.reflect.typeOf
 
 class ParserTests {
@@ -57,5 +59,24 @@ class ParserTests {
         converted.type() shouldBe typeOf<Float>()
         converted[0] shouldBe 1.0f
         converted[1] shouldBe 0.321f
+    }
+
+    @Test
+    fun `converting string to double in different locales`() {
+        val currentLocale = Locale.getDefault()
+        try {
+            val stringValues = listOf("1", "2.3", "4,5")
+            val stringColumn = DataColumn.createValueColumn("nums", stringValues, typeOf<String>())
+            Locale.setDefault(Locale.forLanguageTag("ru-RU"))
+            stringColumn.convertToDouble().shouldBe(
+                DataColumn.createValueColumn("nums", listOf(1.0, 2.3, 4.5), typeOf<Double>())
+            )
+            Locale.setDefault(Locale.forLanguageTag("en-US"))
+            stringColumn.convertToDouble().shouldBe(
+                DataColumn.createValueColumn("nums", listOf(1.0, 2.3, 45.0), typeOf<Double>())
+            )
+        } finally {
+            Locale.setDefault(currentLocale)
+        }
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
@@ -132,7 +132,7 @@ class ParserTests {
             Locale.setDefault(Locale.forLanguageTag("ru-RU"))
 
             columnDot.convertTo<Double>().shouldBe(columnOf(12.345, 67.89))
-            columnComma.convertTo<Double>().shouldBe(columnOf(12345.0, 67890.0))
+            columnComma.convertTo<Double>().shouldBe(columnOf(12.345, 67.89))
             columnMixed.convertTo<Double>().shouldBe(columnOf(12.345, 67890.0))
 
             columnDot.convertToDouble(parsingLocaleNotDefined).shouldBe(columnOf(12.345, 67.89))

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/SampleNotebooksTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/SampleNotebooksTests.kt
@@ -6,6 +6,7 @@ import org.jetbrains.jupyter.parser.notebook.Output
 import org.junit.Ignore
 import org.junit.Test
 import java.io.File
+import java.util.Locale
 
 class SampleNotebooksTests : DataFrameJupyterTest() {
     @Test
@@ -39,13 +40,23 @@ class SampleNotebooksTests : DataFrameJupyterTest() {
     )
 
     @Test
-    fun netflix() = exampleTest(
-        "netflix",
-        replacer = CodeReplacer.byMap(
-            testFile("netflix", "country_codes.csv"),
-            testFile("netflix", "netflix_titles.csv"),
-        )
-    )
+    fun netflix() {
+        val currentLocale = Locale.getDefault()
+        try {
+            // Set explicit locale as of test data contains locale-dependent values (date for parsing)
+            Locale.setDefault(Locale.forLanguageTag("en-US"))
+
+            exampleTest(
+                "netflix",
+                replacer = CodeReplacer.byMap(
+                    testFile("netflix", "country_codes.csv"),
+                    testFile("netflix", "netflix_titles.csv"),
+                )
+            )
+        } finally {
+            Locale.setDefault(currentLocale)
+        }
+    }
 
     @Test
     @Ignore

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/puzzles/BasicTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/puzzles/BasicTests.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.junit.Test
+import java.text.DecimalFormatSymbols
 import kotlin.reflect.typeOf
 
 class BasicTests {
@@ -135,7 +136,8 @@ class BasicTests {
     fun `append and drop new row`() {
         val modifiedDf = df.append("dog", 5.5, 2, "no")
 
-        modifiedDf[10].toString() shouldBe "{ animal:dog, age:5.500000, visits:2, priority:no }"
+        val d = DecimalFormatSymbols.getInstance().decimalSeparator
+        modifiedDf[10].toString() shouldBe "{ animal:dog, age:5${d}500000, visits:2, priority:no }"
 
         modifiedDf.dropLast() shouldBe df
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/PrecisionTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/PrecisionTests.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.io.RendererDecimalFormat
 import org.jetbrains.kotlinx.dataframe.io.defaultPrecision
 import org.jetbrains.kotlinx.dataframe.io.format
 import org.junit.Test
+import java.text.DecimalFormatSymbols
 
 class PrecisionTests {
 
@@ -26,8 +27,9 @@ class PrecisionTests {
 
     @Test
     fun format() {
+        val d = DecimalFormatSymbols.getInstance().decimalSeparator
         val value = 1.2341
-        val expected = "1.23"
+        val expected = "1${d}23"
         val digits = 2
         val formatter = RendererDecimalFormat.fromPrecision(digits)
         value.format(formatter) shouldBe expected

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlinx.dataframe.jupyter.RenderedContent
 import org.jsoup.Jsoup
 import org.junit.Test
 import java.net.URL
+import java.text.DecimalFormatSymbols
 import kotlin.reflect.typeOf
 
 class RenderingTests {
@@ -108,10 +109,11 @@ class RenderingTests {
 
     @Test
     fun `render double with exponent`() {
+        val d = DecimalFormatSymbols.getInstance().decimalSeparator
         listOf(
-            dataFrameOf("col")(1E27) to "1.000000e+27",
-            dataFrameOf("col")(1.123) to "1.123",
-            dataFrameOf("col")(1.0) to "1.0",
+            dataFrameOf("col")(1E27) to "1${d}000000e+27",
+            dataFrameOf("col")(1.123) to "1${d}123",
+            dataFrameOf("col")(1.0) to "1${d}0",
         ).forEach { (df, rendered) ->
             df.toHTML().script shouldContain rendered
         }


### PR DESCRIPTION
When working with specific local settings, we still can get data in international format. And it should be parsed rather than rejected. Here we have fallback on parsing doubles with POSIX number format. (This was made for `convertTo` function but also works on primary parsing. For example, `readCsvWithFloats` test now passes on my computer without switching to empty locale manually.) May be, we should have similar logic in date, time and some other parsers.

Also some new converters (to Boolean and LocalTime) have been added.