### PR TITLE
Adjusted Passenger schema in  KProperties API Docs

### DIFF
--- a/docs/StardustDocs/topics/KPropertiesApi.md
+++ b/docs/StardustDocs/topics/KPropertiesApi.md
@@ -11,7 +11,7 @@ This can be done using `::` expression that provides [property references](https
 data class Passenger(
     val survived: Boolean,
     val home: String,
-    val age: Int,
+    val age: Int?,
     val lastName: String
 )
 


### PR DESCRIPTION
Adjusted Passenger schema to reflect nullability of age attribute. With the fix, we can also use filter: `  .filter{ it[Passenger::age]!=null}`