### PR TITLE
Fix problem with big arrow

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -182,14 +182,18 @@ public data class HtmlData(val style: String, val body: String, val script: Stri
 
 internal fun HtmlData.print() = println(this)
 
-internal fun initHtml(): HtmlData =
-    HtmlData(style = getResources("/table.css"), script = getResourceText("/init.js"), body = "")
+internal fun initHtml(includeJs: Boolean = true, includeCss: Boolean = true): HtmlData =
+    HtmlData(
+        style = if (includeCss) getResources("/table.css") else "",
+        script = if (includeJs) getResourceText("/init.js") else "",
+        body = ""
+    )
 
-public fun <T> DataFrame<T>.html(): String = toHTML(includeInit = true).toString()
+public fun <T> DataFrame<T>.html(): String = toHTML(extraHtml = initHtml()).toString()
 
 public fun <T> DataFrame<T>.toHTML(
     configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,
-    includeInit: Boolean = false,
+    extraHtml: HtmlData? = null,
     cellRenderer: CellRenderer = org.jetbrains.kotlinx.dataframe.jupyter.DefaultCellRenderer,
     getFooter: (DataFrame<T>) -> String = { "DataFrame [${it.size}]" }
 ): HtmlData {
@@ -203,7 +207,7 @@ public fun <T> DataFrame<T>.toHTML(
     val tableHtml = toHtmlData(configuration, cellRenderer)
     val html = tableHtml + HtmlData("", bodyFooter, "")
 
-    return if (includeInit) initHtml() + html else html
+    return if (extraHtml != null) extraHtml + html else html
 }
 
 public data class DisplayConfiguration(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.jupyter
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
+import org.jetbrains.kotlinx.dataframe.io.initHtml
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 
@@ -18,5 +19,13 @@ internal inline fun <reified T : Any> JupyterHtmlRenderer.render(
     val contextRenderer = JupyterCellRenderer(this.notebook, host)
     val reifiedDisplayConfiguration = value.modifyConfig(display)
     val footer = getFooter(value)
-    getDf(value).toHTML(reifiedDisplayConfiguration, includeInit = reifiedDisplayConfiguration.isolatedOutputs, contextRenderer, { footer }).toJupyter()
+    getDf(value).toHTML(
+        reifiedDisplayConfiguration,
+        extraHtml = initHtml(
+            includeJs = reifiedDisplayConfiguration.isolatedOutputs,
+            includeCss = true
+        ),
+        contextRenderer
+    ) { footer }
+        .toJupyter()
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
@@ -59,7 +59,7 @@ class RenderingTests {
     @Test
     fun `long text is trimmed without escaping`() {
         val df = dataFrameOf("text")("asdfkjasdlkjfhasljkddasdasdasdasdasdasdhf")
-        val html = df.toHTML(includeInit = false).toString()
+        val html = df.toHTML().toString()
         html shouldNotContain "\\\\"
         html shouldNotContain "&#34;"
     }
@@ -68,7 +68,7 @@ class RenderingTests {
     fun `non ascii text`() {
         val value = "Шёл Шива по шоссе, сокрушая сущее"
         val df = dataFrameOf("text")(value)
-        val script = df.toHTML(includeInit = false).script
+        val script = df.toHTML().script
         script shouldContain value.escapeHTML()
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
@@ -1,13 +1,14 @@
 package org.jetbrains.kotlinx.dataframe.rendering.html
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.io.initHtml
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import java.awt.Desktop
 import java.io.File
 
 fun AnyFrame.browse() {
     val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-    file.writeText(toHTML(includeInit = true).toString())
+    file.writeText(toHTML(extraHtml = initHtml()).toString())
     val uri = file.toURI()
     val desktop = Desktop.getDesktop()
     desktop.browse(uri)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.api.group
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.parse
 import org.jetbrains.kotlinx.dataframe.io.html
+import org.jetbrains.kotlinx.dataframe.io.initHtml
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.jupyter.findNthSubstring
 import org.junit.Ignore
@@ -19,7 +20,7 @@ class HtmlRenderingTests : BaseTest() {
 
     fun AnyFrame.browse() {
         val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-        file.writeText(toHTML(includeInit = true).toString())
+        file.writeText(toHTML(extraHtml = initHtml()).toString())
         val uri = file.toURI()
         val desktop = Desktop.getDesktop()
         desktop.browse(uri)


### PR DESCRIPTION
This commit fixes the following bug.

Steps to reproduce:
1. Execute %use dataframe
2. Calculate and render some dataframe-like table which is rendered with small arrows. It will be rendered correctly
3. Re-execute cell with %use
4. Arrows in the table now become giant

Reason:
When you re-execute %use command, it effectively clears all the output including CSS-s. The disappearing of styles leads to different visual problems including this one.

Fix:
Include CSS to the output for every dataframe-like object

Possible problems:
`toHTML` is a public function, and its API is broken with this commit. If it's unacceptable, consider another solution