### PR TITLE
Nullable accessors and fixed convertTo

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/GeneratedField.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/GeneratedField.kt
@@ -10,6 +10,58 @@ public sealed interface FieldType {
     public class GroupFieldType(public val markerName: String) : FieldType
 }
 
+/**
+ * Returns whether the column type ends with `?` or not.
+ * NOTE: for [FieldType.FrameFieldType], the `nullable` property indicates the nullability of the frame itself, not the type of the column.
+ */
+public fun FieldType.isNullable(): Boolean =
+    when (this) {
+        is FieldType.FrameFieldType -> markerName.endsWith("?")
+        is FieldType.GroupFieldType -> markerName.endsWith("?")
+        is FieldType.ValueFieldType -> typeFqName.endsWith("?")
+    }
+
+/**
+ * Returns whether the column type doesn't end with `?` or whether it does.
+ * NOTE: for [FieldType.FrameFieldType], the `nullable` property indicates the nullability of the frame itself, not the type of the column.
+ */
+public fun FieldType.isNotNullable(): Boolean = !isNullable()
+
+private fun String.toNullable() = if (this.last() == '?') this else "$this?"
+
+/**
+ * Returns a new fieldType with the same type but with nullability in the column type.
+ * NOTE: for [FieldType.FrameFieldType], the `nullable` property indicates the nullability of the frame itself, not the type of the column.
+ */
+public fun FieldType.toNullable(): FieldType =
+    if (isNotNullable()) {
+        when (this) {
+            is FieldType.FrameFieldType -> FieldType.FrameFieldType(markerName.toNullable(), nullable)
+            is FieldType.GroupFieldType -> FieldType.GroupFieldType(markerName.toNullable())
+            is FieldType.ValueFieldType -> FieldType.ValueFieldType(typeFqName.toNullable())
+        }
+    } else this
+
+/**
+ * Returns a new fieldType with the same type but with nullability disabled in the column type.
+ * NOTE: for [FieldType.FrameFieldType], the `nullable` property indicates the nullability of the frame itself, not the type of the column.
+ */
+public fun FieldType.toNotNullable(): FieldType =
+    if (isNullable()) {
+        when (this) {
+            is FieldType.FrameFieldType -> FieldType.FrameFieldType(markerName.removeSuffix("?"), nullable)
+            is FieldType.GroupFieldType -> FieldType.GroupFieldType(markerName.removeSuffix("?"))
+            is FieldType.ValueFieldType -> FieldType.ValueFieldType(typeFqName.removeSuffix("?"))
+        }
+    } else this
+
+public val FieldType.name: String
+    get() = when (this) {
+        is FieldType.FrameFieldType -> markerName
+        is FieldType.GroupFieldType -> markerName
+        is FieldType.ValueFieldType -> typeFqName
+    }
+
 public class ValidFieldName private constructor(private val identifier: String, public val needsQuote: Boolean) {
     public val unquoted: String get() = identifier
     public val quotedIfNeeded: String get() = if (needsQuote) "`$identifier`" else identifier
@@ -47,6 +99,22 @@ public interface BaseField {
     public val columnName: String
     public val fieldType: FieldType
 }
+
+public fun BaseField.toNullable(): BaseField =
+    if (fieldType.isNullable()) this
+    else object : BaseField {
+        override val fieldName: ValidFieldName = this@toNullable.fieldName
+        override val columnName: String = this@toNullable.columnName
+        override val fieldType: FieldType = this@toNullable.fieldType.toNullable()
+    }
+
+public fun BaseField.toNotNullable(): BaseField =
+    if (fieldType.isNotNullable()) this
+    else object : BaseField {
+        override val fieldName: ValidFieldName = this@toNotNullable.fieldName
+        override val columnName: String = this@toNotNullable.columnName
+        override val fieldType: FieldType = this@toNotNullable.fieldType.toNotNullable()
+    }
 
 public data class GeneratedField(
     override val fieldName: ValidFieldName,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
@@ -122,6 +122,6 @@ internal fun AnyFrame.convertToImpl(
     }
 
     val clazz = type.jvmErasure
-    val marker = MarkersExtractor[clazz]
+    val marker = MarkersExtractor.get(clazz)
     return convertToSchema(marker.schema, emptyPath())
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -58,7 +58,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
             // maybe property is already properly typed, let's do some checks
             val currentMarker = getMarkerClass(property.returnType)
                 ?.takeIf { it.findAnnotation<DataSchema>() != null }
-                ?.let { registeredMarkers[it] ?: MarkersExtractor[it] }
+                ?.let { registeredMarkers[it] ?: MarkersExtractor.get(it) }
             if (currentMarker != null) {
                 // if property is mutable, we need to make sure that its marker type is open in order to let derived data frames be assignable to it
                 if (!isMutable || currentMarker.isOpen) {
@@ -133,7 +133,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
                     return newMarker
                 }
             }
-            val marker = MarkersExtractor[markerClass]
+            val marker = MarkersExtractor.get(markerClass)
             registeredMarkers[markerClass] = marker
             newMarkers.add(marker)
             return marker

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
@@ -87,7 +87,7 @@ internal fun ColumnSchema.createEmptyColumn(name: String): AnyCol = when (this) 
 internal fun DataFrameSchema.createEmptyDataFrame(): AnyFrame = columns.map { (name, schema) -> schema.createEmptyColumn(name) }.toDataFrame()
 
 @PublishedApi
-internal fun createEmptyDataFrameOf(clazz: KClass<*>): AnyFrame = MarkersExtractor[clazz].schema.createEmptyDataFrame()
+internal fun createEmptyDataFrameOf(clazz: KClass<*>): AnyFrame = MarkersExtractor.get(clazz).schema.createEmptyDataFrame()
 
 internal fun getPropertiesOrder(clazz: KClass<*>): Map<String, Int> =
     clazz.primaryConstructor?.parameters?.mapNotNull { it.name }?.mapIndexed { i, v -> v to i }?.toMap() ?: emptyMap()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -109,4 +109,28 @@ class ConvertToTests {
 
         converted shouldBe expected
     }
+
+    @DataSchema
+    data class Location(
+        val name: String,
+        val gps: Gps?,
+    )
+
+    @DataSchema
+    data class Gps(
+        val latitude: Double,
+        val longitude: Double,
+    )
+
+    @Test
+    fun `convert df with nullable DataRow to itself`() {
+        val locations: DataFrame<Location> = listOf(
+            Location("Home", Gps(0.0, 0.0)),
+            Location("Away", null),
+        ).toDataFrame()
+
+        val converted = locations.convertTo<Location>()
+
+        converted shouldBe locations
+    }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
@@ -121,6 +122,21 @@ class ConvertToTests {
         val latitude: Double,
         val longitude: Double,
     )
+
+    // @Test TODO: https://github.com/Kotlin/dataframe/issues/177
+    fun `convert df with nullable DataRow`() {
+        val locations: AnyFrame = dataFrameOf("name", "gps")(
+            "Home", Gps(0.0, 0.0),
+            "Away", null,
+        )
+
+        locations.print(borders = true, title = true, columnTypes = true)
+        locations.schema().print()
+
+        val converted = locations.convertTo<Location>()
+
+        converted shouldBe locations
+    }
 
     @Test
     fun `convert df with nullable DataRow to itself`() {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -34,12 +34,20 @@ class CodeGenerationTests : BaseTest() {
     fun expectedProperties(fullTypeName: String, shortTypeName: String) = """
             val $dfName<$fullTypeName>.age: $dataCol<$intName> @JvmName("${shortTypeName}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$fullTypeName>.age: $intName @JvmName("${shortTypeName}_age") get() = this["age"] as $intName
+            val $dfName<$fullTypeName?>.age: $dataCol<$intName?> @JvmName("Nullable${shortTypeName}_age") get() = this["age"] as $dataCol<$intName?>
+            val $dfRowName<$fullTypeName?>.age: $intName? @JvmName("Nullable${shortTypeName}_age") get() = this["age"] as $intName?
             val $dfName<$fullTypeName>.city: $dataCol<$stringName?> @JvmName("${shortTypeName}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$fullTypeName>.city: $stringName? @JvmName("${shortTypeName}_city") get() = this["city"] as $stringName?
+            val $dfName<$fullTypeName?>.city: $dataCol<$stringName?> @JvmName("Nullable${shortTypeName}_city") get() = this["city"] as $dataCol<$stringName?>
+            val $dfRowName<$fullTypeName?>.city: $stringName? @JvmName("Nullable${shortTypeName}_city") get() = this["city"] as $stringName?
             val $dfName<$fullTypeName>.name: $dataCol<$stringName> @JvmName("${shortTypeName}_name") get() = this["name"] as $dataCol<$stringName>
             val $dfRowName<$fullTypeName>.name: $stringName @JvmName("${shortTypeName}_name") get() = this["name"] as $stringName
+            val $dfName<$fullTypeName?>.name: $dataCol<$stringName?> @JvmName("Nullable${shortTypeName}_name") get() = this["name"] as $dataCol<$stringName?>
+            val $dfRowName<$fullTypeName?>.name: $stringName? @JvmName("Nullable${shortTypeName}_name") get() = this["name"] as $stringName?
             val $dfName<$fullTypeName>.weight: $dataCol<$intName?> @JvmName("${shortTypeName}_weight") get() = this["weight"] as $dataCol<$intName?>
             val $dfRowName<$fullTypeName>.weight: $intName? @JvmName("${shortTypeName}_weight") get() = this["weight"] as $intName?
+            val $dfName<$fullTypeName?>.weight: $dataCol<$intName?> @JvmName("Nullable${shortTypeName}_weight") get() = this["weight"] as $dataCol<$intName?>
+            val $dfRowName<$fullTypeName?>.weight: $intName? @JvmName("Nullable${shortTypeName}_weight") get() = this["weight"] as $intName?
     """.trimIndent()
 
     @Test
@@ -97,8 +105,12 @@ class CodeGenerationTests : BaseTest() {
             
             val $dfName<$type1>.city: $dataCol<$stringName?> @JvmName("${type1}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$type1>.city: $stringName? @JvmName("${type1}_city") get() = this["city"] as $stringName?
+            val $dfName<$type1?>.city: $dataCol<$stringName?> @JvmName("Nullable${type1}_city") get() = this["city"] as $dataCol<$stringName?>
+            val $dfRowName<$type1?>.city: $stringName? @JvmName("Nullable${type1}_city") get() = this["city"] as $stringName?
             val $dfName<$type1>.name: $dataCol<$stringName> @JvmName("${type1}_name") get() = this["name"] as $dataCol<$stringName>
             val $dfRowName<$type1>.name: $stringName @JvmName("${type1}_name") get() = this["name"] as $stringName
+            val $dfName<$type1?>.name: $dataCol<$stringName?> @JvmName("Nullable${type1}_name") get() = this["name"] as $dataCol<$stringName?>
+            val $dfRowName<$type1?>.name: $stringName? @JvmName("Nullable${type1}_name") get() = this["name"] as $stringName?
             
         """.trimIndent()
 
@@ -108,10 +120,16 @@ class CodeGenerationTests : BaseTest() {
             
             val $dfName<$type2>.age: $dataCol<$intName> @JvmName("${type2}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$type2>.age: $intName @JvmName("${type2}_age") get() = this["age"] as $intName
+            val $dfName<$type2?>.age: $dataCol<$intName?> @JvmName("Nullable${type2}_age") get() = this["age"] as $dataCol<$intName?>
+            val $dfRowName<$type2?>.age: $intName? @JvmName("Nullable${type2}_age") get() = this["age"] as $intName?
             val $dfName<$type2>.nameAndCity: $colGroup<$type1> @JvmName("${type2}_nameAndCity") get() = this["nameAndCity"] as $colGroup<$type1>
             val $dfRowName<$type2>.nameAndCity: $dataRow<$type1> @JvmName("${type2}_nameAndCity") get() = this["nameAndCity"] as $dataRow<$type1>
+            val $dfName<$type2?>.nameAndCity: $colGroup<$type1?> @JvmName("Nullable${type2}_nameAndCity") get() = this["nameAndCity"] as $colGroup<$type1?>
+            val $dfRowName<$type2?>.nameAndCity: $dataRow<$type1?> @JvmName("Nullable${type2}_nameAndCity") get() = this["nameAndCity"] as $dataRow<$type1?>
             val $dfName<$type2>.weight: $dataCol<$intName?> @JvmName("${type2}_weight") get() = this["weight"] as $dataCol<$intName?>
             val $dfRowName<$type2>.weight: $intName? @JvmName("${type2}_weight") get() = this["weight"] as $intName?
+            val $dfName<$type2?>.weight: $dataCol<$intName?> @JvmName("Nullable${type2}_weight") get() = this["weight"] as $dataCol<$intName?>
+            val $dfRowName<$type2?>.weight: $intName? @JvmName("Nullable${type2}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
 
         val expectedConverter = "it.cast<$type2>()"
@@ -128,7 +146,8 @@ class CodeGenerationTests : BaseTest() {
             interface $personClass
         """.trimIndent() + "\n" + expectedProperties(personClassName, personShortName)
 
-        val code = CodeGenerator.create(useFqNames = false).generate<Person>(InterfaceGenerationMode.NoFields, extensionProperties = true).declarations
+        val code = CodeGenerator.create(useFqNames = false)
+            .generate<Person>(InterfaceGenerationMode.NoFields, extensionProperties = true).declarations
         code shouldBe expected
     }
 
@@ -145,8 +164,13 @@ class CodeGenerationTests : BaseTest() {
         val codeGen = CodeGenerator.create()
         val schema = df.dropNulls().schema()
         val code = codeGen.generate(
-            schema, "ValidPerson", true, true, isOpen = true, MarkerVisibility.IMPLICIT_PUBLIC,
-            listOf(
+            schema = schema,
+            name = "ValidPerson",
+            fields = true,
+            extensionProperties = true,
+            isOpen = true,
+            visibility = MarkerVisibility.IMPLICIT_PUBLIC,
+            knownMarkers = listOf(
                 MarkersExtractor.get<Person>()
             )
         ).code.declarations
@@ -160,8 +184,12 @@ class CodeGenerationTests : BaseTest() {
             
             val $packageName.ColumnsContainer<ValidPerson>.city: $packageName.DataColumn<kotlin.String> @JvmName("ValidPerson_city") get() = this["city"] as $packageName.DataColumn<kotlin.String>
             val $packageName.DataRow<ValidPerson>.city: kotlin.String @JvmName("ValidPerson_city") get() = this["city"] as kotlin.String
+            val $packageName.ColumnsContainer<ValidPerson?>.city: $packageName.DataColumn<kotlin.String?> @JvmName("NullableValidPerson_city") get() = this["city"] as $packageName.DataColumn<kotlin.String?>
+            val $packageName.DataRow<ValidPerson?>.city: kotlin.String? @JvmName("NullableValidPerson_city") get() = this["city"] as kotlin.String?
             val $packageName.ColumnsContainer<ValidPerson>.weight: $packageName.DataColumn<kotlin.Int> @JvmName("ValidPerson_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int>
             val $packageName.DataRow<ValidPerson>.weight: kotlin.Int @JvmName("ValidPerson_weight") get() = this["weight"] as kotlin.Int
+            val $packageName.ColumnsContainer<ValidPerson?>.weight: $packageName.DataColumn<kotlin.Int?> @JvmName("NullableValidPerson_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int?>
+            val $packageName.DataRow<ValidPerson?>.weight: kotlin.Int? @JvmName("NullableValidPerson_weight") get() = this["weight"] as kotlin.Int?
         """.trimIndent()
         code shouldBe expected
     }
@@ -196,7 +224,8 @@ class CodeGenerationTests : BaseTest() {
     @Test
     fun `declaration with internal visibility`() {
         val repl = CodeGenerator.create()
-        val code = repl.generate(typed.schema(), "DataType", true, true, false, MarkerVisibility.INTERNAL).code.declarations
+        val code =
+            repl.generate(typed.schema(), "DataType", true, true, false, MarkerVisibility.INTERNAL).code.declarations
         val packageName = "org.jetbrains.kotlinx.dataframe"
         code shouldBe """
             @DataSchema(isOpen = false)
@@ -209,19 +238,34 @@ class CodeGenerationTests : BaseTest() {
             
             internal val $packageName.ColumnsContainer<DataType>.age: $packageName.DataColumn<kotlin.Int> @JvmName("DataType_age") get() = this["age"] as $packageName.DataColumn<kotlin.Int>
             internal val $packageName.DataRow<DataType>.age: kotlin.Int @JvmName("DataType_age") get() = this["age"] as kotlin.Int
+            internal val $packageName.ColumnsContainer<DataType?>.age: $packageName.DataColumn<kotlin.Int?> @JvmName("NullableDataType_age") get() = this["age"] as $packageName.DataColumn<kotlin.Int?>
+            internal val $packageName.DataRow<DataType?>.age: kotlin.Int? @JvmName("NullableDataType_age") get() = this["age"] as kotlin.Int?
             internal val $packageName.ColumnsContainer<DataType>.city: $packageName.DataColumn<kotlin.String?> @JvmName("DataType_city") get() = this["city"] as $packageName.DataColumn<kotlin.String?>
             internal val $packageName.DataRow<DataType>.city: kotlin.String? @JvmName("DataType_city") get() = this["city"] as kotlin.String?
+            internal val $packageName.ColumnsContainer<DataType?>.city: $packageName.DataColumn<kotlin.String?> @JvmName("NullableDataType_city") get() = this["city"] as $packageName.DataColumn<kotlin.String?>
+            internal val $packageName.DataRow<DataType?>.city: kotlin.String? @JvmName("NullableDataType_city") get() = this["city"] as kotlin.String?
             internal val $packageName.ColumnsContainer<DataType>.name: $packageName.DataColumn<kotlin.String> @JvmName("DataType_name") get() = this["name"] as $packageName.DataColumn<kotlin.String>
             internal val $packageName.DataRow<DataType>.name: kotlin.String @JvmName("DataType_name") get() = this["name"] as kotlin.String
+            internal val $packageName.ColumnsContainer<DataType?>.name: $packageName.DataColumn<kotlin.String?> @JvmName("NullableDataType_name") get() = this["name"] as $packageName.DataColumn<kotlin.String?>
+            internal val $packageName.DataRow<DataType?>.name: kotlin.String? @JvmName("NullableDataType_name") get() = this["name"] as kotlin.String?
             internal val $packageName.ColumnsContainer<DataType>.weight: $packageName.DataColumn<kotlin.Int?> @JvmName("DataType_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int?>
             internal val $packageName.DataRow<DataType>.weight: kotlin.Int? @JvmName("DataType_weight") get() = this["weight"] as kotlin.Int?
+            internal val $packageName.ColumnsContainer<DataType?>.weight: $packageName.DataColumn<kotlin.Int?> @JvmName("NullableDataType_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int?>
+            internal val $packageName.DataRow<DataType?>.weight: kotlin.Int? @JvmName("NullableDataType_weight") get() = this["weight"] as kotlin.Int?
         """.trimIndent()
     }
 
     @Test
     fun `declaration with explicit public visibility`() {
         val repl = CodeGenerator.create()
-        val code = repl.generate(typed.schema(), "DataType", true, true, false, MarkerVisibility.EXPLICIT_PUBLIC).code.declarations
+        val code = repl.generate(
+            typed.schema(),
+            "DataType",
+            true,
+            true,
+            false,
+            MarkerVisibility.EXPLICIT_PUBLIC
+        ).code.declarations
         val packageName = "org.jetbrains.kotlinx.dataframe"
         code shouldBe """
             @DataSchema(isOpen = false)
@@ -234,12 +278,20 @@ class CodeGenerationTests : BaseTest() {
             
             public val $packageName.ColumnsContainer<DataType>.age: $packageName.DataColumn<kotlin.Int> @JvmName("DataType_age") get() = this["age"] as $packageName.DataColumn<kotlin.Int>
             public val $packageName.DataRow<DataType>.age: kotlin.Int @JvmName("DataType_age") get() = this["age"] as kotlin.Int
+            public val $packageName.ColumnsContainer<DataType?>.age: $packageName.DataColumn<kotlin.Int?> @JvmName("NullableDataType_age") get() = this["age"] as $packageName.DataColumn<kotlin.Int?>
+            public val $packageName.DataRow<DataType?>.age: kotlin.Int? @JvmName("NullableDataType_age") get() = this["age"] as kotlin.Int?
             public val $packageName.ColumnsContainer<DataType>.city: $packageName.DataColumn<kotlin.String?> @JvmName("DataType_city") get() = this["city"] as $packageName.DataColumn<kotlin.String?>
             public val $packageName.DataRow<DataType>.city: kotlin.String? @JvmName("DataType_city") get() = this["city"] as kotlin.String?
+            public val $packageName.ColumnsContainer<DataType?>.city: $packageName.DataColumn<kotlin.String?> @JvmName("NullableDataType_city") get() = this["city"] as $packageName.DataColumn<kotlin.String?>
+            public val $packageName.DataRow<DataType?>.city: kotlin.String? @JvmName("NullableDataType_city") get() = this["city"] as kotlin.String?
             public val $packageName.ColumnsContainer<DataType>.name: $packageName.DataColumn<kotlin.String> @JvmName("DataType_name") get() = this["name"] as $packageName.DataColumn<kotlin.String>
             public val $packageName.DataRow<DataType>.name: kotlin.String @JvmName("DataType_name") get() = this["name"] as kotlin.String
+            public val $packageName.ColumnsContainer<DataType?>.name: $packageName.DataColumn<kotlin.String?> @JvmName("NullableDataType_name") get() = this["name"] as $packageName.DataColumn<kotlin.String?>
+            public val $packageName.DataRow<DataType?>.name: kotlin.String? @JvmName("NullableDataType_name") get() = this["name"] as kotlin.String?
             public val $packageName.ColumnsContainer<DataType>.weight: $packageName.DataColumn<kotlin.Int?> @JvmName("DataType_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int?>
             public val $packageName.DataRow<DataType>.weight: kotlin.Int? @JvmName("DataType_weight") get() = this["weight"] as kotlin.Int?
+            public val $packageName.ColumnsContainer<DataType?>.weight: $packageName.DataColumn<kotlin.Int?> @JvmName("NullableDataType_weight") get() = this["weight"] as $packageName.DataColumn<kotlin.Int?>
+            public val $packageName.DataRow<DataType?>.weight: kotlin.Int? @JvmName("NullableDataType_weight") get() = this["weight"] as kotlin.Int?
         """.trimIndent()
     }
 
@@ -250,7 +302,7 @@ class CodeGenerationTests : BaseTest() {
         val declarations = repl.generate(df.schema(), "DataType", false, true, false).code.declarations
         df.columnNames().forEach {
             val matches = "`$it`".toRegex().findAll(declarations).toList()
-            matches.size shouldBe 2
+            matches.size shouldBe 4
         }
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/NameGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/NameGenerationTests.kt
@@ -45,7 +45,7 @@ class NameGenerationTests {
     fun `properties generation`() {
         val codeGen = ReplCodeGenerator.create()
         val code = codeGen.process<DataRecord>().split("\n")
-        code.size shouldBe 4
+        code.size shouldBe 8
         code.forEach {
             it.count { it == '`' } shouldBe 2
         }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -79,12 +79,20 @@ class ReplCodeGenTests : BaseTest() {
             
             val $dfName<$marker>.age: $dataCol<$intName> @JvmName("${marker}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$marker>.age: $intName @JvmName("${marker}_age") get() = this["age"] as $intName
+            val $dfName<$marker?>.age: $dataCol<$intName?> @JvmName("Nullable${marker}_age") get() = this["age"] as $dataCol<$intName?>
+            val $dfRowName<$marker?>.age: $intName? @JvmName("Nullable${marker}_age") get() = this["age"] as $intName?
             val $dfName<$marker>.city: $dataCol<$stringName?> @JvmName("${marker}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$marker>.city: $stringName? @JvmName("${marker}_city") get() = this["city"] as $stringName?
+            val $dfName<$marker?>.city: $dataCol<$stringName?> @JvmName("Nullable${marker}_city") get() = this["city"] as $dataCol<$stringName?>
+            val $dfRowName<$marker?>.city: $stringName? @JvmName("Nullable${marker}_city") get() = this["city"] as $stringName?
             val $dfName<$marker>.name: $dataCol<$stringName> @JvmName("${marker}_name") get() = this["name"] as $dataCol<$stringName>
             val $dfRowName<$marker>.name: $stringName @JvmName("${marker}_name") get() = this["name"] as $stringName
+            val $dfName<$marker?>.name: $dataCol<$stringName?> @JvmName("Nullable${marker}_name") get() = this["name"] as $dataCol<$stringName?>
+            val $dfRowName<$marker?>.name: $stringName? @JvmName("Nullable${marker}_name") get() = this["name"] as $stringName?
             val $dfName<$marker>.weight: $dataCol<$intName?> @JvmName("${marker}_weight") get() = this["weight"] as $dataCol<$intName?>
             val $dfRowName<$marker>.weight: $intName? @JvmName("${marker}_weight") get() = this["weight"] as $intName?
+            val $dfName<$marker?>.weight: $dataCol<$intName?> @JvmName("Nullable${marker}_weight") get() = this["weight"] as $dataCol<$intName?>
+            val $dfRowName<$marker?>.weight: $intName? @JvmName("Nullable${marker}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
         code shouldBe expected
 
@@ -100,6 +108,8 @@ class ReplCodeGenTests : BaseTest() {
             
             val $dfName<$marker3>.city: $dataCol<$stringName> @JvmName("${marker3}_city") get() = this["city"] as $dataCol<$stringName>
             val $dfRowName<$marker3>.city: $stringName @JvmName("${marker3}_city") get() = this["city"] as $stringName
+            val $dfName<$marker3?>.city: $dataCol<$stringName?> @JvmName("Nullable${marker3}_city") get() = this["city"] as $dataCol<$stringName?>
+            val $dfRowName<$marker3?>.city: $stringName? @JvmName("Nullable${marker3}_city") get() = this["city"] as $stringName?
         """.trimIndent()
 
         code3 shouldBe expected3
@@ -116,6 +126,8 @@ class ReplCodeGenTests : BaseTest() {
             
             val $dfName<$marker5>.weight: $dataCol<$intName> @JvmName("${marker5}_weight") get() = this["weight"] as $dataCol<$intName>
             val $dfRowName<$marker5>.weight: $intName @JvmName("${marker5}_weight") get() = this["weight"] as $intName
+            val $dfName<$marker5?>.weight: $dataCol<$intName?> @JvmName("Nullable${marker5}_weight") get() = this["weight"] as $dataCol<$intName?>
+            val $dfRowName<$marker5?>.weight: $intName? @JvmName("Nullable${marker5}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
         code5 shouldBe expected5
 
@@ -156,8 +168,12 @@ class ReplCodeGenTests : BaseTest() {
             
             val $dfName<$marker>.city: $dataCol<$stringName?> @JvmName("${marker}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$marker>.city: $stringName? @JvmName("${marker}_city") get() = this["city"] as $stringName?
+            val $dfName<$marker?>.city: $dataCol<$stringName?> @JvmName("Nullable${marker}_city") get() = this["city"] as $dataCol<$stringName?>
+            val $dfRowName<$marker?>.city: $stringName? @JvmName("Nullable${marker}_city") get() = this["city"] as $stringName?
             val $dfName<$marker>.weight: $dataCol<$intName?> @JvmName("${marker}_weight") get() = this["weight"] as $dataCol<$intName?>
             val $dfRowName<$marker>.weight: $intName? @JvmName("${marker}_weight") get() = this["weight"] as $intName?
+            val $dfName<$marker?>.weight: $dataCol<$intName?> @JvmName("Nullable${marker}_weight") get() = this["weight"] as $dataCol<$intName?>
+            val $dfRowName<$marker?>.weight: $intName? @JvmName("Nullable${marker}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
 
         val code = repl.process(typed).declarations.trimIndent()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ShortNamesRenderingTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ShortNamesRenderingTest.kt
@@ -27,7 +27,7 @@ internal class ShortNamesRenderingTest : TypeRenderingStrategy by ShortNames {
     }
 
     private val fields by lazy {
-        MarkersExtractor[A::class].allFields.associateBy { it.fieldName.unquoted }
+        MarkersExtractor.get(A::class).allFields.associateBy { it.fieldName.unquoted }
     }
 
     @Test
@@ -120,11 +120,11 @@ internal class ShortNamesRenderingTest : TypeRenderingStrategy by ShortNames {
 
     @Test
     fun `generic field`() {
-        MarkersExtractor[GenericDataSchema::class].allFields[0].renderFieldType() shouldBe "A"
+        MarkersExtractor.get(GenericDataSchema::class).allFields[0].renderFieldType() shouldBe "A"
     }
 
     @Test
     fun `generic column`() {
-        MarkersExtractor[GenericDataSchema::class].allFields[0].renderColumnType() shouldBe "DataColumn<A>"
+        MarkersExtractor.get(GenericDataSchema::class).allFields[0].renderColumnType() shouldBe "DataColumn<A>"
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
@@ -441,10 +441,16 @@ class DataFrameTreeTests : BaseTest() {
         val expected = """
             val $columnsContainer<$className>.age: $columnData<kotlin.Int> @JvmName("${shortName}_age") get() = this["age"] as $columnData<kotlin.Int>
             val $dataFrameRowBase<$className>.age: kotlin.Int @JvmName("${shortName}_age") get() = this["age"] as kotlin.Int
+            val $columnsContainer<$className?>.age: $columnData<kotlin.Int?> @JvmName("Nullable${shortName}_age") get() = this["age"] as $columnData<kotlin.Int?>
+            val $dataFrameRowBase<$className?>.age: kotlin.Int? @JvmName("Nullable${shortName}_age") get() = this["age"] as kotlin.Int?
             val $columnsContainer<$className>.nameAndCity: $groupedColumn<$nameAndCity> @JvmName("${shortName}_nameAndCity") get() = this["nameAndCity"] as $groupedColumn<$nameAndCity>
             val $dataFrameRowBase<$className>.nameAndCity: $dataFrameRow<$nameAndCity> @JvmName("${shortName}_nameAndCity") get() = this["nameAndCity"] as $dataFrameRow<$nameAndCity>
+            val $columnsContainer<$className?>.nameAndCity: $groupedColumn<$nameAndCity?> @JvmName("Nullable${shortName}_nameAndCity") get() = this["nameAndCity"] as $groupedColumn<$nameAndCity?>
+            val $dataFrameRowBase<$className?>.nameAndCity: $dataFrameRow<$nameAndCity?> @JvmName("Nullable${shortName}_nameAndCity") get() = this["nameAndCity"] as $dataFrameRow<$nameAndCity?>
             val $columnsContainer<$className>.weight: $columnData<kotlin.Int?> @JvmName("${shortName}_weight") get() = this["weight"] as $columnData<kotlin.Int?>
             val $dataFrameRowBase<$className>.weight: kotlin.Int? @JvmName("${shortName}_weight") get() = this["weight"] as kotlin.Int?
+            val $columnsContainer<$className?>.weight: $columnData<kotlin.Int?> @JvmName("Nullable${shortName}_weight") get() = this["weight"] as $columnData<kotlin.Int?>
+            val $dataFrameRowBase<$className?>.weight: kotlin.Int? @JvmName("Nullable${shortName}_weight") get() = this["weight"] as kotlin.Int?
         """.trimIndent()
         code shouldBe expected
     }

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
@@ -437,7 +437,7 @@ class DataFrameSymbolProcessorTest {
             )
         )
         result.inspectLines { codeLines ->
-            codeLines.forExactly(2) {
+            codeLines.forExactly(4) {
                 it.shouldContain("this[\"test-name\"]")
             }
             result.successfulCompilation shouldBe true
@@ -678,7 +678,7 @@ class DataFrameSymbolProcessorTest {
             )
         )
         result.inspectLines { codeLines ->
-            codeLines.forExactly(2) {
+            codeLines.forExactly(4) {
                 it.shouldContain("""internal val """)
             }
             result.successfulCompilation shouldBe true
@@ -702,7 +702,7 @@ class DataFrameSymbolProcessorTest {
             )
         )
         result.inspectLines { codeLines ->
-            codeLines.forExactly(2) {
+            codeLines.forExactly(4) {
                 it.shouldContain("""public val""")
             }
             result.successfulCompilation shouldBe true
@@ -726,7 +726,7 @@ class DataFrameSymbolProcessorTest {
             )
         )
         result.inspectLines { codeLines ->
-            codeLines.forExactly(2) {
+            codeLines.forExactly(4) {
                 it.shouldStartWith("""val """)
             }
             result.successfulCompilation shouldBe true


### PR DESCRIPTION
Let's say you have a Dataframe of `Location`:
```kotlin
@DataSchema
public data class Location(
    val name: String,
    val gps: Gps?,
)

@DataSchema
public data class Gps(
    val latitude: Double,
    val longitude: Double,
)

val locations: DataFrame<Location> = listOf(
    Location("Home", Gps(0.0, 0.0)),
    Location("Away", null),
).toDataFrame()
```

In the current implementation working with `gps` is very difficult. Since it is generated as `DataRow<Gps?>`, the extension accessors like `latitude` and `longitude` don't work. Plus, in the dataframe, the `gps` property is shown as `gps: {latitude:Double?, longitude:Double?}`, which further shows that the accessor would be helpful.
The generated accessors do not clash with the non-nullable variants.

Now possible:
```kotlin
locations.filter {
    (gps.latitude ?: Double.MIN_VALUE) >= 0.0
}
```

Also fixing https://github.com/Kotlin/dataframe/issues/176. might need some more convertTo tests, but the example from the issue now works.