### PR TITLE
add delimiter option for solving read error

### DIFF
--- a/docs/StardustDocs/topics/KPropertiesApi.md
+++ b/docs/StardustDocs/topics/KPropertiesApi.md
@@ -15,7 +15,7 @@ data class Passenger(
     val lastName: String
 )
 
-val passengers = DataFrame.read("titanic.csv")
+val passengers = DataFrame.read("titanic.csv", delimiter = ';')
     .add(Passenger::lastName) { "name"<String>().split(",").last() }
     .dropNulls(Passenger::age)
     .filter {
@@ -39,7 +39,7 @@ data class Passenger(
     val name: String
 )
 
-val passengers = DataFrame.read("titanic.csv")
+val passengers = DataFrame.read("titanic.csv", delimiter = ';')
     .filter { it.get(Passenger::city).endsWith("NY") }
     .toListOf<Passenger>()
 ```

--- a/docs/StardustDocs/topics/apiLevels.md
+++ b/docs/StardustDocs/topics/apiLevels.md
@@ -34,7 +34,7 @@ In the most of the code snippets in this documentation there's a tab selector th
 <!---FUN extensionProperties1-->
 
 ```kotlin
-val df = DataFrame.read("titanic.csv")
+val df = DataFrame.read("titanic.csv", delimiter = ';')
 ```
 
 <!---END-->
@@ -55,7 +55,7 @@ df.add("lastName") { name.split(",").last() }
 <!---FUN strings-->
 
 ```kotlin
-DataFrame.read("titanic.csv")
+DataFrame.read("titanic.csv", delimiter = ';')
     .add("lastName") { "name"<String>().split(",").last() }
     .dropNulls("age")
     .filter {
@@ -79,7 +79,7 @@ val age by column<Int?>()
 val name by column<String>()
 val lastName by column<String>()
 
-DataFrame.read("titanic.csv")
+DataFrame.read("titanic.csv", delimiter = ';')
     .add(lastName) { name().split(",").last() }
     .dropNulls { age }
     .filter { survived() && home().endsWith("NY") && age()!! in 10..20 }
@@ -100,7 +100,7 @@ data class Passenger(
     val lastName: String
 )
 
-val passengers = DataFrame.read("titanic.csv")
+val passengers = DataFrame.read("titanic.csv", delimiter = ';')
     .add(Passenger::lastName) { "name"<String>().split(",").last() }
     .dropNulls(Passenger::age)
     .filter {

--- a/docs/StardustDocs/topics/columnAccessorsApi.md
+++ b/docs/StardustDocs/topics/columnAccessorsApi.md
@@ -21,7 +21,7 @@ Now columns can be accessed in a type-safe way using `invoke` operator:
 <!---FUN accessors2-->
 
 ```kotlin
-DataFrame.read("titanic.csv")
+DataFrame.read("titanic.csv", delimiter = ';')
     .add(lastName) { name().split(",").last() }
     .dropNulls { age }
     .filter { survived() && home().endsWith("NY") && age()!! in 10..20 }

--- a/docs/StardustDocs/topics/extensionPropertiesApi.md
+++ b/docs/StardustDocs/topics/extensionPropertiesApi.md
@@ -7,7 +7,7 @@ When `DataFrame` is used within Jupyter Notebooks or Datalore with Kotlin Kernel
 <!---FUN extensionProperties1-->
 
 ```kotlin
-val df = DataFrame.read("titanic.csv")
+val df = DataFrame.read("titanic.csv", delimiter = ';')
 ```
 
 <!---END-->

--- a/docs/StardustDocs/topics/overview.md
+++ b/docs/StardustDocs/topics/overview.md
@@ -31,8 +31,9 @@ The handiness of this abstraction is not in the table itself but in a set of ope
 **Basics:**
 
 ```kotlin
-val df = DataFrame.read("titanic.csv")
+val df = DataFrame.read("titanic.csv", delimiter = ';')
 ```
+
 ```kotlin
 // filter rows
 df.filter { survived && home.endsWith("NY") && age in 10..20 }

--- a/docs/StardustDocs/topics/stringApi.md
+++ b/docs/StardustDocs/topics/stringApi.md
@@ -7,7 +7,7 @@ String column names are the easiest way to access data in DataFrame:
 <!---FUN strings-->
 
 ```kotlin
-DataFrame.read("titanic.csv")
+DataFrame.read("titanic.csv", delimiter = ';')
     .add("lastName") { "name"<String>().split(",").last() }
     .dropNulls("age")
     .filter {


### PR DESCRIPTION
The example file(titanic.csv) is a csv file, but the delimiter is a semi-colon.
Added a delimiter option so that the sample code can run right out of the box.