### PR TITLE
OpenApi post merge

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,8 +4,8 @@ rootProject.name = "dataframe"
 enableFeaturePreview("VERSION_CATALOGS")
 
 includeBuild("generator")
-//include("plugins:dataframe-gradle-plugin")
-//include("plugins:symbol-processor")
+include("plugins:dataframe-gradle-plugin")
+include("plugins:symbol-processor")
 include("tests")
 include("dataframe-arrow")
 include("dataframe-openapi")
@@ -13,7 +13,7 @@ include("dataframe-openapi")
 include("examples:idea-examples:titanic")
 include("examples:idea-examples:movies")
 include("examples:idea-examples:youtube")
-// include("examples:idea-examples:json")
+include("examples:idea-examples:json")
 
 val jupyterApiTCRepo: String by settings
 


### PR DESCRIPTION
Enables the disabled modules again which depended on other modules being in mavenCentral.

Maybe it even needs to be done in two stages, since the plugins were disabled before. But we'll need to test that.