### PR TITLE
Absolute path fixes in plugins

### DIFF
--- a/examples/idea-examples/movies/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/movies/moviesWithInterface.kt
+++ b/examples/idea-examples/movies/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/movies/moviesWithInterface.kt
@@ -2,11 +2,23 @@ package org.jetbrains.kotlinx.dataframe.examples.movies
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
-import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.api.by
+import org.jetbrains.kotlinx.dataframe.api.convertTo
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.jetbrains.kotlinx.dataframe.api.explode
+import org.jetbrains.kotlinx.dataframe.api.filter
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.inplace
+import org.jetbrains.kotlinx.dataframe.api.into
+import org.jetbrains.kotlinx.dataframe.api.mean
+import org.jetbrains.kotlinx.dataframe.api.pivot
+import org.jetbrains.kotlinx.dataframe.api.print
+import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.split
 import org.jetbrains.kotlinx.dataframe.io.read
 
 @DataSchema
-interface Movie{
+interface Movie {
     val movieId: String
     val title: String
     val genres: String


### PR DESCRIPTION
`defaultPath` in `AbstractDefaultReadMethod` implementing IO methods will now be absolute path to solve difference between calls from gradle/the IDE. `@ImportDataSchema` and `dataframes { schemas { data = "" } }` now support absolute path too. Relative path will still be attempted first.

Fixes https://github.com/Kotlin/dataframe/issues/139