### PR TITLE
fix for "Jupyter codegen: attempt to inherit from data class"

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
@@ -37,7 +37,10 @@ internal object MarkersExtractor {
     fun get(markerClass: KClass<*>, nullableProperties: Boolean = false): Marker =
         cache.getOrPut(Pair(markerClass, nullableProperties)) {
             val fields = getFields(markerClass, nullableProperties)
-            val isOpen = markerClass.findAnnotation<DataSchema>()?.isOpen ?: false
+            val isOpen = !markerClass.isSealed &&
+                markerClass.java.isInterface &&
+                markerClass.findAnnotation<DataSchema>()?.isOpen == true
+
             val baseSchemas = markerClass.superclasses.filter { it != Any::class }.map { get(it, nullableProperties) }
             Marker(
                 name = markerClass.qualifiedName ?: markerClass.simpleName!!,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
@@ -6,13 +6,22 @@ import org.jetbrains.kotlinx.dataframe.codeGen.CodeWithConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGeneratorImpl
 import org.jetbrains.kotlinx.jupyter.api.Code
 import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
 
 internal interface ReplCodeGenerator {
 
-    fun process(df: AnyFrame, property: KProperty<*>? = null): CodeWithConverter
+    fun process(
+        df: AnyFrame,
+        property: KProperty<*>? = null,
+        isMutable: Boolean = property is KMutableProperty?,
+    ): CodeWithConverter
 
-    fun process(row: AnyRow, property: KProperty<*>? = null): CodeWithConverter
+    fun process(
+        row: AnyRow,
+        property: KProperty<*>? = null,
+        isMutable: Boolean = property is KMutableProperty?,
+    ): CodeWithConverter
 
     fun process(markerClass: KClass<*>): Code
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/generateCode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/generateCode.kt
@@ -4,7 +4,10 @@ import org.jetbrains.dataframe.impl.codeGen.CodeGenerator
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.schema
 
-public inline fun <reified T> DataFrame<T>.generateCode(fields: Boolean = true, extensionProperties: Boolean = true): String {
+public inline fun <reified T> DataFrame<T>.generateCode(
+    fields: Boolean = true,
+    extensionProperties: Boolean = true,
+): String {
     val name = if (T::class.isAbstract) {
         T::class.simpleName!!
     } else "DataEntry"
@@ -15,16 +18,16 @@ public fun <T> DataFrame<T>.generateCode(
     markerName: String,
     fields: Boolean = true,
     extensionProperties: Boolean = true,
-    visibility: MarkerVisibility = MarkerVisibility.IMPLICIT_PUBLIC
+    visibility: MarkerVisibility = MarkerVisibility.IMPLICIT_PUBLIC,
 ): String {
     val codeGen = CodeGenerator.create()
     return codeGen.generate(
-        schema(),
-        markerName,
+        schema = schema(),
+        name = markerName,
         fields = fields,
         extensionProperties = extensionProperties,
         isOpen = true,
-        visibility
+        visibility = visibility,
     ).code.declarations
 }
 
@@ -34,7 +37,7 @@ public inline fun <reified T> DataFrame<T>.generateInterfaces(): String = genera
 )
 
 public fun <T> DataFrame<T>.generateInterfaces(markerName: String): String = generateCode(
-    markerName,
+    markerName = markerName,
     fields = true,
     extensionProperties = false
 )

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -37,8 +37,8 @@ import org.jetbrains.kotlinx.jupyter.api.Code
 
 private fun renderNullability(nullable: Boolean) = if (nullable) "?" else ""
 
-internal fun getRequiredMarkers(schema: DataFrameSchema, markers: Iterable<Marker>) = markers
-    .filter { it.isOpen && it.schema.compare(schema).isSuperOrEqual() }
+internal fun Iterable<Marker>.filterRequiredForSchema(schema: DataFrameSchema) =
+    filter { it.isOpen && it.schema.compare(schema).isSuperOrEqual() }
 
 internal val charsToQuote = """[ `(){}\[\].<>'"/|\\!?@:;%^&*#$-]""".toRegex()
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -92,9 +92,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
             extensionProperties = true,
             isOpen = isOpen,
             visibility = MarkerVisibility.IMPLICIT_PUBLIC,
-            knownMarkers = registeredMarkers
-                .filterKeys { !it.isData } // filter out data classes, so they aren't used as supertypes
-                .values,
+            knownMarkers = registeredMarkers.values,
         )
 
         result.newMarkers.forEach {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
@@ -133,7 +133,7 @@ internal class SchemaProcessorImpl(
         return Marker(name, isOpen, fields, baseMarkers.onlyLeafs(), visibility, emptyList(), emptyList())
     }
 
-    private fun DataFrameSchema.getRequiredMarkers() = getRequiredMarkers(this, registeredMarkers)
+    private fun DataFrameSchema.getRequiredMarkers() = registeredMarkers.filterRequiredForSchema(this)
 
     override fun process(
         schema: DataFrameSchema,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaProcessorImpl.kt
@@ -22,7 +22,7 @@ internal class SchemaProcessorImpl(
     override val generatedMarkers = mutableListOf<Marker>()
 
     private fun DataFrameSchema.getAllSuperMarkers() = registeredMarkers
-        .filter { it.schema.compare(this).isSuperOrEqual() }
+        .filter { it.isOpen && it.schema.compare(this).isSuperOrEqual() }
 
     private fun List<Marker>.onlyLeafs(): List<Marker> {
         val skip = flatMap { it.allSuperMarkers.keys }.toSet()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -26,7 +26,7 @@ class ReplCodeGenTests : BaseTest() {
     val stringName = String::class.simpleName!!
 
     class Test1 {
-        @DataSchema(isOpen = false)
+        @DataSchema
         interface _DataFrameType
 
         @DataSchema(isOpen = false)
@@ -37,10 +37,10 @@ class ReplCodeGenTests : BaseTest() {
     }
 
     class Test2 {
-        @DataSchema(isOpen = false)
+        @DataSchema
         interface _DataFrameType
 
-        @DataSchema(isOpen = false)
+        @DataSchema
         interface _DataFrameType1
 
         @DataSchema(isOpen = false)
@@ -68,13 +68,13 @@ class ReplCodeGenTests : BaseTest() {
     @Test
     fun `process derived markers`() {
         val repl = ReplCodeGenerator.create()
-        val code = repl.process(df).declarations
+        val code = repl.process(df, isMutable = true).declarations
 
         val marker = ReplCodeGeneratorImpl.markerInterfacePrefix
         val markerFull = Test1._DataFrameType::class.qualifiedName!!
 
         val expected = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $marker
             
             val $dfName<$marker>.age: $dataCol<$intName> @JvmName("${marker}_age") get() = this["age"] as $dataCol<$intName>
@@ -100,7 +100,7 @@ class ReplCodeGenTests : BaseTest() {
         code2 shouldBe ""
 
         val df3 = typed.filter { city != null }
-        val code3 = repl.process(df3).declarations
+        val code3 = repl.process(df3, isMutable = false).declarations
         val marker3 = marker + "1"
         val expected3 = """
             @DataSchema(isOpen = false)
@@ -118,7 +118,7 @@ class ReplCodeGenTests : BaseTest() {
         code4 shouldBe ""
 
         val df5 = typed.filter { weight != null }
-        val code5 = repl.process(df5).declarations
+        val code5 = repl.process(df5, isMutable = false).declarations
         val marker5 = marker + "2"
         val expected5 = """
             @DataSchema(isOpen = false)
@@ -149,7 +149,7 @@ class ReplCodeGenTests : BaseTest() {
             
         """.trimIndent()
 
-        val code = repl.process(typed).declarations.trimIndent()
+        val code = repl.process(typed, isMutable = false).declarations.trimIndent()
         code shouldBe expected
     }
 
@@ -176,7 +176,7 @@ class ReplCodeGenTests : BaseTest() {
             val $dfRowName<$marker?>.weight: $intName? @JvmName("Nullable${marker}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
 
-        val code = repl.process(typed).declarations.trimIndent()
+        val code = repl.process(typed, isMutable = false).declarations.trimIndent()
         code shouldBe expected
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
@@ -36,8 +36,71 @@ class JupyterCodegenTests : JupyterReplTestCase() {
         @Language("kts")
         val res1 = exec(
             """
-            @DataSchema(isOpen = false)
+            @DataSchema
             data class A(val a: Int)
+            """.trimIndent()
+        )
+
+        @Language("kts")
+        val res2 = execRaw(
+            """
+            val df = dataFrameOf("a", "b")(1, 2)
+            df
+            """.trimIndent()
+        )
+
+        (res2 as AnyFrame).should { it.isNotEmpty() }
+    }
+
+    @Test
+    fun `Don't inherit from non open class`() {
+        @Language("kts")
+        val res1 = exec(
+            """
+            @DataSchema
+            class A(val a: Int)
+            """.trimIndent()
+        )
+
+        @Language("kts")
+        val res2 = execRaw(
+            """
+            val df = dataFrameOf("a", "b")(1, 2)
+            df
+            """.trimIndent()
+        )
+
+        (res2 as AnyFrame).should { it.isNotEmpty() }
+    }
+
+    @Test
+    fun `Don't inherit from open class`() {
+        @Language("kts")
+        val res1 = exec(
+            """
+            @DataSchema
+            open class A(val a: Int)
+            """.trimIndent()
+        )
+
+        @Language("kts")
+        val res2 = execRaw(
+            """
+            val df = dataFrameOf("a", "b")(1, 2)
+            df
+            """.trimIndent()
+        )
+
+        (res2 as AnyFrame).should { it.isNotEmpty() }
+    }
+
+    @Test
+    fun `Do inherit from open interface`() {
+        @Language("kts")
+        val res1 = exec(
+            """
+            @DataSchema
+            interface A { val a: Int }
             """.trimIndent()
         )
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
@@ -1,10 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.jupyter
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.api.isNotEmpty
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.jupyter.api.MimeTypedResult
@@ -27,6 +29,27 @@ class JupyterCodegenTests : JupyterReplTestCase() {
         val res2 = execRaw("df") as AnyFrame
 
         res2["value"].type shouldBe typeOf<List<Any?>>()
+    }
+
+    @Test
+    fun `Don't inherit from data class`() {
+        @Language("kts")
+        val res1 = exec(
+            """
+            @DataSchema(isOpen = false)
+            data class A(val a: Int)
+            """.trimIndent()
+        )
+
+        @Language("kts")
+        val res2 = execRaw(
+            """
+            val df = dataFrameOf("a", "b")(1, 2)
+            df
+            """.trimIndent()
+        )
+
+        (res2 as AnyFrame).should { it.isNotEmpty() }
     }
 
     @Test


### PR DESCRIPTION
https://github.com/Kotlin/dataframe/issues/178

Basically, I added a filter for data classes when passing knownMarkers on to `codeGenerator.generate()`, so it cannot appear as supertype anymore.

Small cleanups