### PR TITLE
Write nulls from columns to JSON explicitly

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -858,10 +858,10 @@ private val valueTypes =
     setOf(Boolean::class, Double::class, Int::class, Float::class, Long::class, Short::class, Byte::class)
 
 internal fun KlaxonJson.encodeRow(frame: ColumnsContainer<*>, index: Int): JsonObject? {
-    val values = frame.columns().mapNotNull { col ->
+    val values = frame.columns().map { col ->
         when {
             col is ColumnGroup<*> -> encodeRow(col, index)
-            col is FrameColumn<*> -> col[index]?.let { encodeFrame(it) }
+            col is FrameColumn<*> -> encodeFrame(col[index])
             col.isList() -> {
                 col[index]?.let { array(it as List<*>) } ?: array()
             }
@@ -874,7 +874,7 @@ internal fun KlaxonJson.encodeRow(frame: ColumnsContainer<*>, index: Int): JsonO
             }
 
             else -> col[index]?.toString()
-        }?.let { col.name to it }
+        }.let { col.name to it }
     }
     if (values.isEmpty()) return null
     return obj(values)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -945,4 +945,10 @@ class JsonTests {
             }
         }
     }
+
+    @Test
+    fun `nulls in columns should be encoded explicitly`() {
+        val df = dataFrameOf("a", "b")("1", null, "2", 12)
+        df.toJson(canonical = true) shouldContain "\"b\":null"
+    }
 }


### PR DESCRIPTION
These nulls are useful if you want to modify this JSON manually later. You'll have to edit data, not add missing fields