### PR TITLE
Column creation of @DataSchema instances to produce ColumnGroups

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/inferType.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/inferType.kt
@@ -5,15 +5,19 @@ import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
-import org.jetbrains.kotlinx.dataframe.impl.columns.guessColumnType
+import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumns
 import org.jetbrains.kotlinx.dataframe.type
 import kotlin.reflect.KProperty
 
-public fun AnyCol.inferType(): DataColumn<*> = guessColumnType(name, toList(), type, true)
+public fun AnyCol.inferType(): DataColumn<*> = createColumnGuessingType(name, toList(), type, true)
 
 public fun <T> DataFrame<T>.inferType(): DataFrame<T> = inferType { allDfs() }
-public fun <T> DataFrame<T>.inferType(columns: ColumnsSelector<T, *>): DataFrame<T> = replace(columns).with { it.inferType() }
+public fun <T> DataFrame<T>.inferType(columns: ColumnsSelector<T, *>): DataFrame<T> =
+    replace(columns).with { it.inferType() }
+
 public fun <T> DataFrame<T>.inferType(vararg columns: String): DataFrame<T> = inferType { columns.toColumns() }
-public fun <T> DataFrame<T>.inferType(vararg columns: ColumnReference<*>): DataFrame<T> = inferType { columns.toColumns() }
+public fun <T> DataFrame<T>.inferType(vararg columns: ColumnReference<*>): DataFrame<T> =
+    inferType { columns.toColumns() }
+
 public fun <T> DataFrame<T>.inferType(vararg columns: KProperty<*>): DataFrame<T> = inferType { columns.toColumns() }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/ColumnDataCollector.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/ColumnDataCollector.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.api.concat
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
-import org.jetbrains.kotlinx.dataframe.impl.columns.guessColumnType
+import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
@@ -49,12 +49,14 @@ internal abstract class DataCollectorBase<T>(initCapacity: Int) : DataCollector<
     }
 }
 
-internal open class ColumnDataCollector(initCapacity: Int = 0, val typeOf: (KClass<*>) -> KType) : DataCollectorBase<Any?>(initCapacity) {
+internal open class ColumnDataCollector(initCapacity: Int = 0, val typeOf: (KClass<*>) -> KType) :
+    DataCollectorBase<Any?>(initCapacity) {
 
-    override fun toColumn(name: String) = guessColumnType(name, values)
+    override fun toColumn(name: String) = createColumnGuessingType(name, values)
 }
 
-internal class TypedColumnDataCollector<T>(initCapacity: Int = 0, val type: KType, val checkTypes: Boolean = true) : DataCollectorBase<T?>(initCapacity) {
+internal class TypedColumnDataCollector<T>(initCapacity: Int = 0, val type: KType, val checkTypes: Boolean = true) :
+    DataCollectorBase<T?>(initCapacity) {
 
     internal val kclass = type.jvmErasure
 
@@ -68,8 +70,11 @@ internal class TypedColumnDataCollector<T>(initCapacity: Int = 0, val type: KTyp
     override fun toColumn(name: String) = createColumn(name, type)
 }
 
-internal fun createDataCollector(initCapacity: Int = 0) = createDataCollector(initCapacity) { it.createStarProjectedType(false) }
+internal fun createDataCollector(initCapacity: Int = 0) =
+    createDataCollector(initCapacity) { it.createStarProjectedType(false) }
 
-internal fun createDataCollector(initCapacity: Int = 0, typeOf: (KClass<*>) -> KType) = ColumnDataCollector(initCapacity, typeOf)
+internal fun createDataCollector(initCapacity: Int = 0, typeOf: (KClass<*>) -> KType) =
+    ColumnDataCollector(initCapacity, typeOf)
 
-internal fun <T> createDataCollector(initCapacity: Int = 0, type: KType) = TypedColumnDataCollector<T>(initCapacity, type)
+internal fun <T> createDataCollector(initCapacity: Int = 0, type: KType) =
+    TypedColumnDataCollector<T>(initCapacity, type)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.api.Infer
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -12,6 +13,7 @@ import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.createType
+import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.isSuperclassOf
@@ -334,7 +336,12 @@ internal fun guessValueType(values: Sequence<Any?>, upperBound: KType? = null, l
                 collectionClasses.add(it.javaClass.kotlin)
             }
 
-            else -> classes.add(it.javaClass.kotlin)
+            else ->
+                if (it.javaClass.kotlin.hasAnnotation<DataSchema>()) {
+                    hasRows = true
+                } else {
+                    classes.add(it.javaClass.kotlin)
+                }
         }
     }
     val allListsWithRows = classesInCollection.isNotEmpty() &&

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
@@ -7,16 +7,17 @@ import org.jetbrains.kotlinx.dataframe.aggregation.NamedValue
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.isComparable
 import org.jetbrains.kotlinx.dataframe.api.isNumber
-import org.jetbrains.kotlinx.dataframe.impl.columns.guessColumnType
+import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
 
 internal inline fun <T> Aggregatable<T>.remainingColumns(crossinline predicate: (AnyCol) -> Boolean): ColumnsSelector<T, Any?> =
     remainingColumnsSelector().filter { predicate(it.data) }
 
-internal fun <T> Aggregatable<T>.comparableColumns() = remainingColumns { it.isComparable() } as ColumnsSelector<T, Comparable<Any?>>
+internal fun <T> Aggregatable<T>.comparableColumns() =
+    remainingColumns { it.isComparable() } as ColumnsSelector<T, Comparable<Any?>>
 
 internal fun <T> Aggregatable<T>.numberColumns() = remainingColumns { it.isNumber() } as ColumnsSelector<T, Number?>
 
-internal fun NamedValue.toColumnWithPath() = path to guessColumnType(
+internal fun NamedValue.toColumnWithPath() = path to createColumnGuessingType(
     path.last(),
     listOf(value),
     type,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
 import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.hasNulls
-import org.jetbrains.kotlinx.dataframe.impl.columns.guessColumnType
+import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
 import org.jetbrains.kotlinx.dataframe.impl.commonType
 import org.jetbrains.kotlinx.dataframe.impl.getListType
 import org.jetbrains.kotlinx.dataframe.nrow
@@ -64,7 +64,7 @@ internal fun <T> concatImpl(name: String, columns: List<DataColumn<T>?>, columnS
         val baseType = types.commonType()
         val tartypeOf = if (guessType || !hasList) baseType.withNullability(nulls)
         else getListType(baseType.withNullability(listOfNullable))
-        return guessColumnType(name, list, tartypeOf, guessType, defaultValue).cast()
+        return createColumnGuessingType(name, list, tartypeOf, guessType, defaultValue).cast()
     }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/common.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/common.kt
@@ -4,7 +4,7 @@ import com.github.kittinunf.fuel.httpGet
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
-import org.jetbrains.kotlinx.dataframe.impl.columns.guessColumnType
+import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -32,9 +32,10 @@ public fun <T> List<List<T>>.toDataFrame(containsColumns: Boolean = false): AnyF
             if (it.isEmpty()) return@mapNotNull null
             val name = it[0].toString()
             val values = it.drop(1)
-            guessColumnType(name, values)
+            createColumnGuessingType(name, values)
         }.toDataFrame()
     }
+
     isEmpty() -> DataFrame.Empty
     else -> {
         val header = get(0).map { it.toString() }
@@ -44,7 +45,7 @@ public fun <T> List<List<T>>.toDataFrame(containsColumns: Boolean = false): AnyF
                 if (row.size <= colIndex) null
                 else row[colIndex]
             }
-            guessColumnType(name, values)
+            createColumnGuessingType(name, values)
         }.toDataFrame()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.alsoDebug
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.kind
@@ -11,6 +13,43 @@ import org.junit.Test
 import kotlin.reflect.typeOf
 
 class CreateDataFrameTests {
+
+    @DataSchema
+    data class Gps(
+        val latitude: Double,
+        val longitude: Double,
+    )
+
+    @DataSchema
+    data class Location(
+        val name: String,
+        val gps: Gps?,
+    )
+
+    @Test
+    fun `dataSchema instances`() {
+        val a: DataFrame<Location> = listOf(
+            Location("Home", Gps(0.0, 0.0)),
+            Location("Away", null),
+        ).toDataFrame()
+
+        a.alsoDebug()
+        a.name.type() shouldBe typeOf<String>()
+        a.gps.type() shouldBe typeOf<DataRow<*>>()
+
+        val b: AnyFrame = dataFrameOf("name", "gps")(
+            "Home", Gps(0.0, 0.0),
+            "Away", null,
+        )
+
+        b.alsoDebug()
+        b["name"].type() shouldBe typeOf<String>()
+        b["gps"].type() shouldBe typeOf<DataRow<*>>()
+
+        val c by columnOf(Gps(0.0, 0.0), null)
+        c.toDataFrame().print(borders = true, title = true, columnTypes = true)
+        c.type() shouldBe typeOf<DataRow<*>>()
+    }
 
     @Test
     fun `visibility test`() {
@@ -175,6 +214,7 @@ class CreateDataFrameTests {
     fun treatErasedGenericAsAny() {
         class IncompatibleVersionErrorData<T>(val expected: T, val actual: T)
         class DeserializedContainerSource(val incompatibility: IncompatibleVersionErrorData<*>)
+
         val functions = listOf(DeserializedContainerSource(IncompatibleVersionErrorData(1, 2)))
 
         val df = functions.toDataFrame(maxDepth = 2)


### PR DESCRIPTION
Based on https://github.com/Kotlin/dataframe/issues/177. See this issue for more details and motivation.

Might be related to `dataFrameOf()` overloads in https://github.com/Kotlin/dataframe/issues/113

With these changes:
```kotlin
dataFrameOf("name", "gps")(
    "Home", Gps(0.0, 0.0),
    "Away", null,
)
// ⌌----------------------------------------------------------⌍
// |  | name:String| gps:{latitude:Double?, longitude:Double?}|
// |--|------------|------------------------------------------|
// | 0|        Home|  { latitude:0.000000, longitude:0.0000...|
// | 1|        Away|                                       { }|
// ⌎----------------------------------------------------------⌏
// 
// name: String
// gps:
//     latitude: Double?
//     longitude: Double?
```
instead of 
```kotlin
// ⌌-------------------------------------------------⌍
// |  | name:String|                         gps:Gps?|
// |--|------------|---------------------------------|
// | 0|        Home| Gps(latitude=0.0, longitude=0.0)|
// | 1|        Away|                             null|
// ⌎-------------------------------------------------⌏
// 
// name: String
// gps: Gps?
```

Also changes the behavior of `columnOf(Gps(...))` to produce a `ColumnGroup` now. To be specific, if a new column is created from values where all values are either `null` or the same `@DataSchema` annotated type instance, a `ColumnGroup` will be formed instead of the previous `ValueColumn`.

Would this be acceptable behavior? Better than before? Worse?
@koperagen 
@nikitinas 
