### PR TITLE
Add emptyDataFrame to documentation

### DIFF
--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.column
 import org.jetbrains.kotlinx.dataframe.api.columnGroup
 import org.jetbrains.kotlinx.dataframe.api.columnOf
+import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.frameColumn
@@ -197,6 +198,15 @@ class Create : TestBase() {
         val columns by columnGroup()
         val frames by frameColumn()
         // SampleEnd
+    }
+
+    @Test
+    fun createEmptyDataFrame() {
+        // SampleStart
+        val df = emptyDataFrame()
+        // SampleEnd
+        df.columnsCount() shouldBe 0
+        df.rowsCount() shouldBe 0
     }
 
     @Test

--- a/docs/StardustDocs/topics/createDataFrame.md
+++ b/docs/StardustDocs/topics/createDataFrame.md
@@ -3,6 +3,18 @@
 
 This section describes ways to create [`DataFrame`](DataFrame.md).
 
+### emptyDataFrame
+
+Returns [`DataFrame`](DataFrame.md) with no rows and no columns.
+
+<!---FUN createEmptyDataFrame-->
+
+```kotlin
+val df = emptyDataFrame()
+```
+
+<!---END-->
+
 ### dataFrameOf
 
 Returns [`DataFrame`](DataFrame.md) with given column names and values.


### PR DESCRIPTION
The `emptyDataFrame()` constructor is missing from the [Create DataFrame](https://kotlin.github.io/dataframe/createdataframe.html) page of the documentation - this PR adds it.

Please let me know if I followed the instructions in [contributions.md](https://github.com/Kotlin/dataframe/blob/master/docs/contributions.md) correctly!