### PR TITLE
Jupyter codegen isOpen both for var/val

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
@@ -8,9 +8,9 @@ import org.jetbrains.kotlinx.dataframe.impl.schema.getPropertiesOrder
 import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
@@ -54,7 +54,7 @@ internal object MarkersExtractor {
 
     private fun getFields(markerClass: KClass<*>, nullableProperties: Boolean): List<GeneratedField> {
         val order = getPropertiesOrder(markerClass)
-        return markerClass.declaredMemberProperties.sortedBy { order[it.name] ?: Int.MAX_VALUE }.mapIndexed { _, it ->
+        return markerClass.memberProperties.sortedBy { order[it.name] ?: Int.MAX_VALUE }.mapIndexed { _, it ->
             val fieldName = ValidFieldName.of(it.name)
             val columnName = it.findAnnotation<ColumnName>()?.name ?: fieldName.unquoted
             val type = it.returnType

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlinx.dataframe.codeGen.CodeWithConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGeneratorImpl
 import org.jetbrains.kotlinx.jupyter.api.Code
 import kotlin.reflect.KClass
-import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
 
 internal interface ReplCodeGenerator {
@@ -14,13 +13,11 @@ internal interface ReplCodeGenerator {
     fun process(
         df: AnyFrame,
         property: KProperty<*>? = null,
-        isMutable: Boolean = property is KMutableProperty?,
     ): CodeWithConverter
 
     fun process(
         row: AnyRow,
         property: KProperty<*>? = null,
-        isMutable: Boolean = property is KMutableProperty?,
     ): CodeWithConverter
 
     fun process(markerClass: KClass<*>): Code

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.alsoDebug
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.junit.Test
@@ -239,9 +240,21 @@ class ConvertToTests {
             .alsoDebug("df5 after second convert:")
     }
 
-    private fun <T : DataFrame<*>> T.alsoDebug(println: String? = null): T = apply {
-        println?.let { println(it) }
-        print(borders = true, title = true, columnTypes = true, valueLimit = -1)
-        schema().print()
+    interface KeyValue<T> {
+        val key: String
+        val value: T
+    }
+
+    @DataSchema
+    interface MySchema : KeyValue<Int>
+
+    @Test
+    fun `Convert generic interface to itself`() {
+        val df = dataFrameOf("key", "value")(
+            "a", 1,
+            "b", 2,
+        ).alsoDebug()
+        val converted = df.convertTo<MySchema>().alsoDebug()
+        converted shouldBe df
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -59,7 +59,7 @@ class CodeGenerationTests : BaseTest() {
         val generated = codeGen.process(df, ::df)
         val typeName = ReplCodeGeneratorImpl.markerInterfacePrefix
         val expectedDeclaration = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $typeName
             
         """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
@@ -84,7 +84,7 @@ class CodeGenerationTests : BaseTest() {
         val generated = ReplCodeGenerator.create().process(df[0], property)
         val typeName = ReplCodeGeneratorImpl.markerInterfacePrefix
         val expectedDeclaration = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $typeName
             
         """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
@@ -118,7 +118,7 @@ class CodeGenerationTests : BaseTest() {
         """.trimIndent()
 
         val declaration2 = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $type2
             
             val $dfName<$type2>.age: $dataCol<$intName> @JvmName("${type2}_age") get() = this["age"] as $dataCol<$intName>

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.codeGen
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldBeEmpty
+import io.kotest.matchers.string.shouldNotBeEmpty
 import org.jetbrains.dataframe.impl.codeGen.ReplCodeGenerator
 import org.jetbrains.dataframe.impl.codeGen.process
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
@@ -186,8 +186,8 @@ class ReplCodeGenTests : BaseTest() {
         repl.process<Test3.A>()
         repl.process<Test3.B>()
         repl.process<Test3.C>()
-        val c = repl.process(Test3.df, Test3::df) // TODO this now generates stuff
-        c.declarations.shouldBeEmpty()
+        val c = repl.process(Test3.df, Test3::df)
+        c.declarations.shouldNotBeEmpty()
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -68,7 +68,7 @@ class ReplCodeGenTests : BaseTest() {
     @Test
     fun `process derived markers`() {
         val repl = ReplCodeGenerator.create()
-        val code = repl.process(df, isMutable = true).declarations
+        val code = repl.process(df).declarations
 
         val marker = ReplCodeGeneratorImpl.markerInterfacePrefix
         val markerFull = Test1._DataFrameType::class.qualifiedName!!
@@ -100,10 +100,10 @@ class ReplCodeGenTests : BaseTest() {
         code2 shouldBe ""
 
         val df3 = typed.filter { city != null }
-        val code3 = repl.process(df3, isMutable = false).declarations
+        val code3 = repl.process(df3).declarations
         val marker3 = marker + "1"
         val expected3 = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $marker3 : $markerFull
             
             val $dfName<$marker3>.city: $dataCol<$stringName> @JvmName("${marker3}_city") get() = this["city"] as $dataCol<$stringName>
@@ -118,10 +118,10 @@ class ReplCodeGenTests : BaseTest() {
         code4 shouldBe ""
 
         val df5 = typed.filter { weight != null }
-        val code5 = repl.process(df5, isMutable = false).declarations
+        val code5 = repl.process(df5).declarations
         val marker5 = marker + "2"
         val expected5 = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $marker5 : $markerFull
             
             val $dfName<$marker5>.weight: $dataCol<$intName> @JvmName("${marker5}_weight") get() = this["weight"] as $dataCol<$intName>
@@ -144,12 +144,12 @@ class ReplCodeGenTests : BaseTest() {
         repl.process<Test2._DataFrameType1>() shouldBe ""
 
         val expected = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface ${Test2._DataFrameType2::class.simpleName!!} : ${Test2._DataFrameType::class.qualifiedName}, ${Test2._DataFrameType1::class.qualifiedName}
             
         """.trimIndent()
 
-        val code = repl.process(typed, isMutable = false).declarations.trimIndent()
+        val code = repl.process(typed).declarations.trimIndent()
         code shouldBe expected
     }
 
@@ -163,7 +163,7 @@ class ReplCodeGenTests : BaseTest() {
 
         val marker = Test2._DataFrameType2::class.simpleName!!
         val expected = """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $marker : ${Test2._DataFrameType::class.qualifiedName}
             
             val $dfName<$marker>.city: $dataCol<$stringName?> @JvmName("${marker}_city") get() = this["city"] as $dataCol<$stringName?>
@@ -176,17 +176,17 @@ class ReplCodeGenTests : BaseTest() {
             val $dfRowName<$marker?>.weight: $intName? @JvmName("Nullable${marker}_weight") get() = this["weight"] as $intName?
         """.trimIndent()
 
-        val code = repl.process(typed, isMutable = false).declarations.trimIndent()
+        val code = repl.process(typed).declarations.trimIndent()
         code shouldBe expected
     }
 
     @Test
-    fun `process overriden property`() {
+    fun `process overridden property`() {
         val repl = ReplCodeGenerator.create()
         repl.process<Test3.A>()
         repl.process<Test3.B>()
         repl.process<Test3.C>()
-        val c = repl.process(Test3.df, Test3::df)
+        val c = repl.process(Test3.df, Test3::df) // TODO this now generates stuff
         c.declarations.shouldBeEmpty()
     }
 

--- a/plugins/symbol-processor/src/main/kotlin/org/jetbrains/dataframe/ksp/ExtensionsGenerator.kt
+++ b/plugins/symbol-processor/src/main/kotlin/org/jetbrains/dataframe/ksp/ExtensionsGenerator.kt
@@ -12,7 +12,6 @@ import com.google.devtools.ksp.symbol.KSClassifierReference
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSName
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.Modifier
@@ -61,11 +60,10 @@ class ExtensionsGenerator(
         return when {
             isClassOrInterface() && effectivelyPublicOrInternal() -> {
                 DataSchemaDeclaration(
-                    this,
-                    declarations
-                        .filterIsInstance<KSPropertyDeclaration>()
+                    origin = this,
+                    properties = getAllProperties()
                         .map { KSAnnotatedWithType(it, it.simpleName, it.type) }
-                        .toList()
+                        .toList(),
                 )
             }
             else -> null

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
@@ -749,6 +749,37 @@ class DataFrameSymbolProcessorTest {
     }
 
     @Test
+    fun `generic interface as supertype`() {
+        val result = KspCompilationTestRunner.compile(
+            TestCompilationParameters(
+                sources = listOf(
+                    SourceFile.kotlin(
+                        "MySources.kt",
+                        """
+                package org.example
+
+                $imports
+
+                interface KeyValue<T> {
+                    val key: String
+                    val value: T
+                }
+                
+                @DataSchema
+                interface MySchema : KeyValue<Int>
+
+
+                val ColumnsContainer<MySchema>.test1: DataColumn<String> get() = key
+                val DataRow<MySchema>.test2: Int get() = value
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+        result.successfulCompilation shouldBe true
+    }
+
+    @Test
     fun `nested interface`() {
         val result = KspCompilationTestRunner.compile(
             TestCompilationParameters(


### PR DESCRIPTION
Based on discussion in https://github.com/Kotlin/dataframe/pull/193, root generated `@DataSchema` interfaces in Jupyter will now be always open, regardless of whether it's a `val` or `var`. `var`s are not used often, so we miss out on a lot of potentially reusable data schemas.