### PR TITLE
Bugfix for NPE with fillNulls

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -20,8 +20,12 @@ import kotlin.reflect.KProperty
 public fun <T, C> DataFrame<T>.fillNulls(cols: ColumnsSelector<T, C?>): Update<T, C?> =
     update(cols).where { it == null }
 
-public fun <T> DataFrame<T>.fillNulls(vararg cols: String): Update<T, Any?> = fillNulls { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNulls(vararg cols: KProperty<C>): Update<T, C?> = fillNulls { cols.toColumns() }
+public fun <T> DataFrame<T>.fillNulls(vararg cols: String): Update<T, Any?> =
+    fillNulls { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNulls(vararg cols: KProperty<C>): Update<T, C?> =
+    fillNulls { cols.toColumns() }
+
 public fun <T, C> DataFrame<T>.fillNulls(vararg cols: ColumnReference<C>): Update<T, C?> =
     fillNulls { cols.toColumns() }
 
@@ -38,9 +42,9 @@ internal inline val Any?.isNA: Boolean
         is Double -> isNaN()
         is Float -> isNaN()
         is AnyRow -> allNA()
-    is AnyFrame -> isEmpty()
-    else -> false
-}
+        is AnyFrame -> isEmpty()
+        else -> false
+    }
 
 internal inline val AnyCol.canHaveNaN: Boolean get() = typeClass.let { it == Double::class || it == Float::class }
 
@@ -52,10 +56,18 @@ internal inline val Float?.isNA: Boolean get() = this == null || this.isNaN()
 
 // region fillNaNs
 
-public fun <T, C> DataFrame<T>.fillNaNs(cols: ColumnsSelector<T, C>): Update<T, C> = update(cols).where { it.isNaN }
-public fun <T> DataFrame<T>.fillNaNs(vararg cols: String): Update<T, Any?> = fillNaNs { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: KProperty<C>): Update<T, C> = fillNaNs { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: ColumnReference<C>): Update<T, C> = fillNaNs { cols.toColumns() }
+public fun <T, C> DataFrame<T>.fillNaNs(cols: ColumnsSelector<T, C>): Update<T, C> =
+    update(cols).where { it.isNaN }
+
+public fun <T> DataFrame<T>.fillNaNs(vararg cols: String): Update<T, Any?> =
+    fillNaNs { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: KProperty<C>): Update<T, C> =
+    fillNaNs { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: ColumnReference<C>): Update<T, C> =
+    fillNaNs { cols.toColumns() }
+
 public fun <T, C> DataFrame<T>.fillNaNs(cols: Iterable<ColumnReference<C>>): Update<T, C> =
     fillNaNs { cols.toColumnSet() }
 
@@ -63,11 +75,20 @@ public fun <T, C> DataFrame<T>.fillNaNs(cols: Iterable<ColumnReference<C>>): Upd
 
 // region fillNA
 
-public fun <T, C> DataFrame<T>.fillNA(cols: ColumnsSelector<T, C?>): Update<T, C?> = update(cols).where { it.isNA }
-public fun <T> DataFrame<T>.fillNA(vararg cols: String): Update<T, Any?> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(vararg cols: KProperty<C>): Update<T, C?> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(vararg cols: ColumnReference<C>): Update<T, C?> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(cols: Iterable<ColumnReference<C>>): Update<T, C?> = fillNA { cols.toColumnSet() }
+public fun <T, C> DataFrame<T>.fillNA(cols: ColumnsSelector<T, C?>): Update<T, C?> =
+    update(cols).where { it.isNA }
+
+public fun <T> DataFrame<T>.fillNA(vararg cols: String): Update<T, Any?> =
+    fillNA { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNA(vararg cols: KProperty<C>): Update<T, C?> =
+    fillNA { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNA(vararg cols: ColumnReference<C>): Update<T, C?> =
+    fillNA { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNA(cols: Iterable<ColumnReference<C>>): Update<T, C?> =
+    fillNA { cols.toColumnSet() }
 
 // endregion
 
@@ -79,13 +100,24 @@ public fun <T> DataFrame<T>.dropNulls(whereAllNull: Boolean = false, selector: C
     else drop { row -> cols.any { col -> col[row] == null } }
 }
 
-public fun <T> DataFrame<T>.dropNulls(whereAllNull: Boolean = false): DataFrame<T> = dropNulls(whereAllNull) { all() }
-public fun <T> DataFrame<T>.dropNulls(vararg cols: KProperty<*>, whereAllNull: Boolean = false): DataFrame<T> = dropNulls(whereAllNull) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNulls(vararg cols: String, whereAllNull: Boolean = false): DataFrame<T> = dropNulls(whereAllNull) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNulls(vararg cols: Column, whereAllNull: Boolean = false): DataFrame<T> = dropNulls(whereAllNull) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNulls(cols: Iterable<Column>, whereAllNull: Boolean = false): DataFrame<T> = dropNulls(whereAllNull) { cols.toColumnSet() }
+public fun <T> DataFrame<T>.dropNulls(whereAllNull: Boolean = false): DataFrame<T> =
+    dropNulls(whereAllNull) { all() }
 
-public fun <T> DataColumn<T?>.dropNulls(): DataColumn<T> = (if (!hasNulls()) this else filter { it != null }) as DataColumn<T>
+public fun <T> DataFrame<T>.dropNulls(vararg cols: KProperty<*>, whereAllNull: Boolean = false): DataFrame<T> =
+    dropNulls(whereAllNull) { cols.toColumns() }
+
+public fun <T> DataFrame<T>.dropNulls(vararg cols: String, whereAllNull: Boolean = false): DataFrame<T> =
+    dropNulls(whereAllNull) { cols.toColumns() }
+
+public fun <T> DataFrame<T>.dropNulls(vararg cols: Column, whereAllNull: Boolean = false): DataFrame<T> =
+    dropNulls(whereAllNull) { cols.toColumns() }
+
+public fun <T> DataFrame<T>.dropNulls(cols: Iterable<Column>, whereAllNull: Boolean = false): DataFrame<T> =
+    dropNulls(whereAllNull) { cols.toColumnSet() }
+
+
+public fun <T> DataColumn<T?>.dropNulls(): DataColumn<T> =
+    (if (!hasNulls()) this else filter { it != null }) as DataColumn<T>
 
 // endregion
 
@@ -98,16 +130,25 @@ public fun <T> DataFrame<T>.dropNA(whereAllNA: Boolean = false, selector: Column
     else drop { cols.any { this[it].isNA } }
 }
 
-public fun <T> DataFrame<T>.dropNA(vararg cols: KProperty<*>, whereAllNA: Boolean = false): DataFrame<T> = dropNA(whereAllNA) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNA(vararg cols: String, whereAllNA: Boolean = false): DataFrame<T> = dropNA(whereAllNA) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNA(vararg cols: Column, whereAllNA: Boolean = false): DataFrame<T> = dropNA(whereAllNA) { cols.toColumns() }
-public fun <T> DataFrame<T>.dropNA(cols: Iterable<Column>, whereAllNA: Boolean = false): DataFrame<T> = dropNA(whereAllNA) { cols.toColumnSet() }
+public fun <T> DataFrame<T>.dropNA(vararg cols: KProperty<*>, whereAllNA: Boolean = false): DataFrame<T> =
+    dropNA(whereAllNA) { cols.toColumns() }
 
-public fun <T> DataFrame<T>.dropNA(whereAllNA: Boolean = false): DataFrame<T> = dropNA(whereAllNA) { all() }
+public fun <T> DataFrame<T>.dropNA(vararg cols: String, whereAllNA: Boolean = false): DataFrame<T> =
+    dropNA(whereAllNA) { cols.toColumns() }
 
-public fun <T> DataColumn<T?>.dropNA(): DataColumn<T> = when (typeClass) {
-    Double::class, Float::class -> filter { !it.isNA }.cast()
-    else -> (if (!hasNulls()) this else filter { it != null }) as DataColumn<T>
-}
+public fun <T> DataFrame<T>.dropNA(vararg cols: Column, whereAllNA: Boolean = false): DataFrame<T> =
+    dropNA(whereAllNA) { cols.toColumns() }
+
+public fun <T> DataFrame<T>.dropNA(cols: Iterable<Column>, whereAllNA: Boolean = false): DataFrame<T> =
+    dropNA(whereAllNA) { cols.toColumnSet() }
+
+public fun <T> DataFrame<T>.dropNA(whereAllNA: Boolean = false): DataFrame<T> =
+    dropNA(whereAllNA) { all() }
+
+public fun <T> DataColumn<T?>.dropNA(): DataColumn<T> =
+    when (typeClass) {
+        Double::class, Float::class -> filter { !it.isNA }.cast()
+        else -> (if (!hasNulls()) this else filter { it != null }) as DataColumn<T>
+    }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -17,21 +17,27 @@ import kotlin.reflect.KProperty
 
 // region fillNulls
 
-public fun <T, C> DataFrame<T>.fillNulls(cols: ColumnsSelector<T, C>): Update<T, C> = update(cols).where { it == null }
+public fun <T, C> DataFrame<T>.fillNulls(cols: ColumnsSelector<T, C?>): Update<T, C?> =
+    update(cols).where { it == null }
+
 public fun <T> DataFrame<T>.fillNulls(vararg cols: String): Update<T, Any?> = fillNulls { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNulls(vararg cols: KProperty<C>): Update<T, C> = fillNulls { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNulls(vararg cols: ColumnReference<C>): Update<T, C> = fillNulls { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNulls(cols: Iterable<ColumnReference<C>>): Update<T, C> = fillNulls { cols.toColumnSet() }
+public fun <T, C> DataFrame<T>.fillNulls(vararg cols: KProperty<C>): Update<T, C?> = fillNulls { cols.toColumns() }
+public fun <T, C> DataFrame<T>.fillNulls(vararg cols: ColumnReference<C>): Update<T, C?> =
+    fillNulls { cols.toColumns() }
+
+public fun <T, C> DataFrame<T>.fillNulls(cols: Iterable<ColumnReference<C>>): Update<T, C?> =
+    fillNulls { cols.toColumnSet() }
 
 // endregion
 
 internal inline val Any?.isNaN: Boolean get() = (this is Double && isNaN()) || (this is Float && isNaN())
 
-internal inline val Any?.isNA: Boolean get() = when (this) {
-    null -> true
-    is Double -> isNaN()
-    is Float -> isNaN()
-    is AnyRow -> allNA()
+internal inline val Any?.isNA: Boolean
+    get() = when (this) {
+        null -> true
+        is Double -> isNaN()
+        is Float -> isNaN()
+        is AnyRow -> allNA()
     is AnyFrame -> isEmpty()
     else -> false
 }
@@ -50,17 +56,18 @@ public fun <T, C> DataFrame<T>.fillNaNs(cols: ColumnsSelector<T, C>): Update<T, 
 public fun <T> DataFrame<T>.fillNaNs(vararg cols: String): Update<T, Any?> = fillNaNs { cols.toColumns() }
 public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: KProperty<C>): Update<T, C> = fillNaNs { cols.toColumns() }
 public fun <T, C> DataFrame<T>.fillNaNs(vararg cols: ColumnReference<C>): Update<T, C> = fillNaNs { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNaNs(cols: Iterable<ColumnReference<C>>): Update<T, C> = fillNaNs { cols.toColumnSet() }
+public fun <T, C> DataFrame<T>.fillNaNs(cols: Iterable<ColumnReference<C>>): Update<T, C> =
+    fillNaNs { cols.toColumnSet() }
 
 // endregion
 
 // region fillNA
 
-public fun <T, C> DataFrame<T>.fillNA(cols: ColumnsSelector<T, C>): Update<T, C> = update(cols).where { it.isNA }
+public fun <T, C> DataFrame<T>.fillNA(cols: ColumnsSelector<T, C?>): Update<T, C?> = update(cols).where { it.isNA }
 public fun <T> DataFrame<T>.fillNA(vararg cols: String): Update<T, Any?> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(vararg cols: KProperty<C>): Update<T, C> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(vararg cols: ColumnReference<C>): Update<T, C> = fillNA { cols.toColumns() }
-public fun <T, C> DataFrame<T>.fillNA(cols: Iterable<ColumnReference<C>>): Update<T, C> = fillNA { cols.toColumnSet() }
+public fun <T, C> DataFrame<T>.fillNA(vararg cols: KProperty<C>): Update<T, C?> = fillNA { cols.toColumns() }
+public fun <T, C> DataFrame<T>.fillNA(vararg cols: ColumnReference<C>): Update<T, C?> = fillNA { cols.toColumns() }
+public fun <T, C> DataFrame<T>.fillNA(cols: Iterable<ColumnReference<C>>): Update<T, C?> = fillNA { cols.toColumnSet() }
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -115,7 +115,6 @@ public fun <T> DataFrame<T>.dropNulls(vararg cols: Column, whereAllNull: Boolean
 public fun <T> DataFrame<T>.dropNulls(cols: Iterable<Column>, whereAllNull: Boolean = false): DataFrame<T> =
     dropNulls(whereAllNull) { cols.toColumnSet() }
 
-
 public fun <T> DataColumn<T?>.dropNulls(): DataColumn<T> =
     (if (!hasNulls()) this else filter { it != null }) as DataColumn<T>
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.junit.Test
 
 class UpdateTests {
@@ -11,5 +12,33 @@ class UpdateTests {
         val df = DataFrame.Empty
         val col by column<Int>()
         df.update { col }.with { 2 } shouldBe df
+    }
+
+    @DataSchema
+    interface SchemaA {
+        val i: Int?
+    }
+
+    @DataSchema
+    interface SchemaB {
+        val i: Int
+    }
+
+    @Test
+    fun `fillNulls update`() {
+        val df = dataFrameOf("i")(1, null)
+
+        df.fillNulls(SchemaA::i).with { 42 }
+
+        df.fillNulls(SchemaB::i).with { 42 }
+    }
+
+    @Test
+    fun `fillNA update`() {
+        val df = dataFrameOf("i")(1, null)
+
+        df.fillNA(SchemaA::i).with { 42 }
+
+        df.fillNA(SchemaB::i).with { 42 }
     }
 }


### PR DESCRIPTION
fix for https://github.com/Kotlin/dataframe/issues/136

The problem with the example was the following:
```kotlin
@DataSchema
interface SchemaA { val i: Int? }

@DataSchema
interface SchemaB { val i: Int }

val df = dataFrameOf("i")(1, null)

df.fillNulls(SchemaA::i).with { it: Int? -> 42 }

// breaks because `null != Int`
df.fillNulls(SchemaB::i).with { it: Int -> 42 } 
```
This makes sense from a programming standpoint: Essentially a column with null values is matched to a schema with a non-null column. However, since the intention is to fill in those nulls, it might be okay for us to assume that this is fine. I think it's reasonable to say that for any `fillNulls`- and `fillNA` call, the values should be considered nullable in the `with` statement. This PR fixes that.

So now:
```kotlin
df.fillNulls(SchemaA::i).with { it: Int? -> 42 }

df.fillNulls(SchemaB::i).with { it: Int? -> 42 } 
```
