### PR TITLE
Support custom filling of missing columns in `convertTo`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlinx.dataframe.impl.api.withRowCellImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumns
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.io.toDataFrame
+import org.jetbrains.kotlinx.dataframe.path
 import java.math.BigDecimal
 import java.net.URL
 import java.time.LocalTime
@@ -165,10 +166,10 @@ public fun DataColumn<String?>.convertToDouble(locale: Locale? = null): DataColu
         try {
             return mapIndexed { row, value ->
                 currentRow = row
-                value?.let { parser(value.trim()) ?: throw TypeConversionException(value, typeOf<String>(), typeOf<Double>()) }
+                value?.let { parser(value.trim()) ?: throw TypeConversionException(value, typeOf<String>(), typeOf<Double>(), path) }
             }
         } catch (e: TypeConversionException) {
-            throw CellConversionException(e.value, e.from, e.to, this.name(), currentRow, e)
+            throw CellConversionException(e.value, e.from, e.to, path, currentRow, e)
         }
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -16,7 +16,25 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-public enum class ExcessiveColumns { Remove, Keep, Fail }
+/**
+ * Specifies how to handle columns in original dataframe that were not mathced to any column in destination dataframe schema.
+ */
+public enum class ExcessiveColumns {
+    /**
+     * Remove excessive columns from resulting dataframe
+     */
+    Remove,
+
+    /**
+     * Keep excessive columns in resulting dataframe
+     */
+    Keep,
+
+    /**
+     * Throw [ExcessiveColumnsException] if any excessive columns were found in the original dataframe
+     */
+    Fail
+}
 
 /**
  * Holds data context for [fill] operation

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -1,12 +1,15 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.exceptions.ColumnNotFoundException
 import org.jetbrains.kotlinx.dataframe.exceptions.ExcessiveColumnsException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
+import org.jetbrains.kotlinx.dataframe.impl.api.ConvertSchemaDslInternal
 import org.jetbrains.kotlinx.dataframe.impl.api.convertToImpl
 import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
 import kotlin.reflect.KProperty
@@ -15,16 +18,29 @@ import kotlin.reflect.typeOf
 
 public enum class ExcessiveColumns { Remove, Keep, Fail }
 
+/**
+ * Holds data context for [fill] operation
+ */
+public data class ConvertToFill<T, C>(
+    internal val dsl: ConvertSchemaDsl<T>,
+    val columns: ColumnsSelector<T, C>
+)
+
 /** Provides access to [fromType] and [toSchema] in the flexible [ConvertSchemaDsl.convertIf] method. */
 public class ConverterScope(public val fromType: KType, public val toSchema: ColumnSchema)
 
-/** Dsl to define how specific type conversion should occur.
+/**
+ * Dsl to customize column conversion
  *
  * Example:
  * ```kotlin
  * df.convertTo<SomeSchema> {
  *     // defines how to convert Int? -> String
  *     convert<Int?>().with { it?.toString() ?: "No input given" }
+ *     // defines how to convert String -> SomeType
+ *     parser { SomeType(it) }
+ *     // fill missing column `sum` with expression `a+b`
+ *     fill { sum }.with { a + b }
  * }
  * ```
  */
@@ -54,6 +70,17 @@ public interface ConvertSchemaDsl<in T> {
         condition: (fromType: KType, toSchema: ColumnSchema) -> Boolean,
         converter: ConverterScope.(Any?) -> Any?,
     )
+}
+
+/**
+ * Defines how to fill specified columns in destination schema that were not found in original dataframe.
+ * All [fill] operations for missing columns are executed after successful conversion of matched columns, so converted values of matched columns can be safely used in [with] expression.
+ * @param columns target columns in destination dataframe schema to be filled
+ */
+public inline fun <T, reified C> ConvertSchemaDsl<T>.fill(noinline columns: ColumnsSelector<T, C>): ConvertToFill<T, C> = ConvertToFill(this, columns)
+
+public fun <T, C> ConvertToFill<T, C>.with(expr: RowExpression<T, C>) {
+    (dsl as ConvertSchemaDslInternal<T>).fill(columns as ColumnsSelector<*, C>, expr as RowExpression<*, C>)
 }
 
 /**
@@ -95,6 +122,10 @@ public class ConvertType<T>(
  * df.convertTo<SomeSchema> {
  *     // defines how to convert Int? -> String
  *     convert<Int?>().with { it?.toString() ?: "No input given" }
+ *     // defines how to convert String -> SomeType
+ *     parser { SomeType(it) }
+ *     // fill missing column `sum` with expression `a + b`
+ *     fill { sum }.with { a + b }
  * }
  * ```
  *
@@ -109,8 +140,8 @@ public class ConvertType<T>(
  */
 public inline fun <reified T : Any> AnyFrame.convertTo(
     excessiveColumnsBehavior: ExcessiveColumns = ExcessiveColumns.Keep,
-    noinline body: ConvertSchemaDsl<T>.() -> Unit = {},
-): DataFrame<T> = convertTo(typeOf<T>(), excessiveColumnsBehavior, body).cast()
+    noinline body: ConvertSchemaDsl<T>.() -> Unit = {}
+): DataFrame<T> = convertToImpl(typeOf<T>(), true, excessiveColumnsBehavior, body).cast()
 
 /**
  * Converts values in [DataFrame] to match given column schema [schemaType].
@@ -126,6 +157,10 @@ public inline fun <reified T : Any> AnyFrame.convertTo(
  * df.convertTo<SomeSchema> {
  *     // defines how to convert Int? -> String
  *     convert<Int?>().with { it?.toString() ?: "No input given" }
+ *     // defines how to convert String -> SomeType
+ *     parser { SomeType(it) }
+ *     // fill missing column `sum` with expression `a+b`
+ *     fill { sum }.with { a + b }
  * }
  * ```
  *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ColumnPath.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ColumnPath.kt
@@ -51,5 +51,7 @@ public data class ColumnPath(val path: List<String>) : List<String> by path, Col
 
     override fun toString(): String = path.toString()
 
+    public fun joinToString(separator: String = "/"): String = path.joinToString(separator)
+
     override fun <C> get(column: ColumnReference<C>): ColumnAccessor<C> = ColumnAccessorImpl(this + column.path())
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/CellConversionException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/CellConversionException.kt
@@ -1,15 +1,16 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
+import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import kotlin.reflect.KType
 
 public class CellConversionException(
     value: Any?,
     from: KType,
     to: KType,
-    public val column: String,
+    column: ColumnPath,
     public val row: Int?,
     override val cause: Throwable?
-) : TypeConversionException(value, from, to) {
+) : TypeConversionException(value, from, to, column) {
     override val message: String
         get() = "${super.message} in column $column, row $row"
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConversionException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConversionException.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
-import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.path
+import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import kotlin.reflect.*
 import kotlin.reflect.KType
 
@@ -9,9 +8,9 @@ public open class TypeConversionException(
     public val value: Any?,
     public val from: KType,
     public val to: KType,
-    public val column: AnyCol?
+    public val column: ColumnPath?
 ) : RuntimeException() {
 
     override val message: String
-        get() = "Failed to convert '$value' from $from to $to" + (column?.let { " in column ${it.path.joinToString()}" } ?: "")
+        get() = "Failed to convert '$value' from $from to $to" + (column?.let { " in column ${it.joinToString()}" } ?: "")
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConversionException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConversionException.kt
@@ -1,9 +1,17 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
+import org.jetbrains.kotlinx.dataframe.AnyCol
+import org.jetbrains.kotlinx.dataframe.path
+import kotlin.reflect.*
 import kotlin.reflect.KType
 
-public open class TypeConversionException(public val value: Any?, public val from: KType, public val to: KType) : RuntimeException() {
+public open class TypeConversionException(
+    public val value: Any?,
+    public val from: KType,
+    public val to: KType,
+    public val column: AnyCol?
+) : RuntimeException() {
 
     override val message: String
-        get() = "Failed to convert '$value' from $from to $to"
+        get() = "Failed to convert '$value' from $from to $to" + (column?.let { " in column ${it.path.joinToString()}" } ?: "")
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConverterNotFoundException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConverterNotFoundException.kt
@@ -1,12 +1,15 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
-import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.path
+import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import kotlin.reflect.*
 import kotlin.reflect.KType
 
-public class TypeConverterNotFoundException(public val from: KType, public val to: KType, public val column: AnyCol?) : IllegalArgumentException() {
+public class TypeConverterNotFoundException(
+    public val from: KType,
+    public val to: KType,
+    public val column: ColumnPath?
+) : IllegalArgumentException() {
 
     override val message: String
-        get() = "Type converter from $from to $to is not found" + (column?.let { " for column ${it.path.joinToString()}" } ?: "")
+        get() = "Type converter from $from to $to is not found" + (column?.let { " for column ${it.joinToString()}" } ?: "")
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConverterNotFoundException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/TypeConverterNotFoundException.kt
@@ -1,9 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
+import org.jetbrains.kotlinx.dataframe.AnyCol
+import org.jetbrains.kotlinx.dataframe.path
+import kotlin.reflect.*
 import kotlin.reflect.KType
 
-public class TypeConverterNotFoundException(public val from: KType, public val to: KType) : IllegalArgumentException() {
+public class TypeConverterNotFoundException(public val from: KType, public val to: KType, public val column: AnyCol?) : IllegalArgumentException() {
 
     override val message: String
-        get() = "Type converter from $from to $to is not found"
+        get() = "Type converter from $from to $to is not found" + (column?.let { " for column ${it.path.joinToString()}" } ?: "")
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.impl.columns.DataColumnInternal
 import org.jetbrains.kotlinx.dataframe.impl.columns.newColumn
 import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
+import org.jetbrains.kotlinx.dataframe.path
 import org.jetbrains.kotlinx.dataframe.type
 import java.math.BigDecimal
 import java.net.URL
@@ -78,7 +79,7 @@ internal fun AnyCol.convertToTypeImpl(to: KType): AnyCol {
             nullsFound = true
             null
         }
-        else -> throw TypeConversionException(null, from, to, this)
+        else -> throw TypeConversionException(null, from, to, path)
     }
 
     fun applyConverter(converter: TypeConverter): AnyCol {
@@ -90,7 +91,7 @@ internal fun AnyCol.convertToTypeImpl(to: KType): AnyCol {
             }
             return DataColumn.createValueColumn(name, values, to.withNullability(nullsFound))
         } catch (e: TypeConversionException) {
-            throw CellConversionException(e.value, e.from, e.to, this.name(), currentRow, e)
+            throw CellConversionException(e.value, e.from, e.to, path, currentRow, e)
         }
     }
 
@@ -106,16 +107,16 @@ internal fun AnyCol.convertToTypeImpl(to: KType): AnyCol {
                             val clazz = it.javaClass.kotlin
                             val type = clazz.createStarProjectedType(false)
                             val converter = getConverter(type, to, ParserOptions(locale = Locale.getDefault()))
-                                ?: throw TypeConverterNotFoundException(from, to, this)
+                                ?: throw TypeConverterNotFoundException(from, to, path)
                             converter(it)
                         }.checkNulls()
                     }
                     DataColumn.createValueColumn(name, values, to.withNullability(nullsFound))
                 }
-                else -> throw TypeConverterNotFoundException(from, to, this)
+                else -> throw TypeConverterNotFoundException(from, to, path)
             }
         } catch (e: TypeConversionException) {
-            throw CellConversionException(e.value, e.from, e.to, this.name(), currentRow, e)
+            throw CellConversionException(e.value, e.from, e.to, path, currentRow, e)
         }
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
@@ -148,7 +148,7 @@ internal fun AnyFrame.convertToImpl(
                                         it
                                     }
 
-                                if (!nullsAllowed && result == null) throw TypeConversionException(it, from, to, originalColumn)
+                                if (!nullsAllowed && result == null) throw TypeConversionException(it, from, to, originalColumn.path())
 
                                 result
                             }
@@ -237,9 +237,10 @@ internal fun AnyFrame.convertToImpl(
                     targetColumn.kind == ColumnKind.Frame // frame column can be filled with empty dataframes
 
             if (name !in visited) {
-                if (isNullable) {
-                    newColumns += targetColumn.createEmptyColumn(name, size)
-                } else missingPaths.add(path + name)
+                newColumns += targetColumn.createEmptyColumn(name, size)
+                if (!isNullable) {
+                    missingPaths.add(path + name)
+                }
             }
         }
         return newColumns.toDataFrame()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -56,7 +56,7 @@ internal open class DelegatedStringParser<T>(override val type: KType, val handl
         return {
             val str = it as String
             if (str in nulls) null
-            else handle(str) ?: throw TypeConversionException(it, typeOf<String>(), type)
+            else handle(str) ?: throw TypeConversionException(it, typeOf<String>(), type, null)
         }
     }
 
@@ -71,7 +71,7 @@ internal class StringParserWithFormat<T>(override val type: KType, val getParser
         return {
             val str = it as String
             if (str in nulls) null
-            else handler(str) ?: throw TypeConversionException(it, typeOf<String>(), type)
+            else handler(str) ?: throw TypeConversionException(it, typeOf<String>(), type, null)
         }
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
@@ -137,9 +137,6 @@ internal fun DataFrameSchema.createEmptyDataFrame(numberOfRows: Int): AnyFrame =
         }.toDataFrame()
     }
 
-internal fun createEmptyDataFrame(numberOfRows: Int): AnyFrame =
-    DataFrame.empty(numberOfRows)
-
 @PublishedApi
 internal fun createEmptyDataFrameOf(clazz: KClass<*>): AnyFrame =
     MarkersExtractor.get(clazz).schema.createEmptyDataFrame()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -257,4 +257,29 @@ class ConvertToTests {
         val converted = df.convertTo<MySchema>().alsoDebug()
         converted shouldBe df
     }
+
+    @Test
+    fun `convert with missing nullable column`() {
+        @DataSchema
+        data class Result(val a: Int, val b: Int?)
+
+        val df = dataFrameOf("a")(1, 2)
+        val converted = df.convertTo<Result>()
+        converted shouldBe listOf(Result(1, null), Result(2, null)).toDataFrame()
+    }
+
+    @Test
+    fun `convert with custom fill of missing columns`() {
+        val locations = listOf(
+            Location("Home", Gps(1.0, 1.0)),
+            Location("Away", null),
+        ).toDataFrame().cast<Location>()
+
+        val converted = locations.remove { gps.longitude }.cast<Unit>()
+            .convertTo<Location> {
+                fill { gps.longitude }.with { gps.latitude }
+            }
+
+        converted shouldBe locations.update { gps.longitude }.with { gps.latitude }
+    }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -923,19 +923,28 @@ class Modify : TestBase() {
         // SampleEnd
     }
 
-    @Test
-    fun customConverters() {
+    class MyType(val value: Int)
+
+    @DataSchema
+    class MySchema(val a: MyType, val b: MyType, val c: Int)
+
+    fun customConvertersData() {
         // SampleStart
         class MyType(val value: Int)
 
         @DataSchema
         class MySchema(val a: MyType, val b: MyType, val c: Int)
 
+        // SampleEnd
+    }
+    @Test
+    fun customConverters() {
+        // SampleStart
         val df = dataFrameOf("a", "b")(1, "2")
         df.convertTo<MySchema> {
-            convert<Int>().with { MyType(it) } // used to convert `a` from Int to MyType
-            parser { MyType(it.toInt()) } // used to convert `b` from String to MyType
-            fill { c }.with { a.value + b.value } // used to compute missing column `c`
+            convert<Int>().with { MyType(it) } // converts `a` from Int to MyType
+            parser { MyType(it.toInt()) } // converts `b` from String to MyType
+            fill { c }.with { a.value + b.value } // computes missing column `c`
         }
         // SampleEnd
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -926,14 +926,16 @@ class Modify : TestBase() {
     @Test
     fun customConverters() {
         // SampleStart
-        class IntClass(val value: Int)
+        class MyType(val value: Int)
 
         @DataSchema
-        class IntSchema(val ints: IntClass)
+        class MySchema(val a: MyType, val b: MyType, val c: Int)
 
-        val df = dataFrameOf("ints")(1, 2, 3)
-        df.convertTo<IntSchema> {
-            convert<Int>().with { IntClass(it) }
+        val df = dataFrameOf("a", "b")(1, "2")
+        df.convertTo<MySchema> {
+            convert<Int>().with { MyType(it) } // used to convert `a` from Int to MyType
+            parser { MyType(it.toInt()) } // used to convert `b` from String to MyType
+            fill { c }.with { a.value + b.value } // used to compute missing column `c`
         }
         // SampleEnd
     }

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
@@ -148,12 +148,12 @@ internal class ArrowWriterImpl(
         } catch (e: CellConversionException) {
             if (strictType) {
                 // If conversion failed but strictType is enabled, throw the exception
-                val mismatch = ConvertingMismatch.TypeConversionFail.ConversionFailError(e.column, e.row, e)
+                val mismatch = ConvertingMismatch.TypeConversionFail.ConversionFailError(e.column?.name() ?: "", e.row, e)
                 mismatchSubscriber(mismatch)
                 throw ConvertingException(mismatch)
             } else {
                 // If strictType is not enabled, use original data with its type. Target nullable is saved at this step.
-                mismatchSubscriber(ConvertingMismatch.TypeConversionFail.ConversionFailIgnored(e.column, e.row, e))
+                mismatchSubscriber(ConvertingMismatch.TypeConversionFail.ConversionFailIgnored(e.column?.name() ?: "", e.row, e))
                 column to column!!.toArrowField(mismatchSubscriber)
             }
         } catch (e: TypeConverterNotFoundException) {

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlinx.dataframe.api.convertToBoolean
 import org.jetbrains.kotlinx.dataframe.api.copy
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.map
+import org.jetbrains.kotlinx.dataframe.api.pathOf
 import org.jetbrains.kotlinx.dataframe.api.remove
 import org.jetbrains.kotlinx.dataframe.api.toColumn
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
@@ -206,7 +207,7 @@ internal class ArrowKtTest {
             )
         ) { warning -> warnings.add(warning) }.use { it.saveArrowFeatherToByteArray() }
         warnings.map { it.toString() }.shouldContain(
-            ConvertingMismatch.TypeConversionNotFound.ConversionNotFoundIgnored("settled", TypeConverterNotFoundException(typeOf<Boolean>(), typeOf<kotlinx.datetime.LocalDateTime?>())).toString()
+            ConvertingMismatch.TypeConversionNotFound.ConversionNotFoundIgnored("settled", TypeConverterNotFoundException(typeOf<Boolean>(), typeOf<kotlinx.datetime.LocalDateTime?>(), pathOf("settled"))).toString()
         )
         DataFrame.readArrowFeather(testLoyalType)["settled"].type() shouldBe typeOf<Boolean>()
     }

--- a/docs/StardustDocs/topics/convertTo.md
+++ b/docs/StardustDocs/topics/convertTo.md
@@ -1,26 +1,29 @@
 [//]: # (title: convertTo)
 <!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Modify-->
 
-[Converts](convert.md) columns in `DataFrame` to match given schema.
+[Converts](convert.md) columns in `DataFrame` to match given schema `Schema`
 
 ```kotlin
-convertTo<T>()
+convertTo<Schema>(excessiveColumns = ExcessiveColumns.Keep)
 ```
 
-Any additional columns will be dropped.
-
-You can provide custom converters and parsers:
+Customization DSL:
+* `convert` - how specific column types should be converted
+* `parser` - how to parse strings into custom types
+* `fill` - how to fill missing columns
 <!---FUN customConverters-->
 
 ```kotlin
-class IntClass(val value: Int)
+class MyType(val value: Int)
 
 @DataSchema
-class IntSchema(val ints: IntClass)
+class MySchema(val a: MyType, val b: MyType, val c: Int)
 
-val df = dataFrameOf("ints")(1, 2, 3)
-df.convertTo<IntSchema> {
-    convert<Int>().with { IntClass(it) }
+val df = dataFrameOf("a", "b")(1, "2")
+df.convertTo<MySchema> {
+    convert<Int>().with { MyType(it) } // used to convert `a` from Int to MyType
+    parser { MyType(it.toInt()) } // used to convert `b` from String to MyType
+    fill { c }.with { a.value + b.value } // used to compute missing column `c`
 }
 ```
 

--- a/docs/StardustDocs/topics/convertTo.md
+++ b/docs/StardustDocs/topics/convertTo.md
@@ -11,19 +11,25 @@ Customization DSL:
 * `convert` - how specific column types should be converted
 * `parser` - how to parse strings into custom types
 * `fill` - how to fill missing columns
-<!---FUN customConverters-->
+
+<!---FUN customConvertersData-->
 
 ```kotlin
 class MyType(val value: Int)
 
 @DataSchema
 class MySchema(val a: MyType, val b: MyType, val c: Int)
+```
 
+<!---END-->
+<!---FUN customConverters-->
+
+```kotlin
 val df = dataFrameOf("a", "b")(1, "2")
 df.convertTo<MySchema> {
-    convert<Int>().with { MyType(it) } // used to convert `a` from Int to MyType
-    parser { MyType(it.toInt()) } // used to convert `b` from String to MyType
-    fill { c }.with { a.value + b.value } // used to compute missing column `c`
+    convert<Int>().with { MyType(it) } // converts `a` from Int to MyType
+    parser { MyType(it.toInt()) } // converts `b` from String to MyType
+    fill { c }.with { a.value + b.value } // computes missing column `c`
 }
 ```
 


### PR DESCRIPTION
Support `fill` operation in `convertTo` DSL to fill missing columns with custom row expressions.
Print column path in `TypeConversionException`.
Update docs for `convertTo`.