### PR TITLE
Min kernel version fix

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -60,8 +60,10 @@ private const val MIN_KERNEL_VERSION = "0.11.0.198"
 
 internal val newDataSchemas = mutableListOf<KClass<*>>()
 
-internal class Integration(private val notebook: Notebook, private val options: MutableMap<String, String?>) :
-    JupyterIntegration() {
+internal class Integration(
+    private val notebook: Notebook,
+    private val options: MutableMap<String, String?>,
+) : JupyterIntegration() {
 
     override fun Builder.onLoaded() {
         setMinimalKernelVersion(MIN_KERNEL_VERSION)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -70,8 +70,7 @@ internal class Integration(
             setMinimalKernelVersion(MIN_KERNEL_VERSION)
         } catch (_: NoSuchMethodError) { // will be thrown on version < 0.11.0.198
             throw IllegalStateException(
-                "Your Kotlin Jupyter kernel version appears to be out of date (version ${notebook.kernelVersion}). " +
-                    "Please update to version $MIN_KERNEL_VERSION or higher to be able to use DataFrame."
+                getKernelUpdateMessage(notebook.kernelVersion, MIN_KERNEL_VERSION, notebook.jupyterClientType)
             )
         }
         val codeGen = ReplCodeGenerator.create()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -55,12 +55,16 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.isSubtypeOf
 
+/** Users will get an error if their Kotlin Jupyter kernel is older than this version. */
+private const val MIN_KERNEL_VERSION = "0.11.0.198"
+
 internal val newDataSchemas = mutableListOf<KClass<*>>()
 
 internal class Integration(private val notebook: Notebook, private val options: MutableMap<String, String?>) :
     JupyterIntegration() {
 
     override fun Builder.onLoaded() {
+        setMinimalKernelVersion(MIN_KERNEL_VERSION)
         val codeGen = ReplCodeGenerator.create()
         val config = JupyterConfiguration()
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -66,7 +66,14 @@ internal class Integration(
 ) : JupyterIntegration() {
 
     override fun Builder.onLoaded() {
-        setMinimalKernelVersion(MIN_KERNEL_VERSION)
+        try {
+            setMinimalKernelVersion(MIN_KERNEL_VERSION)
+        } catch (_: NoSuchMethodError) { // will be thrown on version < 0.11.0.198
+            throw IllegalStateException(
+                "Your Kotlin Jupyter kernel version appears to be out of date (version ${notebook.kernelVersion}). " +
+                    "Please update to version $MIN_KERNEL_VERSION or higher to be able to use DataFrame."
+            )
+        }
         val codeGen = ReplCodeGenerator.create()
         val config = JupyterConfiguration()
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/kernelUpdateMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/kernelUpdateMessages.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.kotlinx.dataframe.jupyter
+
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.DATALORE
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.JUPYTER_LAB
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.JUPYTER_NOTEBOOK
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.KERNEL_TESTS
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.KOTLIN_NOTEBOOK
+import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.UNKNOWN
+import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion
+
+private const val UPDATING_DATALORE_URL = "https://github.com/Kotlin/kotlin-jupyter/tree/master#datalore"
+private const val UPDATING = "https://github.com/Kotlin/kotlin-jupyter/tree/master#updating"
+
+internal fun getKernelUpdateMessage(
+    kernelVersion: KotlinKernelVersion,
+    minKernelVersion: String,
+    clientType: JupyterClientType,
+): String = buildString {
+    append("Your Kotlin Jupyter kernel version appears to be out of date (version $kernelVersion). ")
+    appendLine("Please update it to version $minKernelVersion or newer to be able to use DataFrame.")
+    append("Follow the instructions at: ")
+
+    when (clientType) {
+        DATALORE ->
+            appendLine(UPDATING_DATALORE_URL)
+
+        KERNEL_TESTS, JUPYTER_NOTEBOOK, JUPYTER_LAB, KOTLIN_NOTEBOOK, UNKNOWN ->
+            appendLine(UPDATING)
+    }
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/kernelUpdateMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/kernelUpdateMessages.kt
@@ -2,14 +2,11 @@ package org.jetbrains.kotlinx.dataframe.jupyter
 
 import org.jetbrains.kotlinx.jupyter.api.JupyterClientType
 import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.DATALORE
-import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.JUPYTER_LAB
-import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.JUPYTER_NOTEBOOK
-import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.KERNEL_TESTS
 import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.KOTLIN_NOTEBOOK
-import org.jetbrains.kotlinx.jupyter.api.JupyterClientType.UNKNOWN
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion
 
 private const val UPDATING_DATALORE_URL = "https://github.com/Kotlin/kotlin-jupyter/tree/master#datalore"
+private const val UPDATING_KOTLIN_NOTEBOOK_URL = "https://github.com/Kotlin/kotlin-jupyter#kotlin-notebook"
 private const val UPDATING = "https://github.com/Kotlin/kotlin-jupyter/tree/master#updating"
 
 internal fun getKernelUpdateMessage(
@@ -22,10 +19,8 @@ internal fun getKernelUpdateMessage(
     append("Follow the instructions at: ")
 
     when (clientType) {
-        DATALORE ->
-            appendLine(UPDATING_DATALORE_URL)
-
-        KERNEL_TESTS, JUPYTER_NOTEBOOK, JUPYTER_LAB, KOTLIN_NOTEBOOK, UNKNOWN ->
-            appendLine(UPDATING)
+        DATALORE -> appendLine(UPDATING_DATALORE_URL)
+        KOTLIN_NOTEBOOK -> appendLine(UPDATING_KOTLIN_NOTEBOOK_URL)
+        else -> appendLine(UPDATING)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-ksp = "1.7.20-1.0.8"
-kotlinJupyter = "0.11.0-187"
+ksp = "1.8.0-RC-1.0.8"
+kotlinJupyter = "0.11.0-198"
 ktlint = "3.4.5"
-kotlin = "1.7.20"
-dokka = "1.6.20"
+kotlin = "1.8.0-RC"
+dokka = "1.7.20"
 libsPublisher = "0.0.60-dev-30"
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,
 # dogfood Gradle / KSP plugins in tests and idea-examples modules

--- a/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/integrationTest/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginIntegrationTest.kt
@@ -436,7 +436,7 @@ class SchemaGeneratorPluginIntegrationTest : AbstractDataFramePluginIntegrationT
                 
                 kotlin {
                     sourceSets {
-                        js {
+                        js(IR) {
                             browser()
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/208 by setting a minimal kernel version for the Kotlin Jupyter kernel in the library.
Users will see an error provided by the Kotlin Jupyter library if their kernel is too old