### PR TITLE
Don't print header record in csv if requested

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -332,7 +332,9 @@ public fun AnyFrame.writeCSV(
     format: CSVFormat = CSVFormat.DEFAULT,
 ) {
     format.print(writer).use { printer ->
-        printer.printRecord(columnNames())
+        if (format.getSkipHeaderRecord() == false) {
+            printer.printRecord(columnNames())
+        }
         forEach {
             val values = it.values.map {
                 when (it) {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
@@ -214,6 +214,22 @@ class CsvTests {
         df.columnsCount() shouldBe 3
         df.rowsCount() shouldBe 2
     }
+    
+    @Test
+    fun `write csv whitout header produce correct file`() {
+        val df = dataFrameOf("a", "b", "c")(
+            1, 2, 3,
+            1, 3, 2
+        )
+        df.writeCSV(
+            "src/test/resources/without_header.csv",
+            CSVFormat.DEFAULT.withSkipHeaderRecord()
+        )
+        val producedFile = File("src/test/resources/without_header.csv")
+        producedFile.exists() shouldBe true
+        producedFile.readText() shouldBe "a,b,c\r\n1,2,3\r\n1,3,2\r\n"
+        producedFile.delete()
+    }
 
     companion object {
         private val simpleCsv = testCsv("testCSV")


### PR DESCRIPTION
If a CSVFormat is provided in the writeCSV method with withSystemRecordSeparator called on it, the csv file produced should not contain a header record.