### PR TITLE
Describe how to control content cell limit from Jupyter Notebook

### DIFF
--- a/docs/StardustDocs/topics/rendering.md
+++ b/docs/StardustDocs/topics/rendering.md
@@ -1,3 +1,16 @@
 [//]: # (title: Rendering)
 
 // TODO
+
+## Jupyter Notebooks
+
+Rendering in Jupyter Notebooks can be configured using `dataFrameConfig.display` value.
+
+### Content limit length
+
+Content in each cell gets truncated to 40 characters by default. 
+This can be changed by setting `cellContentLimit` to a different value on the display configuration.
+
+```kotlin
+dataFrameConfig.display.cellContentLimit = 100
+```


### PR DESCRIPTION
This is a docs change that shortly describes how to control content cell limit from Jupyter Notebook.

Without this information is highly cumbersome to work with dataframes that have long text values.