### PR TITLE
Add nestedRowsLimit parameter to DisplayConfiguration

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -120,8 +120,8 @@ internal fun AnyFrame.toHtmlData(
     val scripts = mutableListOf<String>()
     val queue = LinkedList<Pair<AnyFrame, Int>>()
 
-    fun AnyFrame.columnToJs(col: AnyCol, rowsLimit: Int): ColumnDataForJs {
-        val values = if (rowsLimit == Int.MAX_VALUE) rows() else rows().take(rowsLimit)
+    fun AnyFrame.columnToJs(col: AnyCol, rowsLimit: Int?): ColumnDataForJs {
+        val values = if (rowsLimit != null) rows().take(rowsLimit) else rows()
         val scale = if (col.isNumber()) col.asNumbers().scale() else 1
         val format = if (scale > 0) {
             RendererDecimalFormat.fromPrecision(scale)
@@ -189,7 +189,7 @@ public fun <T> DataFrame<T>.toHTML(
     cellRenderer: CellRenderer = org.jetbrains.kotlinx.dataframe.jupyter.DefaultCellRenderer,
     getFooter: (DataFrame<T>) -> String = { "DataFrame [${it.size}]" },
 ): HtmlData {
-    val limit = configuration.rowsLimit
+    val limit = configuration.rowsLimit ?: Int.MAX_VALUE
 
     val footer = getFooter(this)
     val bodyFooter = buildString {
@@ -210,8 +210,8 @@ public fun <T> DataFrame<T>.toHTML(
 }
 
 public data class DisplayConfiguration(
-    var rowsLimit: Int = 20,
-    var nestedRowsLimit: Int = 5,
+    var rowsLimit: Int? = 20,
+    var nestedRowsLimit: Int? = 5,
     var cellContentLimit: Int = 40,
     var cellFormatter: RowColFormatter<*, *>? = null,
     var decimalFormat: RendererDecimalFormat = RendererDecimalFormat.DEFAULT,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -121,7 +121,7 @@ internal fun AnyFrame.toHtmlData(
     val queue = LinkedList<Pair<AnyFrame, Int>>()
 
     fun AnyFrame.columnToJs(col: AnyCol, rowsLimit: Int): ColumnDataForJs {
-        val values = rows().take(rowsLimit)
+        val values = if (rowsLimit == Int.MAX_VALUE) rows() else rows().take(rowsLimit)
         val scale = if (col.isNumber()) col.asNumbers().scale() else 1
         val format = if (scale > 0) {
             RendererDecimalFormat.fromPrecision(scale)
@@ -158,7 +158,7 @@ internal fun AnyFrame.toHtmlData(
     queue.add(this to rootId)
     while (!queue.isEmpty()) {
         val (nextDf, nextId) = queue.pop()
-        val rowsLimit = if (nextId == rootId) configuration.rowsLimit else 5
+        val rowsLimit = if (nextId == rootId) configuration.rowsLimit else configuration.nestedRowsLimit
         val preparedColumns = nextDf.columns().map { nextDf.columnToJs(it, rowsLimit) }
         val js = tableJs(preparedColumns, nextId, rootId, nextDf.nrow)
         scripts.add(js)
@@ -211,6 +211,7 @@ public fun <T> DataFrame<T>.toHTML(
 
 public data class DisplayConfiguration(
     var rowsLimit: Int = 20,
+    var nestedRowsLimit: Int = 5,
     var cellContentLimit: Int = 40,
     var cellFormatter: RowColFormatter<*, *>? = null,
     var decimalFormat: RendererDecimalFormat = RendererDecimalFormat.DEFAULT,


### PR DESCRIPTION
By default `DataFrame<T>.toHTML()` renders only first 20 rows of the dataset. We can override it by supplying a `DisplayConfiguration` object with desired `rowsLimit`.

However if dataset contains `FrameColumn` those nested datasets are rendered with hard-coded 5 rows limit and there is no way of changing it.

This PR adds `nestedRowsLimit` parameter to DisplayConfiguration used to limit rendered rows number of nested datasets in FrameColumn.
Also it allows to use `Int.MAX_VALUE` as a sentinel value to turn the limit off in order to render complete dataset.