### PR TITLE
Remove unused useDarkColorScheme parameter from DisplayConfiguration

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -173,7 +173,6 @@ internal fun HtmlData.print() = println(this)
 internal fun initHtml(
     includeJs: Boolean = true,
     includeCss: Boolean = true,
-    useDarkColorScheme: Boolean = false,
 ): HtmlData =
     HtmlData(
         style = if (includeCss) getResources("/table.css") else "",
@@ -217,7 +216,6 @@ public data class DisplayConfiguration(
     var decimalFormat: RendererDecimalFormat = RendererDecimalFormat.DEFAULT,
     var isolatedOutputs: Boolean = flagFromEnv("LETS_PLOT_HTML_ISOLATED_FRAME"),
     internal val localTesting: Boolean = flagFromEnv("KOTLIN_DATAFRAME_LOCAL_TESTING"),
-    var useDarkColorScheme: Boolean = false,
 ) {
     public companion object {
         public val DEFAULT: DisplayConfiguration = DisplayConfiguration()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -47,7 +47,6 @@ import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 import org.jetbrains.kotlinx.jupyter.api.Notebook
 import org.jetbrains.kotlinx.jupyter.api.VariableName
 import org.jetbrains.kotlinx.jupyter.api.declare
-import org.jetbrains.kotlinx.jupyter.api.libraries.ColorScheme
 import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 import org.jetbrains.kotlinx.jupyter.api.libraries.resources
 import org.jetbrains.kotlinx.jupyter.api.renderHtmlAsIFrameIfNeeded
@@ -250,10 +249,6 @@ internal class Integration(
             // TODO: add more conditions to include all generated properties and other internal stuff
             //  that should not be shown to user in Jupyter variables view
             internalTypes.any { property.returnType.isSubtypeOf(it) }
-        }
-
-        onColorSchemeChange {
-            config.display.useDarkColorScheme = (it == ColorScheme.DARK)
         }
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
@@ -25,7 +25,6 @@ internal inline fun <reified T : Any> JupyterHtmlRenderer.render(
         extraHtml = initHtml(
             includeJs = reifiedDisplayConfiguration.isolatedOutputs,
             includeCss = true,
-            useDarkColorScheme = reifiedDisplayConfiguration.useDarkColorScheme
         ),
         contextRenderer
     ) { footer }

--- a/core/src/main/resources/table.css
+++ b/core/src/main/resources/table.css
@@ -14,7 +14,7 @@
     --link-hover: #1a466c;
 }
 
-:root[theme="dark"], :root [data-jp-theme-light="false"], .dataframe_dark{
+:root[theme="dark"], :root [data-jp-theme-light="false"] {
     --background: #303030;
     --background-odd: #3c3c3c;
     --background-hover: #464646;


### PR DESCRIPTION
`useDarkColorScheme` parameter was added to `DisplayConfiguration` in cffe4041ebe680195b097811c2a231ca967362f2
but the code using it was removed in 3db46ccccaa1291c0627307d64133317f545e6ae

This PR is cleaning up leftover parameter which is no longer used and could only confuse future readers