### PR TITLE
Documentation improvements

### DIFF
--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -821,13 +821,53 @@ class Modify : TestBase() {
         // SampleEnd
     }
 
+    private class CityInfo(val city: String?, val population: Int, val location: String)
+    private fun queryCityInfo(city: String?): CityInfo { return CityInfo(city, city?.length ?: 0, "35.5 32.2") }
+
     @Test
-    fun addCalculated() {
+    fun addCalculatedApi() {
+        // SampleStart
         class CityInfo(val city: String?, val population: Int, val location: String)
-        fun queryCityInfo(city: String?): CityInfo { return CityInfo(city, city?.length ?: 0, "35.5 32.2") }
+        fun queryCityInfo(city: String?): CityInfo {
+            return CityInfo(city, city?.length ?: 0, "35.5 32.2")
+        }
+        // SampleEnd
+    }
+
+    @Test
+    fun addCalculated_properties() {
         // SampleStart
         val personWithCityInfo = df.add {
             val cityInfo = city.map { queryCityInfo(it) }
+            "cityInfo" {
+                cityInfo.map { it.location } into CityInfo::location
+                cityInfo.map { it.population } into "population"
+            }
+        }
+        // SampleEnd
+        personWithCityInfo["cityInfo"]["population"] shouldBe df.city.map { it?.length ?: 0 }.named("population")
+    }
+
+    @Test
+    fun addCalculated_accessors() {
+        // SampleStart
+        val city by column<String?>()
+        val personWithCityInfo = df.add {
+            val cityInfo = city().map { queryCityInfo(it) }
+            "cityInfo" {
+                cityInfo.map { it.location } into CityInfo::location
+                cityInfo.map { it.population } into "population"
+            }
+        }
+        // SampleEnd
+        personWithCityInfo["cityInfo"]["population"] shouldBe df.city.map { it?.length ?: 0 }.named("population")
+    }
+
+    @Test
+    fun addCalculated_strings() {
+        // SampleStart
+        val personWithCityInfo = df.add {
+            val cityInfo = "city"<String?>().map { queryCityInfo(it) }
             "cityInfo" {
                 cityInfo.map { it.location } into CityInfo::location
                 cityInfo.map { it.population } into "population"

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -822,6 +822,22 @@ class Modify : TestBase() {
     }
 
     @Test
+    fun addCalculated() {
+        class CityInfo(val city: String?, val population: Int, val location: String)
+        fun queryCityInfo(city: String?): CityInfo { return CityInfo(city, city?.length ?: 0, "35.5 32.2") }
+        // SampleStart
+        val personWithCityInfo = df.add {
+            val cityInfo = city.map { queryCityInfo(it) }
+            "cityInfo" {
+                cityInfo.map { it.location } into CityInfo::location
+                cityInfo.map { it.population } into "population"
+            }
+        }
+        // SampleEnd
+        personWithCityInfo["cityInfo"]["population"] shouldBe df.city.map { it?.length ?: 0 }.named("population")
+    }
+
+    @Test
     fun addMany_properties() {
         // SampleStart
         df.add {

--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -25,7 +25,8 @@
         <toc-element id="DataColumn.md"/>
         <toc-element id="DataRow.md"/>
     </toc-element>
-    <toc-element id="operations.md">
+    <toc-element id="operations.md"/>
+    <toc-element toc-title="Operations">
         <toc-element id="create.md"  show-structure-depth="3">
             <toc-element id="createColumn.md" toc-title="DataColumn"/>
             <toc-element id="createDataFrame.md" toc-title="DataFrame"/>

--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -172,4 +172,5 @@
         </toc-element>
     </toc-element>
     <toc-element id="gradleReference.md"/>
+    <toc-element href="https://github.com/Kotlin/dataframe/tree/master/examples" toc-title="Examples"/>
 </product-profile>

--- a/docs/StardustDocs/project.ihp
+++ b/docs/StardustDocs/project.ihp
@@ -7,4 +7,7 @@
     <images dir="images" version="0.9" web-path="images/" />
     <vars src="v.list"/>
     <product src="d.tree" version="0.9" id="dataframe"/>
+    <settings>
+        <default-property element-name="toc-element" property-name="show-structure-depth" value="2"/>
+    </settings>
 </ihp>

--- a/docs/StardustDocs/topics/add.md
+++ b/docs/StardustDocs/topics/add.md
@@ -64,7 +64,14 @@ add {
     ...
 }
 
-columnMapping = column into columnName | columnName from column | columnName from { rowExpression }
+columnMapping = column into columnName 
+    | columnName from column 
+    | columnName from { rowExpression }
+    | columnGroupName { 
+        columnMapping
+        columnMapping
+        ...
+    }
 ```
 
 <!---FUN addMany-->
@@ -142,6 +149,22 @@ df + score
 
 ```kotlin
 df.add(df1, df2)
+```
+
+<!---END-->
+
+**Add columns using intermediate result:**
+
+<!---FUN addCalculated-->
+
+```kotlin
+val personWithCityInfo = df.add {
+    val cityInfo = city.map { queryCityInfo(it) }
+    "cityInfo" {
+        cityInfo.map { it.location } into CityInfo::location
+        cityInfo.map { it.population } into "population"
+    }
+}
 ```
 
 <!---END-->

--- a/docs/StardustDocs/topics/add.md
+++ b/docs/StardustDocs/topics/add.md
@@ -4,7 +4,7 @@
 
 Returns `DataFrame` which contains all columns from original `DataFrame` followed by newly added columns. Original `DataFrame` is not modified.
 
-**Create new column and add it to `DataFrame`:**
+## Create new column and add it to `DataFrame`
 
 ```text
 add(columnName: String) { rowExpression }
@@ -55,7 +55,7 @@ df.add("fibonacci") {
 
 <!---END-->
 
-**Create and add several columns to `DataFrame`:**
+## Create and add several columns to `DataFrame`
 
 ```kotlin
 add { 
@@ -130,7 +130,23 @@ df.add {
 </tab></tabs>
 <!---END-->
 
-**Add existing column to `DataFrame`:**
+### Create columns using intermediate result
+
+<!---FUN addCalculated-->
+
+```kotlin
+val personWithCityInfo = df.add {
+    val cityInfo = city.map { queryCityInfo(it) }
+    "cityInfo" {
+        cityInfo.map { it.location } into CityInfo::location
+        cityInfo.map { it.population } into "population"
+    }
+}
+```
+
+<!---END-->
+
+## Add existing column to `DataFrame`
 
 <!---FUN addExisting-->
 
@@ -143,28 +159,12 @@ df + score
 
 <!---END-->
 
-**Add all columns from another `DataFrame`:**
+## Add all columns from another `DataFrame`
 
 <!---FUN addDfs-->
 
 ```kotlin
 df.add(df1, df2)
-```
-
-<!---END-->
-
-**Add columns using intermediate result:**
-
-<!---FUN addCalculated-->
-
-```kotlin
-val personWithCityInfo = df.add {
-    val cityInfo = city.map { queryCityInfo(it) }
-    "cityInfo" {
-        cityInfo.map { it.location } into CityInfo::location
-        cityInfo.map { it.population } into "population"
-    }
-}
 ```
 
 <!---END-->

--- a/docs/StardustDocs/topics/add.md
+++ b/docs/StardustDocs/topics/add.md
@@ -132,7 +132,24 @@ df.add {
 
 ### Create columns using intermediate result
 
+Consider this API:
+
+<!---FUN addCalculatedApi-->
+
+```kotlin
+class CityInfo(val city: String?, val population: Int, val location: String)
+fun queryCityInfo(city: String?): CityInfo {
+    return CityInfo(city, city?.length ?: 0, "35.5 32.2")
+}
+```
+
+<!---END-->
+
+Use the following approach to add multiple columns by calling the given API only once per row:
+
 <!---FUN addCalculated-->
+<tabs>
+<tab title="Properties">
 
 ```kotlin
 val personWithCityInfo = df.add {
@@ -144,6 +161,34 @@ val personWithCityInfo = df.add {
 }
 ```
 
+</tab>
+<tab title="Accessors">
+
+```kotlin
+val city by column<String?>()
+val personWithCityInfo = df.add {
+    val cityInfo = city().map { queryCityInfo(it) }
+    "cityInfo" {
+        cityInfo.map { it.location } into CityInfo::location
+        cityInfo.map { it.population } into "population"
+    }
+}
+```
+
+</tab>
+<tab title="Strings">
+
+```kotlin
+val personWithCityInfo = df.add {
+    val cityInfo = "city"<String?>().map { queryCityInfo(it) }
+    "cityInfo" {
+        cityInfo.map { it.location } into CityInfo::location
+        cityInfo.map { it.population } into "population"
+    }
+}
+```
+
+</tab></tabs>
 <!---END-->
 
 ## Add existing column to `DataFrame`

--- a/docs/StardustDocs/topics/operations.md
+++ b/docs/StardustDocs/topics/operations.md
@@ -1,4 +1,4 @@
-[//]: # (title: Operations)
+[//]: # (title: Operations Overview)
 
 <!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Modify-->
 

--- a/docs/StardustDocs/topics/types.md
+++ b/docs/StardustDocs/topics/types.md
@@ -1,4 +1,4 @@
-[//]: # (title: Types)
+[//]: # (title: Data Abstractions)
 
 * [`DataColumn`](DataColumn.md) is a named, typed and ordered collection of elements
 * [`DataFrame`](DataFrame.md) consists of one or several [`DataColumns`](DataColumn.md) with unique names and equal size

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,15 @@
 # Examples of Kotlin Dataframe
 
 ### Idea examples
-* [movies](idea-examples/movies)
+* [movies](idea-examples/movies) Using 3 different [Access APIs](https://kotlin.github.io/dataframe/apilevels.html) to perform data cleaning task
 * [titanic](idea-examples/titanic)
 * [youtube](idea-examples/youtube)
+* [json](idea-examples/json) Using OpenAPI support in DataFrame's Gradle and KSP plugins to access data from [API guru](https://apis.guru/) in a type-safe manner
 
 ### Notebook examples
+
+* people [Datalore](https://datalore.jetbrains.com/view/notebook/aOTioEClQQrsZZBKeUPAQj)
+Small artificial dataset used in [DataFrame API examples](https://kotlin.github.io/dataframe/operations.html) 
 
 * puzzles ([Jupyter](jupyter-notebooks/puzzles/40%20puzzles.ipynb)/[Datalore](https://datalore.jetbrains.com/view/notebook/CVp3br3CDXjUGaxxqfJjFF)) &ndash;
 Inspired [by 100 pandas puzzles](https://github.com/ajcr/100-pandas-puzzles). You will go from the simplest tasks to 


### PR DESCRIPTION
1. Added example for `add` use case that is supported but was missing from the docs
2. Changed nesting level for navigation inside topics so that it should be easier to navigate articles with lots of headers and, as an experiment, changed structure of add.md accordingly
3. Changed the structure of general navigation tree to bring attention to materials that seem neglected