### PR TITLE
Rename Column typealias to AnyColumnReference

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
@@ -57,7 +57,7 @@ public interface DataFrame<out T> : Aggregatable<T>, ColumnsContainer<T> {
     override operator fun <C> get(columns: ColumnsSelector<T, C>): List<DataColumn<C>> =
         getColumnsImpl(UnresolvedColumnsPolicy.Fail, columns)
 
-    public operator fun get(first: Column, vararg other: Column): DataFrame<T> = select(listOf(first) + other)
+    public operator fun get(first: AnyColumnReference, vararg other: AnyColumnReference): DataFrame<T> = select(listOf(first) + other)
     public operator fun get(first: String, vararg other: String): DataFrame<T> = select(listOf(first) + other)
     public operator fun get(columnRange: ClosedRange<String>): DataFrame<T> =
         select { columnRange.start..columnRange.endInclusive }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataRow.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataRow.kt
@@ -28,7 +28,7 @@ public interface DataRow<out T> {
     public operator fun <R> get(column: ColumnReference<R>): R
     public operator fun <R> get(columns: List<ColumnReference<R>>): List<R> = columns.map { get(it) }
     public operator fun <R> get(property: KProperty<R>): R = get(property.columnName) as R
-    public operator fun get(first: Column, vararg other: Column): DataRow<T> = owner.get(first, *other)[index]
+    public operator fun get(first: AnyColumnReference, vararg other: AnyColumnReference): DataRow<T> = owner.get(first, *other)[index]
     public operator fun get(first: String, vararg other: String): DataRow<T> = owner.get(first, *other)[index]
     public operator fun get(path: ColumnPath): Any? = owner.get(path)[index]
     public operator fun get(name: String): Any?

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aliases.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aliases.kt
@@ -138,7 +138,7 @@ public typealias RowValueFilter<T, C> = RowValueExpression<T, C, Boolean>
 
 // region columns
 
-public typealias Column = ColumnReference<*>
+public typealias AnyColumnReference = ColumnReference<*>
 
 public typealias ColumnGroupReference = ColumnReference<AnyRow>
 public typealias ColumnGroupAccessor<T> = ColumnAccessor<DataRow<T>>

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
@@ -1,10 +1,15 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.AnyCol
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
+import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnFilter
+import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
@@ -16,6 +21,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.columns.renamedReference
+import org.jetbrains.kotlinx.dataframe.hasNulls
 import org.jetbrains.kotlinx.dataframe.impl.columnName
 import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnsList
 import org.jetbrains.kotlinx.dataframe.impl.columns.DistinctColumnSet
@@ -31,7 +37,6 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.top
 import org.jetbrains.kotlinx.dataframe.impl.columns.transform
 import org.jetbrains.kotlinx.dataframe.impl.columns.transformSingle
 import org.jetbrains.kotlinx.dataframe.impl.columns.tree.dfs
-import org.jetbrains.kotlinx.dataframe.impl.getColumnsWithPaths
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -67,7 +72,7 @@ public interface ColumnsSelectionDsl<out T> : ColumnSelectionDsl<T>, SingleColum
 
     public operator fun String.rangeTo(endInclusive: String): ColumnSet<*> = toColumnAccessor().rangeTo(endInclusive.toColumnAccessor())
 
-    public operator fun Column.rangeTo(endInclusive: Column): ColumnSet<*> = object : ColumnSet<Any?> {
+    public operator fun AnyColumnReference.rangeTo(endInclusive: AnyColumnReference): ColumnSet<*> = object : ColumnSet<Any?> {
         override fun resolve(context: ColumnResolutionContext): List<ColumnWithPath<Any?>> {
             val startPath = this@rangeTo.resolveSingle(context)!!.path
             val endPath = endInclusive.resolveSingle(context)!!.path
@@ -161,7 +166,7 @@ public interface ColumnsSelectionDsl<out T> : ColumnSelectionDsl<T>, SingleColum
     }
 
     public fun SingleColumn<*>.allAfter(colName: String): ColumnSet<Any?> = allAfter(pathOf(colName))
-    public fun SingleColumn<*>.allAfter(column: Column): ColumnSet<Any?> = allAfter(column.path())
+    public fun SingleColumn<*>.allAfter(column: AnyColumnReference): ColumnSet<Any?> = allAfter(column.path())
 
     // endregion
 
@@ -180,7 +185,7 @@ public interface ColumnsSelectionDsl<out T> : ColumnSelectionDsl<T>, SingleColum
     }
 
     public fun SingleColumn<*>.allSince(colName: String): ColumnSet<Any?> = allSince(pathOf(colName))
-    public fun SingleColumn<*>.allSince(column: Column): ColumnSet<Any?> = allSince(column.path())
+    public fun SingleColumn<*>.allSince(column: AnyColumnReference): ColumnSet<Any?> = allSince(column.path())
 
     // endregion
 
@@ -199,7 +204,7 @@ public interface ColumnsSelectionDsl<out T> : ColumnSelectionDsl<T>, SingleColum
     }
 
     public fun SingleColumn<*>.allBefore(colName: String): ColumnSet<Any?> = allBefore(pathOf(colName))
-    public fun SingleColumn<*>.allBefore(column: Column): ColumnSet<Any?> = allBefore(column.path())
+    public fun SingleColumn<*>.allBefore(column: AnyColumnReference): ColumnSet<Any?> = allBefore(column.path())
 
     // endregion
 
@@ -218,7 +223,7 @@ public interface ColumnsSelectionDsl<out T> : ColumnSelectionDsl<T>, SingleColum
     }
 
     public fun SingleColumn<*>.allUntil(colName: String): ColumnSet<Any?> = allUntil(pathOf(colName))
-    public fun SingleColumn<*>.allUntil(column: Column): ColumnSet<Any?> = allUntil(column.path())
+    public fun SingleColumn<*>.allUntil(column: AnyColumnReference): ColumnSet<Any?> = allUntil(column.path())
 
     // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataFrameGet.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataFrameGet.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnSelector
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
@@ -19,7 +19,6 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumns
 import org.jetbrains.kotlinx.dataframe.impl.getColumnPaths
 import org.jetbrains.kotlinx.dataframe.impl.getColumnsWithPaths
-import org.jetbrains.kotlinx.dataframe.indices
 import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import kotlin.reflect.KProperty
@@ -89,7 +88,7 @@ public fun <T> ColumnsContainer<T>.getColumnGroupOrNull(column: KProperty<*>): C
 public fun <C> ColumnsContainer<*>.containsColumn(column: ColumnReference<C>): Boolean = getColumnOrNull(column) != null
 public fun ColumnsContainer<*>.containsColumn(column: KProperty<*>): Boolean = containsColumn(column.columnName)
 
-public operator fun ColumnsContainer<*>.contains(column: Column): Boolean = containsColumn(column)
+public operator fun ColumnsContainer<*>.contains(column: AnyColumnReference): Boolean = containsColumn(column)
 public operator fun ColumnsContainer<*>.contains(column: KProperty<*>): Boolean = containsColumn(column)
 
 // region rows

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyRow
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -57,10 +57,10 @@ public fun <T> AnyRow.getValueOrNull(column: KProperty<T>): T? = getValueOrNull<
 // region contains
 
 public fun AnyRow.containsKey(columnName: String): Boolean = owner.containsColumn(columnName)
-public fun AnyRow.containsKey(column: Column): Boolean = owner.containsColumn(column)
+public fun AnyRow.containsKey(column: AnyColumnReference): Boolean = owner.containsColumn(column)
 public fun AnyRow.containsKey(column: KProperty<*>): Boolean = owner.containsColumn(column)
 
-public operator fun AnyRow.contains(column: Column): Boolean = containsKey(column)
+public operator fun AnyRow.contains(column: AnyColumnReference): Boolean = containsKey(column)
 public operator fun AnyRow.contains(column: KProperty<*>): Boolean = containsKey(column)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -109,10 +109,10 @@ public fun <T> DataFrame<T>.dropNulls(vararg cols: KProperty<*>, whereAllNull: B
 public fun <T> DataFrame<T>.dropNulls(vararg cols: String, whereAllNull: Boolean = false): DataFrame<T> =
     dropNulls(whereAllNull) { cols.toColumns() }
 
-public fun <T> DataFrame<T>.dropNulls(vararg cols: Column, whereAllNull: Boolean = false): DataFrame<T> =
+public fun <T> DataFrame<T>.dropNulls(vararg cols: AnyColumnReference, whereAllNull: Boolean = false): DataFrame<T> =
     dropNulls(whereAllNull) { cols.toColumns() }
 
-public fun <T> DataFrame<T>.dropNulls(cols: Iterable<Column>, whereAllNull: Boolean = false): DataFrame<T> =
+public fun <T> DataFrame<T>.dropNulls(cols: Iterable<AnyColumnReference>, whereAllNull: Boolean = false): DataFrame<T> =
     dropNulls(whereAllNull) { cols.toColumnSet() }
 
 public fun <T> DataColumn<T?>.dropNulls(): DataColumn<T> =
@@ -135,10 +135,10 @@ public fun <T> DataFrame<T>.dropNA(vararg cols: KProperty<*>, whereAllNA: Boolea
 public fun <T> DataFrame<T>.dropNA(vararg cols: String, whereAllNA: Boolean = false): DataFrame<T> =
     dropNA(whereAllNA) { cols.toColumns() }
 
-public fun <T> DataFrame<T>.dropNA(vararg cols: Column, whereAllNA: Boolean = false): DataFrame<T> =
+public fun <T> DataFrame<T>.dropNA(vararg cols: AnyColumnReference, whereAllNA: Boolean = false): DataFrame<T> =
     dropNA(whereAllNA) { cols.toColumns() }
 
-public fun <T> DataFrame<T>.dropNA(cols: Iterable<Column>, whereAllNA: Boolean = false): DataFrame<T> =
+public fun <T> DataFrame<T>.dropNA(cols: Iterable<AnyColumnReference>, whereAllNA: Boolean = false): DataFrame<T> =
     dropNA(whereAllNA) { cols.toColumnSet() }
 
 public fun <T> DataFrame<T>.dropNA(whereAllNA: Boolean = false): DataFrame<T> =

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
@@ -3,9 +3,9 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -149,9 +149,9 @@ public class AddDsl<T>(@PublishedApi internal val df: DataFrame<T>) : ColumnsCon
     // TODO: support adding column into path
     internal val columns = mutableListOf<AnyCol>()
 
-    public fun add(column: Column): Boolean = columns.add(column.resolveSingle(df)!!.data)
+    public fun add(column: AnyColumnReference): Boolean = columns.add(column.resolveSingle(df)!!.data)
 
-    public operator fun Column.unaryPlus(): Boolean = add(this)
+    public operator fun AnyColumnReference.unaryPlus(): Boolean = add(this)
 
     public operator fun String.unaryPlus(): Boolean = add(df[this])
 
@@ -172,11 +172,11 @@ public class AddDsl<T>(@PublishedApi internal val df: DataFrame<T>) : ColumnsCon
     public inline infix fun <reified R> ColumnAccessor<R>.from(noinline expression: RowExpression<T, R>): Boolean = name().from(expression)
     public inline infix fun <reified R> KProperty<R>.from(noinline expression: RowExpression<T, R>): Boolean = add(name, Infer.Nulls, expression)
 
-    public infix fun String.from(column: Column): Boolean = add(column.rename(this))
+    public infix fun String.from(column: AnyColumnReference): Boolean = add(column.rename(this))
     public inline infix fun <reified R> ColumnAccessor<R>.from(column: ColumnReference<R>): Boolean = name() from column
     public inline infix fun <reified R> KProperty<R>.from(column: ColumnReference<R>): Boolean = name from column
 
-    public infix fun Column.into(name: String): Boolean = add(rename(name))
+    public infix fun AnyColumnReference.into(name: String): Boolean = add(rename(name))
     public infix fun <R> ColumnReference<R>.into(column: ColumnAccessor<R>): Boolean = into(column.name())
     public infix fun <R> ColumnReference<R>.into(column: KProperty<R>): Boolean = into(column.name)
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/countDistinct.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/countDistinct.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumns
@@ -19,6 +19,6 @@ public fun <T, C> DataFrame<T>.countDistinct(columns: ColumnsSelector<T, C>): In
 
 public fun <T> DataFrame<T>.countDistinct(vararg columns: String): Int = countDistinct { columns.toColumns() }
 public fun <T, C> DataFrame<T>.countDistinct(vararg columns: KProperty<C>): Int = countDistinct { columns.toColumns() }
-public fun <T> DataFrame<T>.countDistinct(vararg columns: Column): Int = countDistinct { columns.toColumns() }
+public fun <T> DataFrame<T>.countDistinct(vararg columns: AnyColumnReference): Int = countDistinct { columns.toColumns() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -38,7 +38,7 @@ private val supportedClasses = setOf(Double::class, Float::class, Int::class, Lo
 public fun <T, C> DataFrame<T>.cumSum(skipNA: Boolean = defaultCumSumSkipNA, columns: ColumnsSelector<T, C>): DataFrame<T> =
     convert(columns).to { if (it.typeClass in supportedClasses) it.cast<Number?>().cumSum(skipNA) else it }
 public fun <T> DataFrame<T>.cumSum(vararg columns: String, skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> = cumSum(skipNA) { columns.toColumns() }
-public fun <T> DataFrame<T>.cumSum(vararg columns: Column, skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> = cumSum(skipNA) { columns.toColumns() }
+public fun <T> DataFrame<T>.cumSum(vararg columns: AnyColumnReference, skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> = cumSum(skipNA) { columns.toColumns() }
 public fun <T> DataFrame<T>.cumSum(vararg columns: KProperty<*>, skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> = cumSum(skipNA) { columns.toColumns() }
 
 public fun <T> DataFrame<T>.cumSum(skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> = cumSum(skipNA) { allDfs() }
@@ -50,7 +50,7 @@ public fun <T> DataFrame<T>.cumSum(skipNA: Boolean = defaultCumSumSkipNA): DataF
 public fun <T, G, C> GroupBy<T, G>.cumSum(skipNA: Boolean = defaultCumSumSkipNA, columns: ColumnsSelector<G, C>): GroupBy<T, G> =
     updateGroups { cumSum(skipNA, columns) }
 public fun <T, G> GroupBy<T, G>.cumSum(vararg columns: String, skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> = cumSum(skipNA) { columns.toColumns() }
-public fun <T, G> GroupBy<T, G>.cumSum(vararg columns: Column, skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> = cumSum(skipNA) { columns.toColumns() }
+public fun <T, G> GroupBy<T, G>.cumSum(vararg columns: AnyColumnReference, skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> = cumSum(skipNA) { columns.toColumns() }
 public fun <T, G> GroupBy<T, G>.cumSum(vararg columns: KProperty<*>, skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> = cumSum(skipNA) { columns.toColumns() }
 public fun <T, G> GroupBy<T, G>.cumSum(skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> = cumSum(skipNA) { allDfs() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnSet
@@ -18,19 +18,19 @@ public fun <T> DataFrame<T>.distinct(vararg columns: KProperty<*>): DataFrame<T>
     set
 }
 public fun <T> DataFrame<T>.distinct(vararg columns: String): DataFrame<T> = distinct { columns.toColumns() }
-public fun <T> DataFrame<T>.distinct(vararg columns: Column): DataFrame<T> = distinct { columns.toColumns() }
+public fun <T> DataFrame<T>.distinct(vararg columns: AnyColumnReference): DataFrame<T> = distinct { columns.toColumns() }
 
 @JvmName("distinctT")
 public fun <T> DataFrame<T>.distinct(columns: Iterable<String>): DataFrame<T> = distinct { columns.toColumns() }
-public fun <T> DataFrame<T>.distinct(columns: Iterable<Column>): DataFrame<T> = distinct { columns.toColumnSet() }
+public fun <T> DataFrame<T>.distinct(columns: Iterable<AnyColumnReference>): DataFrame<T> = distinct { columns.toColumnSet() }
 
 public fun <T> DataFrame<T>.distinctBy(vararg columns: KProperty<*>): DataFrame<T> = distinctBy { columns.toColumns() }
 public fun <T> DataFrame<T>.distinctBy(vararg columns: String): DataFrame<T> = distinctBy { columns.toColumns() }
-public fun <T> DataFrame<T>.distinctBy(vararg columns: Column): DataFrame<T> = distinctBy { columns.toColumns() }
+public fun <T> DataFrame<T>.distinctBy(vararg columns: AnyColumnReference): DataFrame<T> = distinctBy { columns.toColumns() }
 
 @JvmName("distinctByT")
 public fun <T> DataFrame<T>.distinctBy(columns: Iterable<String>): DataFrame<T> = distinctBy { columns.toColumns() }
-public fun <T> DataFrame<T>.distinctBy(columns: Iterable<Column>): DataFrame<T> = distinctBy { columns.toColumnSet() }
+public fun <T> DataFrame<T>.distinctBy(columns: Iterable<AnyColumnReference>): DataFrame<T> = distinctBy { columns.toColumnSet() }
 
 public fun <T, C> DataFrame<T>.distinctBy(columns: ColumnsSelector<T, C>): DataFrame<T> {
     val cols = get(columns)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -16,7 +16,7 @@ public data class GroupClause<T, C>(val df: DataFrame<T>, val columns: ColumnsSe
 
 public fun <T, C> DataFrame<T>.group(columns: ColumnsSelector<T, C>): GroupClause<T, C> = GroupClause(this, columns)
 public fun <T> DataFrame<T>.group(vararg columns: String): GroupClause<T, Any?> = group { columns.toColumns() }
-public fun <T> DataFrame<T>.group(vararg columns: Column): GroupClause<T, Any?> = group { columns.toColumns() }
+public fun <T> DataFrame<T>.group(vararg columns: AnyColumnReference): GroupClause<T, Any?> = group { columns.toColumns() }
 public fun <T> DataFrame<T>.group(vararg columns: KProperty<*>): GroupClause<T, Any?> = group { columns.toColumns() }
 
 @JvmName("intoString")
@@ -25,7 +25,7 @@ public fun <T> DataFrame<T>.group(vararg columns: KProperty<*>): GroupClause<T, 
 public infix fun <T, C> GroupClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> String): DataFrame<T> = df.move(columns).under { column(it).toColumnAccessor() }
 
 @JvmName("intoColumn")
-public infix fun <T, C> GroupClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> Column): DataFrame<T> = df.move(columns).under(column)
+public infix fun <T, C> GroupClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> AnyColumnReference): DataFrame<T> = df.move(columns).under(column)
 public infix fun <T, C> GroupClause<T, C>.into(column: String): DataFrame<T> = into(columnGroup().named(column))
 public infix fun <T, C> GroupClause<T, C>.into(column: AnyColumnGroupAccessor): DataFrame<T> = df.move(columns).under(column)
 public infix fun <T, C> GroupClause<T, C>.into(column: KProperty<*>): DataFrame<T> = into(column.columnName)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -19,17 +19,17 @@ import kotlin.reflect.KProperty
 // region DataFrame
 
 public fun <T> DataFrame<T>.groupBy(moveToTop: Boolean = true, cols: ColumnsSelector<T, *>): GroupBy<T, T> = groupByImpl(moveToTop, cols)
-public fun <T> DataFrame<T>.groupBy(cols: Iterable<Column>): GroupBy<T, T> = groupBy { cols.toColumnSet() }
+public fun <T> DataFrame<T>.groupBy(cols: Iterable<AnyColumnReference>): GroupBy<T, T> = groupBy { cols.toColumnSet() }
 public fun <T> DataFrame<T>.groupBy(vararg cols: KProperty<*>): GroupBy<T, T> = groupBy { cols.toColumns() }
 public fun <T> DataFrame<T>.groupBy(vararg cols: String): GroupBy<T, T> = groupBy { cols.toColumns() }
-public fun <T> DataFrame<T>.groupBy(vararg cols: Column, moveToTop: Boolean = true): GroupBy<T, T> = groupBy(moveToTop) { cols.toColumns() }
+public fun <T> DataFrame<T>.groupBy(vararg cols: AnyColumnReference, moveToTop: Boolean = true): GroupBy<T, T> = groupBy(moveToTop) { cols.toColumns() }
 
 // endregion
 
 // region Pivot
 
 public fun <T> Pivot<T>.groupBy(moveToTop: Boolean = true, columns: ColumnsSelector<T, *>): PivotGroupBy<T> = (this as PivotImpl<T>).toGroupedPivot(moveToTop, columns)
-public fun <T> Pivot<T>.groupBy(vararg columns: Column): PivotGroupBy<T> = groupBy { columns.toColumns() }
+public fun <T> Pivot<T>.groupBy(vararg columns: AnyColumnReference): PivotGroupBy<T> = groupBy { columns.toColumns() }
 public fun <T> Pivot<T>.groupBy(vararg columns: String): PivotGroupBy<T> = groupBy { columns.toColumns() }
 public fun <T> Pivot<T>.groupBy(vararg columns: KProperty<*>): PivotGroupBy<T> = groupBy { columns.toColumns() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnSelector
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -21,20 +21,20 @@ public fun <T, C> DataFrame<T>.move(vararg cols: KProperty<C>): MoveClause<T, C>
 
 public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, columns: ColumnsSelector<T, *>): DataFrame<T> = move(columns).to(newColumnIndex)
 public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, vararg columns: String): DataFrame<T> = moveTo(newColumnIndex) { columns.toColumns() }
-public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, vararg columns: Column): DataFrame<T> = moveTo(newColumnIndex) { columns.toColumns() }
+public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, vararg columns: AnyColumnReference): DataFrame<T> = moveTo(newColumnIndex) { columns.toColumns() }
 public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, vararg columns: KProperty<*>): DataFrame<T> = moveTo(newColumnIndex) { columns.toColumns() }
 
 public fun <T> DataFrame<T>.moveToLeft(columns: ColumnsSelector<T, *>): DataFrame<T> = move(columns).toLeft()
 public fun <T> DataFrame<T>.moveToLeft(vararg columns: String): DataFrame<T> = moveToLeft { columns.toColumns() }
-public fun <T> DataFrame<T>.moveToLeft(vararg columns: Column): DataFrame<T> = moveToLeft { columns.toColumns() }
+public fun <T> DataFrame<T>.moveToLeft(vararg columns: AnyColumnReference): DataFrame<T> = moveToLeft { columns.toColumns() }
 public fun <T> DataFrame<T>.moveToLeft(vararg columns: KProperty<*>): DataFrame<T> = moveToLeft { columns.toColumns() }
 
 public fun <T> DataFrame<T>.moveToRight(columns: ColumnsSelector<T, *>): DataFrame<T> = move(columns).toRight()
 public fun <T> DataFrame<T>.moveToRight(vararg columns: String): DataFrame<T> = moveToRight { columns.toColumns() }
-public fun <T> DataFrame<T>.moveToRight(vararg columns: Column): DataFrame<T> = moveToRight { columns.toColumns() }
+public fun <T> DataFrame<T>.moveToRight(vararg columns: AnyColumnReference): DataFrame<T> = moveToRight { columns.toColumns() }
 public fun <T> DataFrame<T>.moveToRight(vararg columns: KProperty<*>): DataFrame<T> = moveToRight { columns.toColumns() }
 
-public fun <T, C> MoveClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> Column): DataFrame<T> = moveImpl(
+public fun <T, C> MoveClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> AnyColumnReference): DataFrame<T> = moveImpl(
     under = false,
     column
 )
@@ -42,7 +42,7 @@ public fun <T, C> MoveClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWi
 public fun <T, C> MoveClause<T, C>.into(column: String): DataFrame<T> = pathOf(column).let { path -> into { path } }
 
 public fun <T, C> MoveClause<T, C>.intoIndexed(
-    newPathExpression: ColumnsSelectionDsl<T>.(ColumnWithPath<C>, Int) -> Column
+    newPathExpression: ColumnsSelectionDsl<T>.(ColumnWithPath<C>, Int) -> AnyColumnReference
 ): DataFrame<T> {
     var counter = 0
     return into { col ->
@@ -52,7 +52,7 @@ public fun <T, C> MoveClause<T, C>.intoIndexed(
 
 public fun <T, C> MoveClause<T, C>.under(column: String): DataFrame<T> = pathOf(column).let { path -> under { path } }
 public fun <T, C> MoveClause<T, C>.under(column: AnyColumnGroupAccessor): DataFrame<T> = column.path().let { path -> under { path } }
-public fun <T, C> MoveClause<T, C>.under(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> Column): DataFrame<T> = moveImpl(
+public fun <T, C> MoveClause<T, C>.under(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> AnyColumnReference): DataFrame<T> = moveImpl(
     under = true,
     column
 )
@@ -66,7 +66,7 @@ public fun <T, C> MoveClause<T, C>.toTop(
 
 public fun <T, C> MoveClause<T, C>.after(column: ColumnSelector<T, *>): DataFrame<T> = afterOrBefore(column, true)
 public fun <T, C> MoveClause<T, C>.after(column: String): DataFrame<T> = after { column.toColumnAccessor() }
-public fun <T, C> MoveClause<T, C>.after(column: Column): DataFrame<T> = after { column }
+public fun <T, C> MoveClause<T, C>.after(column: AnyColumnReference): DataFrame<T> = after { column }
 public fun <T, C> MoveClause<T, C>.after(column: KProperty<*>): DataFrame<T> = after { column.toColumnAccessor() }
 
 // TODO: implement 'before'

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -41,17 +41,17 @@ public interface PivotDsl<out T> : ColumnsSelectionDsl<T> {
 
 public fun <T> DataFrame<T>.pivot(inward: Boolean? = null, columns: PivotColumnsSelector<T, *>): Pivot<T> = PivotImpl(this, columns, inward)
 public fun <T> DataFrame<T>.pivot(vararg columns: String, inward: Boolean? = null): Pivot<T> = pivot(inward) { columns.toColumns() }
-public fun <T> DataFrame<T>.pivot(vararg columns: Column, inward: Boolean? = null): Pivot<T> = pivot(inward) { columns.toColumns() }
+public fun <T> DataFrame<T>.pivot(vararg columns: AnyColumnReference, inward: Boolean? = null): Pivot<T> = pivot(inward) { columns.toColumns() }
 public fun <T> DataFrame<T>.pivot(vararg columns: KProperty<*>, inward: Boolean? = null): Pivot<T> = pivot(inward) { columns.toColumns() }
 
 public fun <T> DataFrame<T>.pivotMatches(inward: Boolean = true, columns: ColumnsSelector<T, *>): DataFrame<T> = pivot(inward, columns).groupByOther().matches()
 public fun <T> DataFrame<T>.pivotMatches(vararg columns: String, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
-public fun <T> DataFrame<T>.pivotMatches(vararg columns: Column, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
+public fun <T> DataFrame<T>.pivotMatches(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
 public fun <T> DataFrame<T>.pivotMatches(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
 
 public fun <T> DataFrame<T>.pivotCounts(inward: Boolean = true, columns: ColumnsSelector<T, *>): DataFrame<T> = pivot(inward, columns).groupByOther().count()
 public fun <T> DataFrame<T>.pivotCounts(vararg columns: String, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
-public fun <T> DataFrame<T>.pivotCounts(vararg columns: Column, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
+public fun <T> DataFrame<T>.pivotCounts(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
 public fun <T> DataFrame<T>.pivotCounts(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
 
 // endregion
@@ -59,18 +59,18 @@ public fun <T> DataFrame<T>.pivotCounts(vararg columns: KProperty<*>, inward: Bo
 // region GroupBy
 
 public fun <G> GroupBy<*, G>.pivot(inward: Boolean = true, columns: ColumnsSelector<G, *>): PivotGroupBy<G> = PivotGroupByImpl(this, columns, inward)
-public fun <G> GroupBy<*, G>.pivot(vararg columns: Column, inward: Boolean = true): PivotGroupBy<G> = pivot(inward) { columns.toColumns() }
+public fun <G> GroupBy<*, G>.pivot(vararg columns: AnyColumnReference, inward: Boolean = true): PivotGroupBy<G> = pivot(inward) { columns.toColumns() }
 public fun <G> GroupBy<*, G>.pivot(vararg columns: String, inward: Boolean = true): PivotGroupBy<G> = pivot(inward) { columns.toColumns() }
 public fun <G> GroupBy<*, G>.pivot(vararg columns: KProperty<*>, inward: Boolean = true): PivotGroupBy<G> = pivot(inward) { columns.toColumns() }
 
 public fun <G> GroupBy<*, G>.pivotMatches(inward: Boolean = true, columns: ColumnsSelector<G, *>): DataFrame<G> = pivot(inward, columns).matches()
 public fun <G> GroupBy<*, G>.pivotMatches(vararg columns: String, inward: Boolean = true): DataFrame<G> = pivotMatches(inward) { columns.toColumns() }
-public fun <G> GroupBy<*, G>.pivotMatches(vararg columns: Column, inward: Boolean = true): DataFrame<G> = pivotMatches(inward) { columns.toColumns() }
+public fun <G> GroupBy<*, G>.pivotMatches(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<G> = pivotMatches(inward) { columns.toColumns() }
 public fun <G> GroupBy<*, G>.pivotMatches(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<G> = pivotMatches(inward) { columns.toColumns() }
 
 public fun <G> GroupBy<*, G>.pivotCounts(inward: Boolean = true, columns: ColumnsSelector<G, *>): DataFrame<G> = pivot(inward, columns).count()
 public fun <G> GroupBy<*, G>.pivotCounts(vararg columns: String, inward: Boolean = true): DataFrame<G> = pivotCounts(inward) { columns.toColumns() }
-public fun <G> GroupBy<*, G>.pivotCounts(vararg columns: Column, inward: Boolean = true): DataFrame<G> = pivotCounts(inward) { columns.toColumns() }
+public fun <G> GroupBy<*, G>.pivotCounts(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<G> = pivotCounts(inward) { columns.toColumns() }
 public fun <G> GroupBy<*, G>.pivotCounts(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<G> = pivotCounts(inward) { columns.toColumns() }
 
 // endregion
@@ -80,17 +80,17 @@ public fun <G> GroupBy<*, G>.pivotCounts(vararg columns: KProperty<*>, inward: B
 public fun <T> AggregateGroupedDsl<T>.pivot(inward: Boolean = true, columns: ColumnsSelector<T, *>): PivotGroupBy<T> =
     PivotInAggregateImpl(this, columns, inward)
 public fun <T> AggregateGroupedDsl<T>.pivot(vararg columns: String, inward: Boolean = true): PivotGroupBy<T> = pivot(inward) { columns.toColumns() }
-public fun <T> AggregateGroupedDsl<T>.pivot(vararg columns: Column, inward: Boolean = true): PivotGroupBy<T> = pivot(inward) { columns.toColumns() }
+public fun <T> AggregateGroupedDsl<T>.pivot(vararg columns: AnyColumnReference, inward: Boolean = true): PivotGroupBy<T> = pivot(inward) { columns.toColumns() }
 public fun <T> AggregateGroupedDsl<T>.pivot(vararg columns: KProperty<*>, inward: Boolean = true): PivotGroupBy<T> = pivot(inward) { columns.toColumns() }
 
 public fun <T> AggregateGroupedDsl<T>.pivotMatches(inward: Boolean = true, columns: ColumnsSelector<T, *>): DataFrame<T> = pivot(inward, columns).matches()
 public fun <T> AggregateGroupedDsl<T>.pivotMatches(vararg columns: String, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
-public fun <T> AggregateGroupedDsl<T>.pivotMatches(vararg columns: Column, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
+public fun <T> AggregateGroupedDsl<T>.pivotMatches(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
 public fun <T> AggregateGroupedDsl<T>.pivotMatches(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<T> = pivotMatches(inward) { columns.toColumns() }
 
 public fun <T> AggregateGroupedDsl<T>.pivotCounts(inward: Boolean = true, columns: ColumnsSelector<T, *>): DataFrame<T> = pivot(inward, columns).matches()
 public fun <T> AggregateGroupedDsl<T>.pivotCounts(vararg columns: String, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
-public fun <T> AggregateGroupedDsl<T>.pivotCounts(vararg columns: Column, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
+public fun <T> AggregateGroupedDsl<T>.pivotCounts(vararg columns: AnyColumnReference, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
 public fun <T> AggregateGroupedDsl<T>.pivotCounts(vararg columns: KProperty<*>, inward: Boolean = true): DataFrame<T> = pivotCounts(inward) { columns.toColumns() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/remove.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/remove.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.api.removeImpl
@@ -13,12 +13,12 @@ import kotlin.reflect.KProperty
 public fun <T> DataFrame<T>.remove(columns: ColumnsSelector<T, *>): DataFrame<T> = removeImpl(allowMissingColumns = true, columns = columns).df
 public fun <T> DataFrame<T>.remove(vararg columns: KProperty<*>): DataFrame<T> = remove { columns.toColumns() }
 public fun <T> DataFrame<T>.remove(vararg columns: String): DataFrame<T> = remove { columns.toColumns() }
-public fun <T> DataFrame<T>.remove(vararg columns: Column): DataFrame<T> = remove { columns.toColumns() }
-public fun <T> DataFrame<T>.remove(columns: Iterable<Column>): DataFrame<T> = remove { columns.toColumnSet() }
+public fun <T> DataFrame<T>.remove(vararg columns: AnyColumnReference): DataFrame<T> = remove { columns.toColumns() }
+public fun <T> DataFrame<T>.remove(columns: Iterable<AnyColumnReference>): DataFrame<T> = remove { columns.toColumnSet() }
 
 public infix operator fun <T> DataFrame<T>.minus(columns: ColumnsSelector<T, *>): DataFrame<T> = remove(columns)
 public infix operator fun <T> DataFrame<T>.minus(column: String): DataFrame<T> = remove(column)
-public infix operator fun <T> DataFrame<T>.minus(column: Column): DataFrame<T> = remove(column)
-public infix operator fun <T> DataFrame<T>.minus(columns: Iterable<Column>): DataFrame<T> = remove(columns)
+public infix operator fun <T> DataFrame<T>.minus(column: AnyColumnReference): DataFrame<T> = remove(column)
+public infix operator fun <T> DataFrame<T>.minus(columns: Iterable<AnyColumnReference>): DataFrame<T> = remove(columns)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.columnName
@@ -13,9 +13,9 @@ import kotlin.reflect.KProperty
 public fun <T> DataFrame<T>.select(columns: ColumnsSelector<T, *>): DataFrame<T> = get(columns).toDataFrame().cast()
 public fun <T> DataFrame<T>.select(vararg columns: KProperty<*>): DataFrame<T> = select(columns.map { it.columnName })
 public fun <T> DataFrame<T>.select(vararg columns: String): DataFrame<T> = select(columns.asIterable())
-public fun <T> DataFrame<T>.select(vararg columns: Column): DataFrame<T> = select { columns.toColumns() }
+public fun <T> DataFrame<T>.select(vararg columns: AnyColumnReference): DataFrame<T> = select { columns.toColumns() }
 @JvmName("selectT")
 public fun <T> DataFrame<T>.select(columns: Iterable<String>): DataFrame<T> = columns.map { get(it) }.toDataFrame().cast()
-public fun <T> DataFrame<T>.select(columns: Iterable<Column>): DataFrame<T> = select { columns.toColumnSet() }
+public fun <T> DataFrame<T>.select(columns: Iterable<AnyColumnReference>): DataFrame<T> = select { columns.toColumnSet() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyBaseCol
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.Column
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -40,7 +40,7 @@ public fun <T> DataFrame<T>.read(vararg columns: String): DataFrame<T> = unfold(
 public fun <T> DataFrame<T>.read(vararg columns: KProperty<*>): DataFrame<T> = unfold(*columns)
 
 @Deprecated("Replaced with `unfold` operation.", ReplaceWith("this.unfold(*columns)"), DeprecationLevel.ERROR)
-public fun <T> DataFrame<T>.read(vararg columns: Column): DataFrame<T> = unfold(*columns)
+public fun <T> DataFrame<T>.read(vararg columns: AnyColumnReference): DataFrame<T> = unfold(*columns)
 
 @JvmName("toDataFrameT")
 public fun <T> Iterable<DataRow<T>>.toDataFrame(): DataFrame<T> {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -25,4 +25,4 @@ public inline fun <reified T> DataColumn<T>.unfold(): AnyCol =
 public fun <T> DataFrame<T>.unfold(columns: ColumnsSelector<T, *>): DataFrame<T> = replace(columns).with { it.unfold() }
 public fun <T> DataFrame<T>.unfold(vararg columns: String): DataFrame<T> = unfold { columns.toColumns() }
 public fun <T> DataFrame<T>.unfold(vararg columns: KProperty<*>): DataFrame<T> = unfold { columns.toColumns() }
-public fun <T> DataFrame<T>.unfold(vararg columns: Column): DataFrame<T> = unfold { columns.toColumns() }
+public fun <T> DataFrame<T>.unfold(vararg columns: AnyColumnReference): DataFrame<T> = unfold { columns.toColumns() }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ungroup.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ungroup.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumns
@@ -15,7 +15,7 @@ public fun <T, C> DataFrame<T>.ungroup(columns: ColumnsSelector<T, C>): DataFram
 }
 
 public fun <T> DataFrame<T>.ungroup(vararg columns: String): DataFrame<T> = ungroup { columns.toColumns() }
-public fun <T> DataFrame<T>.ungroup(vararg columns: Column): DataFrame<T> = ungroup { columns.toColumns() }
+public fun <T> DataFrame<T>.ungroup(vararg columns: AnyColumnReference): DataFrame<T> = ungroup { columns.toColumns() }
 public fun <T> DataFrame<T>.ungroup(vararg columns: KProperty<*>): DataFrame<T> = ungroup { columns.toColumns() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -70,7 +70,7 @@ public fun <T> DataFrame<T>.valueCounts(
     resultColumn: String = defaultCountColumnName
 ): DataFrame<T> = valueCounts(sort, ascending, dropNA, resultColumn) { columns.toColumns() }
 public fun <T> DataFrame<T>.valueCounts(
-    vararg columns: Column,
+    vararg columns: AnyColumnReference,
     sort: Boolean = true,
     ascending: Boolean = false,
     dropNA: Boolean = true,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/values.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/values.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -24,7 +24,7 @@ public fun <T> DataFrame<T>.valuesNotNull(byRow: Boolean = false): Sequence<Any>
 
 // region GroupBy
 
-public fun <T> Grouped<T>.values(vararg columns: Column, dropNA: Boolean = false, distinct: Boolean = false): DataFrame<T> = values(dropNA, distinct) { columns.toColumns() }
+public fun <T> Grouped<T>.values(vararg columns: AnyColumnReference, dropNA: Boolean = false, distinct: Boolean = false): DataFrame<T> = values(dropNA, distinct) { columns.toColumns() }
 public fun <T> Grouped<T>.values(vararg columns: String, dropNA: Boolean = false, distinct: Boolean = false): DataFrame<T> = values(dropNA, distinct) { columns.toColumns() }
 public fun <T> Grouped<T>.values(
     dropNA: Boolean = false,
@@ -40,7 +40,7 @@ public fun <T> Grouped<T>.values(dropNA: Boolean = false, distinct: Boolean = fa
 public fun <T, G> ReducedGroupBy<T, G>.values(): DataFrame<G> = values(groupBy.remainingColumnsSelector())
 
 public fun <T, G> ReducedGroupBy<T, G>.values(
-    vararg columns: Column
+    vararg columns: AnyColumnReference
 ): DataFrame<G> = values { columns.toColumns() }
 
 public fun <T, G> ReducedGroupBy<T, G>.values(
@@ -66,7 +66,7 @@ public fun <T> Pivot<T>.values(
     columns: ColumnsForAggregateSelector<T, *>
 ): DataRow<T> = delegate { values(dropNA, distinct, separate, columns) }
 public fun <T> Pivot<T>.values(
-    vararg columns: Column,
+    vararg columns: AnyColumnReference,
     dropNA: Boolean = false,
     distinct: Boolean = false,
     separate: Boolean = false
@@ -95,7 +95,7 @@ public fun <T> ReducedPivot<T>.values(
 ): DataRow<T> = pivot.delegate { reduce(reducer).values(separate = separate) }
 
 public fun <T> ReducedPivot<T>.values(
-    vararg columns: Column,
+    vararg columns: AnyColumnReference,
     separate: Boolean = false
 ): DataRow<T> = values(separate) { columns.toColumns() }
 
@@ -121,7 +121,7 @@ public fun <T> ReducedPivot<T>.values(
 public fun <T> PivotGroupBy<T>.values(dropNA: Boolean = false, distinct: Boolean = false, separate: Boolean = false): DataFrame<T> = values(dropNA, distinct, separate, remainingColumnsSelector())
 
 public fun <T> PivotGroupBy<T>.values(
-    vararg columns: Column,
+    vararg columns: AnyColumnReference,
     dropNA: Boolean = false,
     distinct: Boolean = false,
     separate: Boolean = false
@@ -155,7 +155,7 @@ public fun <T> ReducedPivotGroupBy<T>.values(
 ): DataFrame<T> = values(separate, pivot.remainingColumnsSelector())
 
 public fun <T> ReducedPivotGroupBy<T>.values(
-    vararg columns: Column,
+    vararg columns: AnyColumnReference,
     separate: Boolean = false
 ): DataFrame<T> = values(separate) { columns.toColumns() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/with.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/with.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
@@ -37,7 +37,7 @@ public inline fun <T, reified V> ReducedPivotGroupBy<T>.with(noinline expression
     return pivot.aggregate {
         val value = reducer(this)?.let {
             val value = expression(it, it)
-            if (value is Column) it[value]
+            if (value is AnyColumnReference) it[value]
             else value
         }
         internal().yield(emptyPath(), value, type)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregations.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregations.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
@@ -90,7 +90,7 @@ internal fun <T, C> AggregateInternalDsl<T>.columnValues(
 internal fun <T, V> AggregateInternalDsl<T>.withExpr(type: KType, path: ColumnPath, expression: RowExpression<T, V>) {
     val values = df.rows().map {
         val value = expression(it, it)
-        if (value is Column) it[value]
+        if (value is AnyColumnReference) it[value]
         else value
     }
     yieldOneOrMany(path, values, type)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/move.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/move.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
-import org.jetbrains.kotlinx.dataframe.Column
+import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -43,7 +43,7 @@ internal fun <T, C> MoveClause<T, C>.afterOrBefore(column: ColumnSelector<T, *>,
 
 internal fun <T, C> MoveClause<T, C>.moveImpl(
     under: Boolean = false,
-    newPathExpression: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> Column
+    newPathExpression: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> AnyColumnReference
 ): DataFrame<T> {
     val receiver = object : DataFrameReceiver<T>(df, UnresolvedColumnsPolicy.Fail), ColumnsSelectionDsl<T> {}
     val removeResult = df.removeImpl(columns = columns)


### PR DESCRIPTION
Since all type aliases with a `*` are called `AnySomething`, it felt odd to have `ColumnReference<*>` be called `Column`. This insinuates that it is a Column object instance, which is not the case. `AnyColumnReference` (or a variant of that) seems more in line with the other aliases.