### PR TITLE
[Fix] Update.asFrame now takes filter into account.

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.RowValueExpression
 import org.jetbrains.kotlinx.dataframe.RowValueFilter
 import org.jetbrains.kotlinx.dataframe.Selector
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
+import org.jetbrains.kotlinx.dataframe.impl.api.asFrameImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.updateImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.updateWithValuePerColumnImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnSet
@@ -57,7 +58,7 @@ public infix fun <T, C> Update<T, C>.with(expression: UpdateExpression<T, C, C?>
     }
 
 public infix fun <T, C, R> Update<T, DataRow<C>>.asFrame(expression: DataFrameExpression<C, DataFrame<R>>): DataFrame<T> =
-    df.replace(columns).with { it.asColumnGroup().let { expression(it, it) }.asColumnGroup(it.name()) }
+    asFrameImpl(expression)
 
 public fun <T, C> Update<T, C>.asNullable(): Update<T, C?> = this as Update<T, C?>
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -16,26 +16,26 @@ class UpdateTests {
     }
 
     @DataSchema
-    interface AAndB {
+    interface DataPart {
         val a: Int
         val b: String
     }
 
     @DataSchema
-    data class Update(
+    data class Data(
         override val a: Int,
         override val b: String,
         val c: Boolean,
-    ) : AAndB
+    ) : DataPart
 
     @Test
     fun `update asFrame`() {
         val df = listOf(
-            Update(1, "a", true),
-            Update(2, "b", false),
+            Data(1, "a", true),
+            Data(2, "b", false),
         ).toDataFrame()
 
-        val group by columnGroup<AAndB>() named "Some Group"
+        val group by columnGroup<DataPart>() named "Some Group"
         val groupedDf = df.group { a and b }.into { group }
 
         val res = groupedDf


### PR DESCRIPTION
Fix for https://github.com/Kotlin/dataframe/issues/280.

Similar to `Update.perCol {}`, in the body of `asFrame`, users will have access to the entire selected group column (treated as a DF), but now the result of the operation will only be applied to rows that satisfy a given `where/at` clause of the `update` call chain.

See the new test for an example.