### PR TITLE
Improve experience with HTML rendering of dataframes

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -12,11 +12,11 @@ import org.jetbrains.kotlinx.dataframe.impl.api.SingleAttribute
 import org.jetbrains.kotlinx.dataframe.impl.api.encode
 import org.jetbrains.kotlinx.dataframe.impl.api.formatImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.linearGradient
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import kotlin.reflect.KProperty
-import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 
 // region DataFrame
 

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -14,8 +14,9 @@ import org.jetbrains.kotlinx.dataframe.impl.api.formatImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.linearGradient
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.io.toHTML
-import org.jetbrains.kotlinx.jupyter.api.HtmlData
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import kotlin.reflect.KProperty
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 
 // region DataFrame
 
@@ -98,7 +99,19 @@ public class FormattedFrame<T>(
     internal val df: DataFrame<T>,
     internal val formatter: RowColFormatter<T, *>? = null,
 ) {
-    public fun toHTML(configuration: DisplayConfiguration): HtmlData = df.toHTML(getDisplayConfiguration(configuration))
+    /**
+     * @return DataFrameHtmlData without additional definitions. Can be rendered in Jupyter kernel environments
+     */
+    public fun toHTML(configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT): DataFrameHtmlData {
+        return df.toHTML(getDisplayConfiguration(configuration))
+    }
+
+    /**
+     * @return DataFrameHtmlData with table script and css definitions. Can be saved as an *.html file and displayed in the browser
+     */
+    public fun toStandaloneHTML(configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT): DataFrameHtmlData {
+        return df.toStandaloneHTML(getDisplayConfiguration(configuration))
+    }
 
     public fun getDisplayConfiguration(configuration: DisplayConfiguration): DisplayConfiguration {
         return configuration.copy(cellFormatter = formatter as RowColFormatter<*, *>?)

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -17,10 +17,10 @@ import org.jetbrains.kotlinx.dataframe.impl.codeGen.CodeGenerationReadResult
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.urlCodeGenReader
 import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
 import org.jetbrains.kotlinx.dataframe.impl.renderType
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 import org.jetbrains.kotlinx.dataframe.io.SupportedCodeGenerationFormat
 import org.jetbrains.kotlinx.dataframe.io.supportedFormats
 import org.jetbrains.kotlinx.jupyter.api.HTML
-import org.jetbrains.kotlinx.jupyter.api.HtmlData
 import org.jetbrains.kotlinx.jupyter.api.JupyterClientType
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 import org.jetbrains.kotlinx.jupyter.api.Notebook
@@ -29,7 +29,6 @@ import org.jetbrains.kotlinx.jupyter.api.declare
 import org.jetbrains.kotlinx.jupyter.api.libraries.ColorScheme
 import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 import org.jetbrains.kotlinx.jupyter.api.libraries.resources
-import org.jetbrains.kotlinx.jupyter.api.renderHtmlAsIFrameIfNeeded
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.isSubtypeOf
@@ -95,7 +94,14 @@ internal class Integration(
                 applyRowsLimit = false
             )
 
-            render<HtmlData> { notebook.renderHtmlAsIFrameIfNeeded(it) }
+            render<DataFrameHtmlData> {
+                if (notebook.jupyterClientType == JupyterClientType.KOTLIN_NOTEBOOK) {
+                    (it.withTableDefinitions().toJupyterHtmlData()).toIFrame(notebook.currentColorScheme)
+                } else {
+                    it.toJupyterHtmlData().toSimpleHtml(notebook.currentColorScheme)
+                }
+            }
+
             render<AnyRow>(
                 { "DataRow: index = ${it.index()}, columnsCount = ${it.columnsCount()}" },
             )

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -95,8 +95,10 @@ internal class Integration(
             )
 
             render<DataFrameHtmlData> {
+                // Our integration declares script and css definition. But in Kotlin Notebook outputs are isolated in IFrames
+                // That's why we include them directly in the output
                 if (notebook.jupyterClientType == JupyterClientType.KOTLIN_NOTEBOOK) {
-                    (it.withTableDefinitions().toJupyterHtmlData()).toIFrame(notebook.currentColorScheme)
+                    it.withTableDefinitions().toJupyterHtmlData().toIFrame(notebook.currentColorScheme)
                 } else {
                     it.toJupyterHtmlData().toSimpleHtml(notebook.currentColorScheme)
                 }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
@@ -1,15 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.rendering.html
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.io.initHtml
-import org.jetbrains.kotlinx.dataframe.io.toHTML
-import java.awt.Desktop
-import java.io.File
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 
 fun AnyFrame.browse() {
-    val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-    file.writeText(toHTML(extraHtml = initHtml()).toString())
-    val uri = file.toURI()
-    val desktop = Desktop.getDesktop()
-    desktop.browse(uri)
+    toStandaloneHTML().openInBrowser()
 }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
@@ -1,0 +1,43 @@
+package org.jetbrains.kotlinx.dataframe.samples.api
+
+import java.io.File
+import kotlin.io.path.Path
+import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
+import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.sortByDesc
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
+import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
+import org.jetbrains.kotlinx.dataframe.io.toHTML
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
+import org.junit.Ignore
+import org.junit.Test
+
+class Render : TestBase() {
+    @Test
+    @Ignore
+    fun useRenderingResult() {
+        // SampleStart
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).openInBrowser()
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(File("/path/to/file"))
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(Path("/path/to/file"))
+        // SampleEnd
+    }
+
+    @Test
+    fun composeTables() {
+        // SampleStart
+        val df1 = df.reorderColumnsByName()
+        val df2 = df.sortBy { age }
+        val df3 = df.sortByDesc { age }
+
+        listOf(df1, df2, df3).fold(DataFrameHtmlData.tableDefinitions()) { acc, df -> acc + df.toHTML() }
+        // SampleEnd
+    }
+
+    @Test
+    fun configureCellOutput() {
+        // SampleStart
+        df.toHTML(DisplayConfiguration(cellContentLimit = -1))
+        // SampleEnd
+    }
+}

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.samples.api
 
-import java.io.File
-import kotlin.io.path.Path
 import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.sortByDesc
@@ -11,6 +9,8 @@ import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.junit.Ignore
 import org.junit.Test
+import java.io.File
+import kotlin.io.path.Path
 
 class Render : TestBase() {
     @Test

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
@@ -7,9 +7,7 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.group
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.parse
-import org.jetbrains.kotlinx.dataframe.io.html
-import org.jetbrains.kotlinx.dataframe.io.initHtml
-import org.jetbrains.kotlinx.dataframe.io.toHTML
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.jetbrains.kotlinx.jupyter.findNthSubstring
 import org.junit.Ignore
 import org.junit.Test
@@ -20,7 +18,7 @@ class HtmlRenderingTests : BaseTest() {
 
     fun AnyFrame.browse() {
         val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-        file.writeText(toHTML(extraHtml = initHtml()).toString())
+        file.writeText(toStandaloneHTML().toString())
         val uri = file.toURI()
         val desktop = Desktop.getDesktop()
         desktop.browse(uri)
@@ -36,7 +34,7 @@ class HtmlRenderingTests : BaseTest() {
     fun `render url`() {
         val address = "http://www.google.com"
         val df = dataFrameOf("url")(address).parse()
-        val html = df.html()
+        val html = df.toStandaloneHTML().toString()
         html shouldContain "href"
         html.findNthSubstring(address, 2) shouldNotBe -1
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dataframe.impl.api.formatImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.linearGradient
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.io.toHTML
-import org.jetbrains.kotlinx.jupyter.api.HtmlData
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import kotlin.reflect.KProperty
 
 // region DataFrame
@@ -98,7 +98,19 @@ public class FormattedFrame<T>(
     internal val df: DataFrame<T>,
     internal val formatter: RowColFormatter<T, *>? = null,
 ) {
-    public fun toHTML(configuration: DisplayConfiguration): HtmlData = df.toHTML(getDisplayConfiguration(configuration))
+    /**
+     * @return DataFrameHtmlData without additional definitions. Can be rendered in Jupyter kernel environments
+     */
+    public fun toHTML(configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT): DataFrameHtmlData {
+        return df.toHTML(getDisplayConfiguration(configuration))
+    }
+
+    /**
+     * @return DataFrameHtmlData with table script and css definitions. Can be saved as an *.html file and displayed in the browser
+     */
+    public fun toStandaloneHTML(configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT): DataFrameHtmlData {
+        return df.toStandaloneHTML(getDisplayConfiguration(configuration))
+    }
 
     public fun getDisplayConfiguration(configuration: DisplayConfiguration): DisplayConfiguration {
         return configuration.copy(cellFormatter = formatter as RowColFormatter<*, *>?)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -12,11 +12,11 @@ import org.jetbrains.kotlinx.dataframe.impl.api.SingleAttribute
 import org.jetbrains.kotlinx.dataframe.impl.api.encode
 import org.jetbrains.kotlinx.dataframe.impl.api.formatImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.linearGradient
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import kotlin.reflect.KProperty
-import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 
 // region DataFrame
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import kotlin.reflect.KProperty
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 
 // region DataFrame
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
@@ -21,7 +22,8 @@ import org.jetbrains.kotlinx.dataframe.jupyter.RenderedContent
 import org.jetbrains.kotlinx.dataframe.name
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.size
-import org.jetbrains.kotlinx.jupyter.api.HtmlData
+import java.awt.Desktop
+import java.io.File
 import java.io.InputStreamReader
 import java.net.URL
 import java.util.LinkedList
@@ -116,7 +118,7 @@ internal fun nextTableId() = sessionId + (tableInSessionId++)
 internal fun AnyFrame.toHtmlData(
     configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,
     cellRenderer: CellRenderer,
-): HtmlData {
+): DataFrameHtmlData {
     val scripts = mutableListOf<String>()
     val queue = LinkedList<Pair<AnyFrame, Int>>()
 
@@ -165,40 +167,31 @@ internal fun AnyFrame.toHtmlData(
     }
     val body = getResourceText("/table.html", "ID" to rootId)
     val script = scripts.joinToString("\n") + "\n" + getResourceText("/renderTable.js", "___ID___" to rootId)
-    return HtmlData("", body, script)
+    return DataFrameHtmlData("", body, script)
 }
 
-internal fun HtmlData.print() = println(this)
+internal fun DataFrameHtmlData.print() = println(this)
 
-internal fun initHtml(
-    includeJs: Boolean = true,
-    includeCss: Boolean = true,
-    useDarkColorScheme: Boolean = false,
-): HtmlData =
-    HtmlData(
-        style = if (includeCss) getResources("/table.css") else "",
-        script = if (includeJs) getResourceText("/init.js") else "",
-        body = "",
-    )
-
-@Deprecated("Clarify difference with .toHTML()", ReplaceWith("this.toStandaloneHTML()", "org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML"))
-public fun <T> DataFrame<T>.html(): String = toHTML(extraHtml = initHtml()).toString()
+@Deprecated("Clarify difference with .toHTML()", ReplaceWith("this.toStandaloneHTML().toString()", "org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML"))
+public fun <T> DataFrame<T>.html(): String = toStandaloneHTML().toString()
 
 /**
- * @return HTML String that be saved as an *.html file and displayed in the browser
+ * @return DataFrameHtmlData with table script and css definitions. Can be saved as an *.html file and displayed in the browser
  */
 public fun <T> DataFrame<T>.toStandaloneHTML(
     configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,
     cellRenderer: CellRenderer = org.jetbrains.kotlinx.dataframe.jupyter.DefaultCellRenderer,
     getFooter: (DataFrame<T>) -> String = { "DataFrame [${it.size}]" },
-): String = toHTML(configuration, extraHtml = initHtml(), cellRenderer, getFooter).toString()
+): DataFrameHtmlData = toHTML(configuration, cellRenderer, getFooter).withTableDefinitions()
 
+/**
+ * @return DataFrameHtmlData without additional definitions. Can be rendered in Jupyter kernel environments
+ */
 public fun <T> DataFrame<T>.toHTML(
     configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,
-    extraHtml: HtmlData? = null,
     cellRenderer: CellRenderer = org.jetbrains.kotlinx.dataframe.jupyter.DefaultCellRenderer,
     getFooter: (DataFrame<T>) -> String = { "DataFrame [${it.size}]" },
-): HtmlData {
+): DataFrameHtmlData {
     val limit = configuration.rowsLimit ?: Int.MAX_VALUE
 
     val footer = getFooter(this)
@@ -214,9 +207,65 @@ public fun <T> DataFrame<T>.toHTML(
     }
 
     val tableHtml = toHtmlData(configuration, cellRenderer)
-    val html = tableHtml + HtmlData("", bodyFooter, "")
 
-    return if (extraHtml != null) extraHtml + html else html
+    return tableHtml + DataFrameHtmlData("", bodyFooter, "")
+}
+
+public data class DataFrameHtmlData(val style: String, val body: String, val script: String) {
+    @Language("html")
+    override fun toString(): String = """
+        <html>
+        <head>
+            <style type="text/css">
+                $style
+            </style>
+        </head>
+        <body>
+            $body
+        </body>
+        <script>
+            $script
+        </script>
+        </html>
+    """.trimIndent()
+
+    public operator fun plus(other: DataFrameHtmlData): DataFrameHtmlData =
+        DataFrameHtmlData(
+            style + "\n" + other.style,
+            body + "\n" + other.body,
+            script + "\n" + other.script,
+        )
+
+    public fun writeHTML(destination: File) {
+        destination.writeText(toString())
+    }
+
+    public fun openInBrowser() {
+        val file = File.createTempFile("df_rendering", ".html")
+        writeHTML(file)
+        val uri = file.toURI()
+        val desktop = Desktop.getDesktop()
+        desktop.browse(uri)
+    }
+
+    public fun withTableDefinitions(): DataFrameHtmlData = tableDefinitions() + this
+
+    public companion object {
+        /**
+         * @return CSS and JS required to render DataFrame tables
+         * Can be used as a starting point to create page with multiple tables
+         * @see DataFrame.toHTML
+         * @see DataFrameHtmlData.plus
+         */
+        public fun tableDefinitions(
+            includeJs: Boolean = true,
+            includeCss: Boolean = true,
+        ): DataFrameHtmlData = DataFrameHtmlData(
+            style = if (includeCss) getResources("/table.css") else "",
+            script = if (includeJs) getResourceText("/init.js") else "",
+            body = "",
+        )
+    }
 }
 
 public data class DisplayConfiguration(
@@ -462,7 +511,7 @@ internal class DataFrameFormatter(
                 "</a>"
             )
 
-            is HtmlData -> RenderedContent.text(value.body)
+            is DataFrameHtmlData -> RenderedContent.text(value.body)
             else -> renderer.content(value, configuration)
         }
         if (result != null && result.textLength > configuration.cellContentLimit) return null

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -181,7 +181,17 @@ internal fun initHtml(
         body = "",
     )
 
+@Deprecated("Clarify difference with .toHTML()", ReplaceWith("this.toStandaloneHTML()", "org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML"))
 public fun <T> DataFrame<T>.html(): String = toHTML(extraHtml = initHtml()).toString()
+
+/**
+ * @return HTML String that be saved as an *.html file and displayed in the browser
+ */
+public fun <T> DataFrame<T>.toStandaloneHTML(
+    configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,
+    cellRenderer: CellRenderer = org.jetbrains.kotlinx.dataframe.jupyter.DefaultCellRenderer,
+    getFooter: (DataFrame<T>) -> String = { "DataFrame [${it.size}]" },
+): String = toHTML(configuration, extraHtml = initHtml(), cellRenderer, getFooter).toString()
 
 public fun <T> DataFrame<T>.toHTML(
     configuration: DisplayConfiguration = DisplayConfiguration.DEFAULT,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -26,8 +26,10 @@ import java.awt.Desktop
 import java.io.File
 import java.io.InputStreamReader
 import java.net.URL
+import java.nio.file.Path
 import java.util.LinkedList
 import java.util.Random
+import kotlin.io.path.writeText
 
 internal val tooltipLimit = 1000
 
@@ -241,6 +243,10 @@ public data class DataFrameHtmlData(val style: String = "", val body: String = "
         )
 
     public fun writeHTML(destination: File) {
+        destination.writeText(toString())
+    }
+
+    public fun writeHTML(destination: Path) {
         destination.writeText(toString())
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -211,7 +211,11 @@ public fun <T> DataFrame<T>.toHTML(
     return tableHtml + DataFrameHtmlData("", bodyFooter, "")
 }
 
-public data class DataFrameHtmlData(val style: String, val body: String, val script: String) {
+/**
+ * Container for HTML page data in form of String
+ * Can be used to compose rendered dataframe tables with additional HTML elements
+ */
+public data class DataFrameHtmlData(val style: String = "", val body: String = "", val script: String = "") {
     @Language("html")
     override fun toString(): String = """
         <html>
@@ -268,6 +272,10 @@ public data class DataFrameHtmlData(val style: String, val body: String, val scr
     }
 }
 
+/**
+ * @param rowsLimit null to disable rows limit
+ * @param cellContentLimit -1 to disable content trimming
+ */
 public data class DisplayConfiguration(
     var rowsLimit: Int? = 20,
     var nestedRowsLimit: Int? = 5,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -17,10 +17,10 @@ import org.jetbrains.kotlinx.dataframe.impl.codeGen.CodeGenerationReadResult
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.urlCodeGenReader
 import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
 import org.jetbrains.kotlinx.dataframe.impl.renderType
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
 import org.jetbrains.kotlinx.dataframe.io.SupportedCodeGenerationFormat
 import org.jetbrains.kotlinx.dataframe.io.supportedFormats
 import org.jetbrains.kotlinx.jupyter.api.HTML
-import org.jetbrains.kotlinx.jupyter.api.HtmlData
 import org.jetbrains.kotlinx.jupyter.api.JupyterClientType
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 import org.jetbrains.kotlinx.jupyter.api.Notebook
@@ -29,7 +29,6 @@ import org.jetbrains.kotlinx.jupyter.api.declare
 import org.jetbrains.kotlinx.jupyter.api.libraries.ColorScheme
 import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 import org.jetbrains.kotlinx.jupyter.api.libraries.resources
-import org.jetbrains.kotlinx.jupyter.api.renderHtmlAsIFrameIfNeeded
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.isSubtypeOf
@@ -95,7 +94,14 @@ internal class Integration(
                 applyRowsLimit = false
             )
 
-            render<HtmlData> { notebook.renderHtmlAsIFrameIfNeeded(it) }
+            render<DataFrameHtmlData> {
+                if (notebook.jupyterClientType == JupyterClientType.KOTLIN_NOTEBOOK) {
+                    (it.withTableDefinitions().toJupyterHtmlData()).toIFrame(notebook.currentColorScheme)
+                } else {
+                    it.toJupyterHtmlData().toSimpleHtml(notebook.currentColorScheme)
+                }
+            }
+
             render<AnyRow>(
                 { "DataRow: index = ${it.index()}, columnsCount = ${it.columnsCount()}" },
             )

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -95,8 +95,10 @@ internal class Integration(
             )
 
             render<DataFrameHtmlData> {
+                // Our integration declares script and css definition. But in Kotlin Notebook outputs are isolated in IFrames
+                // That's why we include them directly in the output
                 if (notebook.jupyterClientType == JupyterClientType.KOTLIN_NOTEBOOK) {
-                    (it.withTableDefinitions().toJupyterHtmlData()).toIFrame(notebook.currentColorScheme)
+                    it.withTableDefinitions().toJupyterHtmlData().toIFrame(notebook.currentColorScheme)
                 } else {
                     it.toJupyterHtmlData().toSimpleHtml(notebook.currentColorScheme)
                 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/html/Utils.kt
@@ -1,15 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.rendering.html
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.io.initHtml
-import org.jetbrains.kotlinx.dataframe.io.toHTML
-import java.awt.Desktop
-import java.io.File
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 
 fun AnyFrame.browse() {
-    val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-    file.writeText(toHTML(extraHtml = initHtml()).toString())
-    val uri = file.toURI()
-    val desktop = Desktop.getDesktop()
-    desktop.browse(uri)
+    toStandaloneHTML().openInBrowser()
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.kotlinx.dataframe.samples.api
+
+import java.io.File
+import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
+import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.sortByDesc
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
+import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
+import org.jetbrains.kotlinx.dataframe.io.toHTML
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
+import org.junit.Ignore
+import org.junit.Test
+
+class Render : TestBase() {
+    @Test
+    @Ignore
+    fun useRenderingResult() {
+        // SampleStart
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).openInBrowser()
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(File("/path/to/file"))
+        // SampleEnd
+    }
+
+    @Test
+    fun composeTables() {
+        // SampleStart
+        val df1 = df.reorderColumnsByName()
+        val df2 = df.sortBy { age }
+        val df3 = df.sortByDesc { age }
+
+        listOf(df1, df2, df3).fold(DataFrameHtmlData.tableDefinitions()) { acc, df -> acc + df.toHTML() }
+        // SampleEnd
+    }
+
+    @Test
+    fun configureCellOutput() {
+        // SampleStart
+        df.toHTML(DisplayConfiguration(cellContentLimit = -1))
+        // SampleEnd
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.samples.api
 
 import java.io.File
+import kotlin.io.path.Path
 import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.sortByDesc
@@ -18,6 +19,7 @@ class Render : TestBase() {
         // SampleStart
         df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).openInBrowser()
         df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(File("/path/to/file"))
+        df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(Path("/path/to/file"))
         // SampleEnd
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Render.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.samples.api
 
-import java.io.File
-import kotlin.io.path.Path
 import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.sortByDesc
@@ -11,6 +9,8 @@ import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.junit.Ignore
 import org.junit.Test
+import java.io.File
+import kotlin.io.path.Path
 
 class Render : TestBase() {
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
@@ -7,9 +7,9 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.group
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.parse
-import org.jetbrains.kotlinx.dataframe.io.html
 import org.jetbrains.kotlinx.dataframe.io.initHtml
 import org.jetbrains.kotlinx.dataframe.io.toHTML
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.jetbrains.kotlinx.jupyter.findNthSubstring
 import org.junit.Ignore
 import org.junit.Test
@@ -36,7 +36,7 @@ class HtmlRenderingTests : BaseTest() {
     fun `render url`() {
         val address = "http://www.google.com"
         val df = dataFrameOf("url")(address).parse()
-        val html = df.html()
+        val html = df.toStandaloneHTML()
         html shouldContain "href"
         html.findNthSubstring(address, 2) shouldNotBe -1
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/HtmlRenderingTests.kt
@@ -7,8 +7,6 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.group
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.parse
-import org.jetbrains.kotlinx.dataframe.io.initHtml
-import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.jetbrains.kotlinx.jupyter.findNthSubstring
 import org.junit.Ignore
@@ -20,7 +18,7 @@ class HtmlRenderingTests : BaseTest() {
 
     fun AnyFrame.browse() {
         val file = File("temp.html") // File.createTempFile("df_rendering", ".html")
-        file.writeText(toHTML(extraHtml = initHtml()).toString())
+        file.writeText(toStandaloneHTML().toString())
         val uri = file.toURI()
         val desktop = Desktop.getDesktop()
         desktop.browse(uri)
@@ -36,7 +34,7 @@ class HtmlRenderingTests : BaseTest() {
     fun `render url`() {
         val address = "http://www.google.com"
         val df = dataFrameOf("url")(address).parse()
-        val html = df.toStandaloneHTML()
+        val html = df.toStandaloneHTML().toString()
         html shouldContain "href"
         html.findNthSubstring(address, 2) shouldNotBe -1
     }

--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -169,7 +169,9 @@
             <toc-element topic="toMap.md"/>
         </toc-element>
         <toc-element topic="rendering.md">
+            <toc-element topic="toHTML.md"/>
             <toc-element topic="format.md"/>
+            <toc-element topic="jupyterRendering.md"/>
         </toc-element>
     </toc-element>
     <toc-element topic="gradleReference.md"/>

--- a/docs/StardustDocs/topics/jupyterRendering.md
+++ b/docs/StardustDocs/topics/jupyterRendering.md
@@ -1,0 +1,13 @@
+[//]: # (title: Jupyter Notebooks)
+
+Rendering in Jupyter Notebooks can be configured using `dataFrameConfig.display` value.
+Have a look at [toHTML](toHTML.md#configuring-display-for-individual-output) function to configure output for single cell
+
+### Content limit length
+
+Content in each cell gets truncated to 40 characters by default.
+This can be changed by setting `cellContentLimit` to a different value on the display configuration.
+
+```kotlin
+dataFrameConfig.display.cellContentLimit = 100
+```

--- a/docs/StardustDocs/topics/rendering.md
+++ b/docs/StardustDocs/topics/rendering.md
@@ -1,16 +1,6 @@
 [//]: # (title: Rendering)
 
-// TODO
+This section describes APIs that you can use to render DataFrame types and configure display.
 
-## Jupyter Notebooks
-
-Rendering in Jupyter Notebooks can be configured using `dataFrameConfig.display` value.
-
-### Content limit length
-
-Content in each cell gets truncated to 40 characters by default. 
-This can be changed by setting `cellContentLimit` to a different value on the display configuration.
-
-```kotlin
-dataFrameConfig.display.cellContentLimit = 100
-```
+* [`toHTML`](toHTML.md) — operation for rendering DataFrame object to an HTML table
+* [`Jupyter Notebooks`](jupyterRendering.md) — configuration specific to notebook environments

--- a/docs/StardustDocs/topics/toHTML.md
+++ b/docs/StardustDocs/topics/toHTML.md
@@ -12,7 +12,7 @@ Depending on your environment there can be different ways to use result of `toHT
 
 ### Working with result
 
-Following function produces HTML that includes JS and CSS definitions. It can be displayed in the browser and has parameters for customization.
+The following function produces HTML that includes JS and CSS definitions. It can be displayed in the browser and has parameters for customization.
 
 <!---FUN useRenderingResult-->
 
@@ -26,7 +26,7 @@ df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(Path("/pat
 
 ### Composing multiple tables
 
-`toHTML` and `toStandaloneHTML` return composable `DataFrameHtmlData`. You can use it to include additional scripts, elements, styles on final page or just merge together multiple tables
+`toHTML` and `toStandaloneHTML` return composable `DataFrameHtmlData`. You can use it to include additional scripts, elements, styles on final page or just merge together multiple tables.
 
 <!---FUN composeTables-->
 
@@ -44,7 +44,7 @@ listOf(df1, df2, df3).fold(DataFrameHtmlData.tableDefinitions()) { acc, df -> ac
 
 ### Configuring display for individual output
 
-`toHTML` is useful if you want to configure display for single cell, not whole notebook as described in section for [Jupyter Notebooks](jupyterRendering.md)
+`toHTML` is useful if you want to configure how a single cell is displayed. To configure the display for the entire notebook, please refer to [Jupyter Notebooks](jupyterRendering.md) section.
 
 <!---FUN configureCellOutput-->
 

--- a/docs/StardustDocs/topics/toHTML.md
+++ b/docs/StardustDocs/topics/toHTML.md
@@ -1,0 +1,56 @@
+[//]: # (title: toHTML)
+
+<!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Render-->
+
+DataFrame can be rendered to HTML.
+Rendering of hierarchical tables in HTML is supported by JS and CSS definitions
+that can be found in project resources.
+
+Depending on your environment there can be different ways to use result of `toHTML` functions
+
+## IntelliJ IDEA
+
+### Working with result
+
+Following function produces HTML that includes JS and CSS definitions. It can be displayed in the browser and has parameters for customization.
+
+<!---FUN useRenderingResult-->
+
+```kotlin
+df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).openInBrowser()
+df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(File("/path/to/file"))
+```
+
+<!---END-->
+
+### Composing multiple tables
+
+`toHTML` and `toStandaloneHTML` return composable `DataFrameHtmlData`. You can use it to include additional scripts, elements, styles on final page or just merge together multiple tables
+
+<!---FUN composeTables-->
+
+```kotlin
+val df1 = df.reorderColumnsByName()
+val df2 = df.sortBy { age }
+val df3 = df.sortByDesc { age }
+
+listOf(df1, df2, df3).fold(DataFrameHtmlData.tableDefinitions()) { acc, df -> acc + df.toHTML() }
+```
+
+<!---END-->
+
+## Jupyter Notebooks
+
+### Configuring display for individual output
+
+`toHTML` is useful if you want to configure display for single cell, not whole notebook as described in section for [Jupyter Notebooks](jupyterRendering.md)
+
+<!---FUN configureCellOutput-->
+
+```kotlin
+df.toHTML(DisplayConfiguration(cellContentLimit = -1))
+```
+
+<!---END-->
+
+

--- a/docs/StardustDocs/topics/toHTML.md
+++ b/docs/StardustDocs/topics/toHTML.md
@@ -19,6 +19,7 @@ Following function produces HTML that includes JS and CSS definitions. It can be
 ```kotlin
 df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).openInBrowser()
 df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(File("/path/to/file"))
+df.toStandaloneHTML(DisplayConfiguration(rowsLimit = null)).writeHTML(Path("/path/to/file"))
 ```
 
 <!---END-->


### PR DESCRIPTION
In this PR i'll to address issues that exist with our HTML rendering
1. It wasn't possible to render DataFrame so that it can be rendered in the browser (initHtml is an internal function, and it's not clear what it does)
2. We lack documentation for custom-rendering-in-Jupyter use-case
3. It exposes HtmlData class that is not a part of our API
4. ...? 