### PR TITLE
[Bug fix] "SyntaxError: Invalid hexadecimal escape sequence" for rendering DataFrames with "\" in content

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/html.kt
@@ -261,7 +261,7 @@ internal fun String.escapeHTML(): String {
     val str = this
     return buildString {
         for (c in str) {
-            if (c.code > 127 || c == '"' || c == '\'' || c == '<' || c == '>' || c == '&') {
+            if (c.code > 127 || c == '"' || c == '\'' || c == '<' || c == '>' || c == '&' || c == '\\') {
                 append("&#")
                 append(c.code)
                 append(';')

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
@@ -57,6 +57,13 @@ class RenderingTests {
     }
 
     @Test
+    fun unicodeEscapeSequencesAreEscaped() {
+        val df = dataFrameOf("content")("""Hello\nfrom \x and \y""")
+        val html = df.toHTML().toString()
+        html shouldContain "Hello&#92;nfrom &#92;x and &#92;y"
+    }
+
+    @Test
     fun `long text is trimmed without escaping`() {
         val df = dataFrameOf("text")("asdfkjasdlkjfhasljkddasdasdasdasdasdasdhf")
         val html = df.toHTML().toString()


### PR DESCRIPTION
Fixed bug where reading attached file using `DataFrame.read("bug.csv")` and rendering in notebooks would result in no rendering at all. This was caused by a "\x" not being escaped and considered an "Invalid hexadecimal escape sequence". This fix replaces "\" characters with proper hex codes.

[bug.csv](https://github.com/Kotlin/dataframe/files/10991059/bug.csv)
