### PR TITLE
Set logging to QUIET for generateDataFrameXXX tasks

### DIFF
--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
@@ -4,6 +4,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.services.DefaultLoggingManager
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -103,6 +105,7 @@ class SchemaGeneratorPlugin : Plugin<Project> {
         val delimiters = schema.withNormalizationBy ?: extension.withNormalizationBy ?: setOf('\t', ' ', '_')
 
         return target.tasks.create("generateDataFrame${interfaceName}", GenerateDataSchemaTask::class.java) {
+            (logging as? DefaultLoggingManager)?.setLevelInternal(LogLevel.QUIET)
             group = GROUP
             data.set(schema.data)
             this.interfaceName.set(interfaceName)


### PR DESCRIPTION
Set logging to QUIET for generateDataFrameXXX tasks in an attempt to shut up swagger parser errors.

Note: This does also disable logs for the WARNING level and lower in this task. Currently I haven't figured out a way yet to only disable logs for a certain package.


Potential fix for https://github.com/Kotlin/dataframe/issues/262