### PR TITLE
Overload toDataFrame for basic types to avoid surprising results

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
 import org.jetbrains.kotlinx.dataframe.impl.api.createDataFrameImpl
@@ -186,6 +187,83 @@ public abstract class CreateDataFrameDsl<T> : TraversePropertiesDsl {
 }
 
 // endregion
+
+// region toDataFrame overloads for built-in types
+
+/*
+Without overloads Iterable<String>.toDataFrame produces unexpected result
+
+
+```
+val string = listOf("aaa", "aa", null)
+string.toDataFrame()
+```
+=>
+  length
+0    3
+1    2
+2 null
+ */
+
+@JvmName("toDataFrameByte")
+public inline fun <reified B : Byte?> Iterable<B>.toDataFrame(): DataFrame<OfSingleValueColumn<B>> = toDataFrame {
+    OfSingleValueColumn<B>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameShort")
+public inline fun <reified S : Short?> Iterable<S>.toDataFrame(): DataFrame<OfSingleValueColumn<S>> = toDataFrame {
+    OfSingleValueColumn<S>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameInt")
+public inline fun <reified I : Int?> Iterable<I>.toDataFrame(): DataFrame<OfSingleValueColumn<I>> = toDataFrame {
+    OfSingleValueColumn<I>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameLong")
+public inline fun <reified L : Long?> Iterable<L>.toDataFrame(): DataFrame<OfSingleValueColumn<L>> = toDataFrame {
+    OfSingleValueColumn<L>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameString")
+public inline fun <reified S : String?> Iterable<S>.toDataFrame(): DataFrame<OfSingleValueColumn<S>> = toDataFrame {
+    OfSingleValueColumn<S>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameChar")
+public inline fun <reified C : Char?> Iterable<C>.toDataFrame(): DataFrame<OfSingleValueColumn<C>> = toDataFrame {
+    OfSingleValueColumn<C>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameBoolean")
+public inline fun <reified B : Boolean?> Iterable<B>.toDataFrame(): DataFrame<OfSingleValueColumn<B>> = toDataFrame {
+    OfSingleValueColumn<B>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameUByte")
+public inline fun <reified U : UByte?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
+    OfSingleValueColumn<U>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameUShort")
+public inline fun <reified U : UShort?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
+    OfSingleValueColumn<U>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameUInt")
+public inline fun <reified U : UInt?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
+    OfSingleValueColumn<U>::value from { it }
+}.cast()
+
+@JvmName("toDataFrameULong")
+public inline fun <reified U : ULong?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
+    OfSingleValueColumn<U>::value from { it }
+}.cast()
+
+@DataSchema
+public interface OfSingleValueColumn<T> {
+    public val value: T
+}
 
 // region Create DataFrame from Map
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -206,62 +206,62 @@ string.toDataFrame()
  */
 
 @JvmName("toDataFrameByte")
-public inline fun <reified B : Byte?> Iterable<B>.toDataFrame(): DataFrame<OfSingleValueColumn<B>> = toDataFrame {
-    OfSingleValueColumn<B>::value from { it }
+public inline fun <reified B : Byte?> Iterable<B>.toDataFrame(): DataFrame<ValueProperty<B>> = toDataFrame {
+    ValueProperty<B>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameShort")
-public inline fun <reified S : Short?> Iterable<S>.toDataFrame(): DataFrame<OfSingleValueColumn<S>> = toDataFrame {
-    OfSingleValueColumn<S>::value from { it }
+public inline fun <reified S : Short?> Iterable<S>.toDataFrame(): DataFrame<ValueProperty<S>> = toDataFrame {
+    ValueProperty<S>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameInt")
-public inline fun <reified I : Int?> Iterable<I>.toDataFrame(): DataFrame<OfSingleValueColumn<I>> = toDataFrame {
-    OfSingleValueColumn<I>::value from { it }
+public inline fun <reified I : Int?> Iterable<I>.toDataFrame(): DataFrame<ValueProperty<I>> = toDataFrame {
+    ValueProperty<I>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameLong")
-public inline fun <reified L : Long?> Iterable<L>.toDataFrame(): DataFrame<OfSingleValueColumn<L>> = toDataFrame {
-    OfSingleValueColumn<L>::value from { it }
+public inline fun <reified L : Long?> Iterable<L>.toDataFrame(): DataFrame<ValueProperty<L>> = toDataFrame {
+    ValueProperty<L>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameString")
-public inline fun <reified S : String?> Iterable<S>.toDataFrame(): DataFrame<OfSingleValueColumn<S>> = toDataFrame {
-    OfSingleValueColumn<S>::value from { it }
+public inline fun <reified S : String?> Iterable<S>.toDataFrame(): DataFrame<ValueProperty<S>> = toDataFrame {
+    ValueProperty<S>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameChar")
-public inline fun <reified C : Char?> Iterable<C>.toDataFrame(): DataFrame<OfSingleValueColumn<C>> = toDataFrame {
-    OfSingleValueColumn<C>::value from { it }
+public inline fun <reified C : Char?> Iterable<C>.toDataFrame(): DataFrame<ValueProperty<C>> = toDataFrame {
+    ValueProperty<C>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameBoolean")
-public inline fun <reified B : Boolean?> Iterable<B>.toDataFrame(): DataFrame<OfSingleValueColumn<B>> = toDataFrame {
-    OfSingleValueColumn<B>::value from { it }
+public inline fun <reified B : Boolean?> Iterable<B>.toDataFrame(): DataFrame<ValueProperty<B>> = toDataFrame {
+    ValueProperty<B>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameUByte")
-public inline fun <reified U : UByte?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
-    OfSingleValueColumn<U>::value from { it }
+public inline fun <reified U : UByte?> Iterable<U>.toDataFrame(): DataFrame<ValueProperty<U>> = toDataFrame {
+    ValueProperty<U>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameUShort")
-public inline fun <reified U : UShort?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
-    OfSingleValueColumn<U>::value from { it }
+public inline fun <reified U : UShort?> Iterable<U>.toDataFrame(): DataFrame<ValueProperty<U>> = toDataFrame {
+    ValueProperty<U>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameUInt")
-public inline fun <reified U : UInt?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
-    OfSingleValueColumn<U>::value from { it }
+public inline fun <reified U : UInt?> Iterable<U>.toDataFrame(): DataFrame<ValueProperty<U>> = toDataFrame {
+    ValueProperty<U>::value from { it }
 }.cast()
 
 @JvmName("toDataFrameULong")
-public inline fun <reified U : ULong?> Iterable<U>.toDataFrame(): DataFrame<OfSingleValueColumn<U>> = toDataFrame {
-    OfSingleValueColumn<U>::value from { it }
+public inline fun <reified U : ULong?> Iterable<U>.toDataFrame(): DataFrame<ValueProperty<U>> = toDataFrame {
+    ValueProperty<U>::value from { it }
 }.cast()
 
 @DataSchema
-public interface OfSingleValueColumn<T> {
+public interface ValueProperty<T> {
     public val value: T
 }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -216,8 +216,8 @@ class CreateDataFrameTests {
             val typeParameter = type.first()
             val func = """
             @JvmName("toDataFrame$type")
-            public inline fun <reified $typeParameter : $type?> Iterable<$typeParameter>.toDataFrame(): DataFrame<SingleColumn<$typeParameter>> = toDataFrame {
-                OfSingleValueColumn<$typeParameter>::value from { it }
+            public inline fun <reified $typeParameter : $type?> Iterable<$typeParameter>.toDataFrame(): DataFrame<ValueProperty<$typeParameter>> = toDataFrame {
+                ValueProperty<$typeParameter>::value from { it }
             }.cast()
             """.trimIndent()
             println(func)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.samples.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.Infer
+import org.jetbrains.kotlinx.dataframe.api.OfSingleValueColumn
 import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.column
 import org.jetbrains.kotlinx.dataframe.api.columnGroup
@@ -18,6 +20,7 @@ import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.toColumn
 import org.jetbrains.kotlinx.dataframe.api.toColumnOf
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.api.value
 import org.jetbrains.kotlinx.dataframe.api.withValues
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.kind
@@ -312,6 +315,16 @@ class Create : TestBase() {
         df.rowsCount() shouldBe 3
         df["name"].type() shouldBe typeOf<String>()
         df["age"].type() shouldBe typeOf<Int>()
+    }
+
+    @Test
+    fun readDataFrameFromValues() {
+        // SampleStart
+        val names = listOf("Alice", "Bob", "Charlie")
+        val df: DataFrame<OfSingleValueColumn<String>> = names.toDataFrame()
+        df.add("length") { value.length }
+        // SampleEnd
+        df.value.toList() shouldBe names
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
@@ -3,7 +3,7 @@ package org.jetbrains.kotlinx.dataframe.samples.api
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.Infer
-import org.jetbrains.kotlinx.dataframe.api.OfSingleValueColumn
+import org.jetbrains.kotlinx.dataframe.api.ValueProperty
 import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.column
 import org.jetbrains.kotlinx.dataframe.api.columnGroup
@@ -321,7 +321,7 @@ class Create : TestBase() {
     fun readDataFrameFromValues() {
         // SampleStart
         val names = listOf("Alice", "Bob", "Charlie")
-        val df: DataFrame<OfSingleValueColumn<String>> = names.toDataFrame()
+        val df: DataFrame<ValueProperty<String>> = names.toDataFrame()
         df.add("length") { value.length }
         // SampleEnd
         df.value.toList() shouldBe names

--- a/docs/StardustDocs/topics/createDataFrame.md
+++ b/docs/StardustDocs/topics/createDataFrame.md
@@ -134,6 +134,20 @@ map.toDataFrame()
 
 <!---END-->
 
+[`DataFrame`](DataFrame.md) from [`Iterable`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-iterable/) of [basic types](https://kotlinlang.org/docs/basic-types.html) (except arrays):
+
+Return type of these overloads is a typed DataFrame. Its data schema defines column that can be used right after conversion for additional computations
+
+<!---FUN readDataFrameFromValues-->
+
+```kotlin
+val names = listOf("Alice", "Bob", "Charlie")
+val df: DataFrame<OfSingleValueColumn<String>> = names.toDataFrame()
+df.add("length") { value.length }
+```
+
+<!---END-->
+
 [`DataFrame`](DataFrame.md) from [`Iterable`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-iterable/) of objects:
 
 <!---FUN readDataFrameFromObject-->

--- a/docs/StardustDocs/topics/createDataFrame.md
+++ b/docs/StardustDocs/topics/createDataFrame.md
@@ -142,7 +142,7 @@ Return type of these overloads is a typed DataFrame. Its data schema defines col
 
 ```kotlin
 val names = listOf("Alice", "Bob", "Charlie")
-val df: DataFrame<OfSingleValueColumn<String>> = names.toDataFrame()
+val df: DataFrame<ValueProperty<String>> = names.toDataFrame()
 df.add("length") { value.length }
 ```
 


### PR DESCRIPTION
Without overloads Iterable<String>.toDataFrame produces unexpected result

```
val string = listOf("aaa", "aa", null)
string.toDataFrame()
```
=>
  length
0    3
1    2
2 null

I think it will be more reasonable to create a dataframe with a single column for all basic types (numbers, strings, char, boolean), and do reflection scan for everything else 