### PR TITLE
Avoiding to use the URL-encoded path - part 2

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -269,7 +269,7 @@ dataframes {
     schema {
         sourceSet = "test"
         visibility = org.jetbrains.dataframe.gradle.DataSchemaVisibility.IMPLICIT_PUBLIC
-        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
+        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"
         name = "org.jetbrains.kotlinx.dataframe.samples.api.Repository"
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Schemas.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Schemas.kt
@@ -113,7 +113,7 @@ class Schemas {
     @Test
     fun useInferredSchema() {
         // SampleStart
-        // Repository.readCSV() has argument 'path' with default value https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv
+        // Repository.readCSV() has argument 'path' with default value https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv
         val df = Repository.readCSV()
         // Use generated properties to access data in rows
         df.maxBy { stargazersCount }.print()

--- a/docs/StardustDocs/topics/gradle.md
+++ b/docs/StardustDocs/topics/gradle.md
@@ -66,7 +66,7 @@ the same package as file containing the annotation.
 ```kotlin
 @file:ImportDataSchema(
     "Repository",
-    "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv",
+    "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv",
 )
 
 import org.jetbrains.kotlinx.dataframe.annotations.ImportDataSchema
@@ -88,7 +88,7 @@ to `build/generated/dataframe/org/example` folder.
 ```kotlin
 dataframes {
     schema {
-        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
+        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"
         name = "org.example.Repository"
     }
 }
@@ -104,7 +104,7 @@ After `assemble`, the following code should compile and run:
 <!---FUN useInferredSchema-->
 
 ```kotlin
-// Repository.readCSV() has argument 'path' with default value https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv
+// Repository.readCSV() has argument 'path' with default value https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv
 val df = Repository.readCSV()
 // Use generated properties to access data in rows
 df.maxBy { stargazersCount }.print()

--- a/docs/StardustDocs/topics/gradleReference.md
+++ b/docs/StardustDocs/topics/gradleReference.md
@@ -6,7 +6,7 @@ In the best scenario, your schema could be defined as simple as this:
 dataframes {
     // output: build/generated/dataframe/main/kotlin/org/example/dataframe/JetbrainsRepositories.Generated.kt
     schema {
-        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
+        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"
     }
 }
 ```
@@ -29,7 +29,7 @@ is derived from the directory structure with child directory `dataframe`. The na
 ```kotlin
 schema {
     // output: build/generated/dataframe/main/kotlin/org/example/dataframe/MyName.Generated.kt
-    data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
+    data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"
     name = "MyName"
 }
 ```
@@ -81,7 +81,7 @@ But if you need generated files in other directory, set `src`:
 dataframes {
     // output: schemas/org/example/test/OtherName.Generated.kt
     schema {
-        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"
+        data = "https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"
         name = "org.example.test.OtherName"
         src = file("schemas")
     }

--- a/docs/StardustDocs/topics/read.md
+++ b/docs/StardustDocs/topics/read.md
@@ -21,7 +21,7 @@ import java.net.URL
 
 DataFrame.readCSV("input.csv")
 DataFrame.readCSV(File("input.csv"))
-DataFrame.readCSV(URL("https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv"))
+DataFrame.readCSV(URL("https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv"))
 ```
 
 All `readCSV` overloads support different options.

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPluginTest.kt
@@ -159,7 +159,7 @@ internal class SchemaGeneratorPluginTest {
                     packageName = "org.test"
                 }
                 schema {
-                    data = URL("https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains_repositories.csv")
+                    data = URL("https://raw.githubusercontent.com/Kotlin/dataframe/master/data/jetbrains%20repositories.csv")
                     name = "Schema"
                     packageName = "org.test"
                 }


### PR DESCRIPTION
Fixes references to github changed by https://github.com/Kotlin/dataframe/pull/357