### PR TITLE
prevent CI/CD from publishing artifacts where version = build number

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ fun detectVersion(): String {
         if (rootProject.findProperty("build.number.detection") == "true") {
             "$versionProp-dev-$buildNumber"
         } else {
-            buildNumber
+            error("use build.number + build.number.detection = true or release build")
         }
     } else if (hasProperty("release")) {
         versionProp


### PR DESCRIPTION
this feature was used to publish versions such as "0.8.0-RC-1", etc. For now it will be impossible, but we can re-introduce it later.
We discussed and decided to always use version from the repository as a prefix to any build number. It should make it less prone to mistakes (i.e. impossible to publish version "123")