### PR TITLE
withValue() -> with { value }

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -35,7 +35,6 @@ internal interface FillNulls {
      *   | .`[notNull][org.jetbrains.kotlinx.dataframe.api.Update.notNull]` { `[rowExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.RowValueExpression.WithExample]` }
      *   | .`[perCol][org.jetbrains.kotlinx.dataframe.api.Update.perCol]` { `[colExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenColumn.ColumnExpression.WithExample]` }
      *   | .`[perRowCol][org.jetbrains.kotlinx.dataframe.api.Update.perRowCol]` { `[rowColExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]` }
-     *   | .`[withValue][org.jetbrains.kotlinx.dataframe.api.Update.withValue]`(value)
      *   | .`[withNull][org.jetbrains.kotlinx.dataframe.api.Update.withNull]`()
      *   | .`[withZero][org.jetbrains.kotlinx.dataframe.api.Update.withZero]`()
      *   | .`[asFrame][org.jetbrains.kotlinx.dataframe.api.Update.asFrame]` { `[dataFrameExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenDataFrame.DataFrameExpression.WithExample]` }`
@@ -239,7 +238,6 @@ internal interface FillNaNs {
      *   | .`[notNull][org.jetbrains.kotlinx.dataframe.api.Update.notNull]` { `[rowExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.RowValueExpression.WithExample]` }
      *   | .`[perCol][org.jetbrains.kotlinx.dataframe.api.Update.perCol]` { `[colExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenColumn.ColumnExpression.WithExample]` }
      *   | .`[perRowCol][org.jetbrains.kotlinx.dataframe.api.Update.perRowCol]` { `[rowColExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]` }
-     *   | .`[withValue][org.jetbrains.kotlinx.dataframe.api.Update.withValue]`(value)
      *   | .`[withNull][org.jetbrains.kotlinx.dataframe.api.Update.withNull]`()
      *   | .`[withZero][org.jetbrains.kotlinx.dataframe.api.Update.withZero]`()
      *   | .`[asFrame][org.jetbrains.kotlinx.dataframe.api.Update.asFrame]` { `[dataFrameExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenDataFrame.DataFrameExpression.WithExample]` }`
@@ -413,7 +411,6 @@ internal interface FillNA {
      *   | .`[notNull][org.jetbrains.kotlinx.dataframe.api.Update.notNull]` { `[rowExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.RowValueExpression.WithExample]` }
      *   | .`[perCol][org.jetbrains.kotlinx.dataframe.api.Update.perCol]` { `[colExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenColumn.ColumnExpression.WithExample]` }
      *   | .`[perRowCol][org.jetbrains.kotlinx.dataframe.api.Update.perRowCol]` { `[rowColExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]` }
-     *   | .`[withValue][org.jetbrains.kotlinx.dataframe.api.Update.withValue]`(value)
      *   | .`[withNull][org.jetbrains.kotlinx.dataframe.api.Update.withNull]`()
      *   | .`[withZero][org.jetbrains.kotlinx.dataframe.api.Update.withZero]`()
      *   | .`[asFrame][org.jetbrains.kotlinx.dataframe.api.Update.asFrame]` { `[dataFrameExpression][org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenDataFrame.DataFrameExpression.WithExample]` }`

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -50,7 +50,6 @@ public data class Update<T, C>(
      *   | .`[notNull][Update.notNull]` { `[rowExpression][ExpressionsGivenRow.RowValueExpression.WithExample]` }
      *   | .`[perCol][Update.perCol]` { `[colExpression][ExpressionsGivenColumn.ColumnExpression.WithExample]` }
      *   | .`[perRowCol][Update.perRowCol]` { `[rowColExpression][ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]` }
-     *   | .`[withValue][Update.withValue]`(value)
      *   | .`[withNull][Update.withNull]`()
      *   | .`[withZero][Update.withZero]`()
      *   | .`[asFrame][Update.asFrame]` { `[dataFrameExpression][ExpressionsGivenDataFrame.DataFrameExpression.WithExample]` }`
@@ -764,4 +763,5 @@ public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColu
  *
  * @param [value] The value to set the selected rows to. In contrast to [with][Update.with], this must be the same exact type.
  */
+@Deprecated("Use with { value } instead", ReplaceWith("this.with { value }"))
 public fun <T, C> Update<T, C>.withValue(value: C): DataFrame<T> = with { value }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/contains.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/contains.kt
@@ -17,7 +17,7 @@ class ContainsTests {
         val df = dataFrameOf("a", "b")(1, 2, 3, 4)
         val col = df.asColumnGroup("col")
         col.contains(df[0]) shouldBe true
-        col.contains(df.update("b").withValue(0)[0]) shouldBe false
+        col.contains(df.update("b").with { 0 }[0]) shouldBe false
     }
 
     @Test

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dataframe.api.prev
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
 import org.junit.Test
 
@@ -38,11 +37,11 @@ class DataRowApi : TestBase() {
         // Row condition is used to filter rows by index
         df.filter { index() % 5 == 0 }
 
-        // Row condition is used to drop rows where `age` is the same as in previous row
+        // Row condition is used to drop rows where `age` is the same as in the previous row
         df.drop { diff { age } == 0 }
 
         // Row condition is used to filter rows for value update
-        df.update { weight }.where { index() > 4 && city != "Paris" }.withValue(50)
+        df.update { weight }.where { index() > 4 && city != "Paris" }.with { 50 }
         // SampleEnd
     }
 }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dataframe.api.prev
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
 import org.junit.Test
 
@@ -38,11 +37,11 @@ class DataRowApi : TestBase() {
         // Row condition is used to filter rows by index
         df.filter { index() % 5 == 0 }
 
-        // Row condition is used to drop rows where `age` is the same as in previous row
+        // Row condition is used to drop rows where `age` is the same as in the previous row
         df.drop { diffOrNull { age } == 0 }
 
         // Row condition is used to filter rows for value update
-        df.update { weight }.where { index() > 4 && city != "Paris" }.withValue(50)
+        df.update { weight }.where { index() > 4 && city != "Paris" }.with { 50 }
         // SampleEnd
     }
 }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -95,7 +95,6 @@ import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.api.withNull
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.jetbrains.kotlinx.dataframe.api.withZero
 import org.jetbrains.kotlinx.dataframe.explainer.PluginCallbackProxy
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
@@ -137,7 +136,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun updateWithConst() {
         // SampleStart
-        df.update { city }.where { name.firstName == "Alice" }.withValue("Paris")
+        df.update { city }.where { name.firstName == "Alice" }.with { "Paris" }
         // SampleEnd
     }
 
@@ -304,7 +303,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun fillNA() {
         // SampleStart
-        df.fillNA { weight }.withValue(-1)
+        df.fillNA { weight }.with { -1 }
         // SampleEnd
     }
 

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
@@ -8,8 +8,8 @@ import org.jetbrains.kotlinx.dataframe.api.name
 import org.jetbrains.kotlinx.dataframe.api.transpose
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.value
+import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.api.withNull
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.junit.Test
 import kotlin.reflect.typeOf
 
@@ -38,7 +38,7 @@ class AnimalsTests {
 
     @Test
     fun `mean of empty`() {
-        val cleared = df.update { age }.withValue(Double.NaN).update { visits }.withNull()
+        val cleared = df.update { age }.with { Double.NaN }.update { visits }.withNull()
         val mean = cleared.mean()
         mean[age] shouldBe Double.NaN
         (mean[visits.name()] as Double).isNaN() shouldBe true

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -238,14 +238,14 @@ class DataFrameTests : BaseTest() {
 
     @Test
     fun `update cells by index`() {
-        val res = typed.update { age }.at(2, 4).withValue(100)
+        val res = typed.update { age }.at(2, 4).with { 100 }
         val expected = typed.rows().map { if (it.index == 2 || it.index == 4) 100 else it.age }
         res.age.toList() shouldBe expected
     }
 
     @Test
     fun `update cells by index range`() {
-        val res = typed.update { age }.at(2..4).withValue(100)
+        val res = typed.update { age }.at(2..4).with { 100 }
         val expected = typed.rows().map { if (it.index in 2..4) 100 else it.age }
         res.age.toList() shouldBe expected
     }
@@ -257,13 +257,13 @@ class DataFrameTests : BaseTest() {
             this["weight"].toList() shouldBe expected
         }
 
-        typed.fillNulls { weight }.withValue(0).check()
-        typed.fillNulls(typed.weight).withValue(0).check()
+        typed.fillNulls { weight }.with { 0 }.check()
+        typed.fillNulls(typed.weight).with { 0 }.check()
 
-        df.fillNulls { weight }.withValue(0).check()
-        df.fillNulls(weight).withValue(0).check()
+        df.fillNulls { weight }.with { 0 }.check()
+        df.fillNulls(weight).with { 0 }.check()
 
-        df.fillNulls("weight").withValue(0).check()
+        df.fillNulls("weight").with { 0 }.check()
 
         typed.fillNulls { weight }.withZero().check()
         typed.fillNulls { weight }.withZero().check()
@@ -1337,7 +1337,7 @@ class DataFrameTests : BaseTest() {
 
     @Test
     fun corr() {
-        val fixed = typed.fillNulls { weight }.withValue(60)
+        val fixed = typed.fillNulls { weight }.with { 60 }
         val res = fixed.corr()
         res.ncol shouldBe 3
         res.nrow shouldBe 2
@@ -1526,7 +1526,7 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `update nullable column with not null`() {
         val df = dataFrameOf("name", "value")("Alice", 1, null, 2)
-        df.update("name").at(0).withValue("ALICE")
+        df.update("name").at(0).with { "ALICE" }
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -1905,7 +1905,7 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `find the longest string`() {
         val longestCityName = "Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu"
-        val updated = typed.update { city }.where { it == "Dubai" }.withValue(longestCityName)
+        val updated = typed.update { city }.where { it == "Dubai" }.with { longestCityName }
         updated.valuesNotNull { colsOf<String?>() }.maxByOrNull { it.length } shouldBe longestCityName
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -50,7 +50,6 @@ public data class Update<T, C>(
      *   | .`[notNull][Update.notNull]` { `[rowExpression][ExpressionsGivenRow.RowValueExpression.WithExample]` }
      *   | .`[perCol][Update.perCol]` { `[colExpression][ExpressionsGivenColumn.ColumnExpression.WithExample]` }
      *   | .`[perRowCol][Update.perRowCol]` { `[rowColExpression][ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]` }
-     *   | .`[withValue][Update.withValue]`(value)
      *   | .`[withNull][Update.withNull]`()
      *   | .`[withZero][Update.withZero]`()
      *   | .`[asFrame][Update.asFrame]` { `[dataFrameExpression][ExpressionsGivenDataFrame.DataFrameExpression.WithExample]` }`
@@ -453,4 +452,5 @@ public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColu
  *
  * @param [value] The value to set the selected rows to. In contrast to [with][Update.with], this must be the same exact type.
  */
+@Deprecated("Use with { value } instead", ReplaceWith("this.with { value }"))
 public fun <T, C> Update<T, C>.withValue(value: C): DataFrame<T> = with { value }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/contains.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/contains.kt
@@ -17,7 +17,7 @@ class ContainsTests {
         val df = dataFrameOf("a", "b")(1, 2, 3, 4)
         val col = df.asColumnGroup("col")
         col.contains(df[0]) shouldBe true
-        col.contains(df.update("b").withValue(0)[0]) shouldBe false
+        col.contains(df.update("b").with { 0 }[0]) shouldBe false
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/DataRowApi.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dataframe.api.prev
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
 import org.junit.Test
 
@@ -38,11 +37,11 @@ class DataRowApi : TestBase() {
         // Row condition is used to filter rows by index
         df.filter { index() % 5 == 0 }
 
-        // Row condition is used to drop rows where `age` is the same as in previous row
+        // Row condition is used to drop rows where `age` is the same as in the previous row
         df.drop { diff { age } == 0 }
 
         // Row condition is used to filter rows for value update
-        df.update { weight }.where { index() > 4 && city != "Paris" }.withValue(50)
+        df.update { weight }.where { index() > 4 && city != "Paris" }.with { 50 }
         // SampleEnd
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -95,7 +95,6 @@ import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.api.withNull
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.jetbrains.kotlinx.dataframe.api.withZero
 import org.jetbrains.kotlinx.dataframe.explainer.PluginCallbackProxy
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
@@ -137,7 +136,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun updateWithConst() {
         // SampleStart
-        df.update { city }.where { name.firstName == "Alice" }.withValue("Paris")
+        df.update { city }.where { name.firstName == "Alice" }.with { "Paris" }
         // SampleEnd
     }
 
@@ -304,7 +303,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun fillNA() {
         // SampleStart
-        df.fillNA { weight }.withValue(-1)
+        df.fillNA { weight }.with { -1 }
         // SampleEnd
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
@@ -8,8 +8,8 @@ import org.jetbrains.kotlinx.dataframe.api.name
 import org.jetbrains.kotlinx.dataframe.api.transpose
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.value
+import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.api.withNull
-import org.jetbrains.kotlinx.dataframe.api.withValue
 import org.junit.Test
 import kotlin.reflect.typeOf
 
@@ -38,7 +38,7 @@ class AnimalsTests {
 
     @Test
     fun `mean of empty`() {
-        val cleared = df.update { age }.withValue(Double.NaN).update { visits }.withNull()
+        val cleared = df.update { age }.with { Double.NaN }.update { visits }.withNull()
         val mean = cleared.mean()
         mean[age] shouldBe Double.NaN
         (mean[visits.name()] as Double).isNaN() shouldBe true

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -238,14 +238,14 @@ class DataFrameTests : BaseTest() {
 
     @Test
     fun `update cells by index`() {
-        val res = typed.update { age }.at(2, 4).withValue(100)
+        val res = typed.update { age }.at(2, 4).with { 100 }
         val expected = typed.rows().map { if (it.index == 2 || it.index == 4) 100 else it.age }
         res.age.toList() shouldBe expected
     }
 
     @Test
     fun `update cells by index range`() {
-        val res = typed.update { age }.at(2..4).withValue(100)
+        val res = typed.update { age }.at(2..4).with { 100 }
         val expected = typed.rows().map { if (it.index in 2..4) 100 else it.age }
         res.age.toList() shouldBe expected
     }
@@ -257,13 +257,13 @@ class DataFrameTests : BaseTest() {
             this["weight"].toList() shouldBe expected
         }
 
-        typed.fillNulls { weight }.withValue(0).check()
-        typed.fillNulls(typed.weight).withValue(0).check()
+        typed.fillNulls { weight }.with { 0 }.check()
+        typed.fillNulls(typed.weight).with { 0 }.check()
 
-        df.fillNulls { weight }.withValue(0).check()
-        df.fillNulls(weight).withValue(0).check()
+        df.fillNulls { weight }.with { 0 }.check()
+        df.fillNulls(weight).with { 0 }.check()
 
-        df.fillNulls("weight").withValue(0).check()
+        df.fillNulls("weight").with { 0 }.check()
 
         typed.fillNulls { weight }.withZero().check()
         typed.fillNulls { weight }.withZero().check()
@@ -1337,7 +1337,7 @@ class DataFrameTests : BaseTest() {
 
     @Test
     fun corr() {
-        val fixed = typed.fillNulls { weight }.withValue(60)
+        val fixed = typed.fillNulls { weight }.with { 60 }
         val res = fixed.corr()
         res.ncol shouldBe 3
         res.nrow shouldBe 2
@@ -1526,7 +1526,7 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `update nullable column with not null`() {
         val df = dataFrameOf("name", "value")("Alice", 1, null, 2)
-        df.update("name").at(0).withValue("ALICE")
+        df.update("name").at(0).with { "ALICE" }
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -1905,7 +1905,7 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `find the longest string`() {
         val longestCityName = "Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu"
-        val updated = typed.update { city }.where { it == "Dubai" }.withValue(longestCityName)
+        val updated = typed.update { city }.where { it == "Dubai" }.with { longestCityName }
         updated.valuesNotNull { colsOf<String?>() }.maxByOrNull { it.length } shouldBe longestCityName
     }
 

--- a/docs/StardustDocs/snippets/org.jetbrains.kotlinx.dataframe.samples.api.DataRowApi.conditions.html
+++ b/docs/StardustDocs/snippets/org.jetbrains.kotlinx.dataframe.samples.api.DataRowApi.conditions.html
@@ -232,7 +232,7 @@ summary {
                         </details>
                         <br>
                         <details>
-                        <summary>df.update { weight }.where { index() &amp;gt; 4 &amp;&amp; city != &quot;Paris&quot; }.withValue(50)</summary>
+                        <summary>df.update { weight }.where { index() &amp;gt; 4 &amp;&amp; city != &quot;Paris&quot; }.with { 50 }</summary>
                         
                                     <details>
                                     <summary>Input DataFrame: rowsCount = 7, columnsCount = 5</summary>

--- a/docs/StardustDocs/topics/DataRow.md
+++ b/docs/StardustDocs/topics/DataRow.md
@@ -54,11 +54,11 @@ Row condition is a special case of [row expression](#row-expressions) that retur
 // Row condition is used to filter rows by index
 df.filter { index() % 5 == 0 }
 
-// Row condition is used to drop rows where `age` is the same as in previous row
+// Row condition is used to drop rows where `age` is the same as in the previous row
 df.drop { diff { age } == 0 }
 
 // Row condition is used to filter rows for value update
-df.update { weight }.where { index() > 4 && city != "Paris" }.withValue(50)
+df.update { weight }.where { index() > 4 && city != "Paris" }.with { 50 }
 ```
 
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.DataRowApi.conditions.html"/>

--- a/docs/StardustDocs/topics/convert.md
+++ b/docs/StardustDocs/topics/convert.md
@@ -5,7 +5,7 @@ Returns [`DataFrame`](DataFrame.md) with changed values in some columns. Allows 
 
 ```text
 convert { columnsSelector }
-    .with { rowExpression } | .perRowCol { rowColExpression } | .withValue(value)  | to<Type>() | to { colExpression }
+    .with { rowExpression } | .perRowCol { rowColExpression } | to<Type>() | to { colExpression }
 
 rowExpression = DataRow.(OldValue) -> NewValue
 rowColExpression = (DataRow, DataColumn) -> NewValue

--- a/docs/StardustDocs/topics/fill.md
+++ b/docs/StardustDocs/topics/fill.md
@@ -39,7 +39,7 @@ Replaces `null`, `Double.NaN` and `Float.NaN` values with given value or express
 <!---FUN fillNA-->
 
 ```kotlin
-df.fillNA { weight }.withValue(-1)
+df.fillNA { weight }.with { -1 }
 ```
 
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.fillNA.html"/>

--- a/docs/StardustDocs/topics/update.md
+++ b/docs/StardustDocs/topics/update.md
@@ -8,7 +8,7 @@ Returns [`DataFrame`](DataFrame.md) with changed values in some cells. Column ty
 update { columns }
     [.where { rowCondition } ]
     [.at(rowIndices) ] 
-     .with { rowExpression } | .notNull { rowExpression } | .perCol { colExpression } | .perRowCol { rowColExpression } | .withValue(value) | .withNull() | .withZero() | .asFrame { frameExpression } 
+     .with { rowExpression } | .notNull { rowExpression } | .perCol { colExpression } | .perRowCol { rowColExpression } | .withNull() | .withZero() | .asFrame { frameExpression } 
 
 rowCondition: DataRow.(OldValue) -> Boolean
 rowExpression: DataRow.(OldValue) -> NewValue
@@ -36,7 +36,7 @@ Update with constant value:
 <!---FUN updateWithConst-->
 
 ```kotlin
-df.update { city }.where { name.firstName == "Alice" }.withValue("Paris")
+df.update { city }.where { name.firstName == "Alice" }.with { "Paris" }
 ```
 
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.updateWithConst.html"/>

--- a/examples/idea-examples/titanic/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/titanic/ml/titanic.kt
+++ b/examples/idea-examples/titanic/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/titanic/ml/titanic.kt
@@ -38,7 +38,7 @@ fun main() {
     val (train, test) = df
         // imputing
         .fillNulls { sibsp and parch and age and fare }.perCol { it.mean() }
-        .fillNulls { sex }.withValue("female")
+        .fillNulls { sex }.with { "female" }
         // one hot encoding
         .pivotMatches { pclass and sex }
         // feature extraction

--- a/examples/notebooks/puzzles/40 puzzles.ipynb
+++ b/examples/notebooks/puzzles/40 puzzles.ipynb
@@ -803,7 +803,7 @@
     }
    ],
    "source": [
-    "df.update { age }.at(5).withValue(1.5)"
+    "df.update { age }.at(5).with { 1.5 }"
    ]
   },
   {

--- a/examples/notebooks/titanic/Titanic.ipynb
+++ b/examples/notebooks/titanic/Titanic.ipynb
@@ -1111,7 +1111,7 @@
     "val df1 = df\n",
     "    // imputing\n",
     "    .fillNulls { sibsp and parch and age and fare }.perCol { mean() }\n",
-    "    .fillNulls { sex }.withValue(\"female\")\n",
+    "    .fillNulls { sex }.with { \"female\" }\n",
     "    .fillNulls { embarked }.with { \"S\" }\n",
     "    .convert { sibsp and parch and age and fare }.toDouble()\n",
     "\n",


### PR DESCRIPTION
Discussed in https://github.com/Kotlin/dataframe/issues/253#issuecomment-1587226245

Since we have no plans atm to implement single-value columns, I think it might be best to remove `withValue()` from the `Update` function (and the docs of `Convert`).

This PR replaces usage of it across the library and examples and provides a helpful deprecation annotation.