### PR TITLE
Add row functions to "operations overview" to make it comprehensive

### DIFF
--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -155,6 +155,7 @@
             <toc-element topic="statisticalRelationship.md">
                 <toc-element topic="corr.md"/>
             </toc-element>
+            <toc-element topic="rowStats.md"/>
         </toc-element>
         <toc-element topic="multipleDataFrames.md">
             <toc-element topic="addDf.md"/>

--- a/docs/StardustDocs/topics/DataRow.md
+++ b/docs/StardustDocs/topics/DataRow.md
@@ -5,12 +5,14 @@
 
 ## Row functions
 
+<snippet id="rowFunctions">
+
 * `index(): Int` — sequential row number in [`DataFrame`](DataFrame.md), starts from 0
 * `prev(): DataRow?` — previous row (`null` for the first row)
 * `next(): DataRow?` — next row (`null` for the last row)
-* `diff(T) { rowExpression }: T / diffOrNull { rowExpression }: T?` — difference between the results of a [row expression](#row-expressions) calculated for current and previous rows
+* `diff(T) { rowExpression }: T / diffOrNull { rowExpression }: T?` — difference between the results of a [row expression](DataRow.md#row-expressions) calculated for current and previous rows
 * `values(): List<Any?>` — list of all cell values from the current row
-* `valuesOf<T>(): List<T>` — list of values of given type 
+* `valuesOf<T>(): List<T>` — list of values of the given type 
 * `columnsCount(): Int` — number of columns
 * `columnNames(): List<String>` — list of all column names
 * `columnTypes(): List<KType>` — list of all column types 
@@ -23,6 +25,8 @@
 * `relative(Iterable<Int>): DataFrame` — dataframe with subset of rows selected by relative row index: `relative(-1..1)` will return previous, current and next row. Requested indices will be coerced to the valid range and invalid indices will be skipped
 * `get(column): T` — cell value by this row and given `column`
 * `df()` — [`DataFrame`](DataFrame.md) that current row belongs to
+
+</snippet>
 
 ## Row expressions
 Row expressions provide a value for every row of [`DataFrame`](DataFrame.md) and are used in [add](add.md), [filter](filter.md), [forEach](iterate.md), [update](update.md) and other operations.
@@ -66,7 +70,11 @@ df.update { weight }.where { index() > 4 && city != "Paris" }.withValue(50)
 
 Row condition signature: ```DataRow.(DataRow) -> Boolean```
 
+
+
 ## Row statistics
+
+<snippet id="rowStatistics">
 
 The following [statistics](summaryStatistics.md) are available for `DataRow`:
 * `rowMax`
@@ -85,3 +93,5 @@ To apply statistics only to values of particular type use `-Of` versions:
 * `rowSumOf<T>`
 * `rowMeanOf<T>`
 * `rowMedianOf<T>`
+
+</snippet>

--- a/docs/StardustDocs/topics/operations.md
+++ b/docs/StardustDocs/topics/operations.md
@@ -37,6 +37,14 @@ Most multiplex operations end with `into` or `with` function. The following nami
 * `into` defines column names for storing operation results. Used in [`move`](move.md), [`group`](group.md), [`split`](split.md), [`merge`](merge.md), [`gather`](gather.md), [`groupBy`](groupBy.md), [`rename`](rename.md).
 * `with` defines row-wise data transformation with [`row expression`](DataRow.md#row-expressions). Used in [`update`](update.md), [`convert`](convert.md), [`replace`](replace.md), [`pivot`](pivot.md).
 
+## List of DataRow operations
+
+<include from="DataRow.md" element-id="rowFunctions"/>
+
+## List of DataRow statistics
+
+<include from="DataRow.md" element-id="rowStatistics"/>
+
 ## List of DataFrame operations
 
 * [add](add.md) — add columns

--- a/docs/StardustDocs/topics/rowStats.md
+++ b/docs/StardustDocs/topics/rowStats.md
@@ -1,0 +1,3 @@
+# Row statistics
+
+<include from="DataRow.md" element-id="rowStatistics"/>


### PR DESCRIPTION
It's nice to have a list of most functions on the same page, also an example on how to reuse content with writerside :) 