### PR TITLE
Added update gradle.properties version to RELEASE_CHECK_LIST

### DIFF
--- a/RELEASE_CHECK_LIST.md
+++ b/RELEASE_CHECK_LIST.md
@@ -28,3 +28,4 @@
 16. Prepare and publish the Release Notes 
 17. Create Release from the release tag on GitHub 
 18. Update a KDF version in the [Kotlin Jupyter Descriptor](https://github.com/Kotlin/kotlin-jupyter-libraries/blob/master/dataframe.json). Now the Renovate bot doing this 
+19. Update DataFrame version in gradle.properties file for next release cycle (i.e. 0.10.0 -> 0.11.0)


### PR DESCRIPTION
To start producing the new SNAPSHOT and dev versions with the correct number, we also need to update the DF version in the master branch to the next number.