### PR TITLE
Deprecation messages

### DIFF
--- a/RELEASE_CHECK_LIST.md
+++ b/RELEASE_CHECK_LIST.md
@@ -29,3 +29,8 @@
 17. Create Release from the release tag on GitHub 
 18. Update a KDF version in the [Kotlin Jupyter Descriptor](https://github.com/Kotlin/kotlin-jupyter-libraries/blob/master/dataframe.json). Now the Renovate bot doing this 
 19. Update DataFrame version in gradle.properties file for next release cycle (i.e. 0.10.0 -> 0.11.0)
+20. Update deprecated functions in [deprecationMessages.kt](/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt)
+    such that 
+    - `Level.WARNING` messages are changed to `Level.ERROR`
+    - `Level.ERROR` messages and their functions are removed.
+    - Update regions in the file accordingly.

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -12,6 +12,10 @@ import org.jetbrains.kotlinx.dataframe.impl.api.updateImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.updateWithValuePerColumnImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.util.ITERABLE_COLUMNS_DEPRECATION_MESSAGE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_AS_NULLABLE_MESSAGE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_AS_NULLABLE_REPLACE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_WITH_VALUE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_WITH_VALUE_REPLACE
 import kotlin.reflect.KProperty
 
 /**
@@ -403,8 +407,9 @@ public fun <T, C, R> Update<T, DataRow<C>>.asFrame(expression: DataFrameExpressi
     asFrameImpl(expression)
 
 @Deprecated(
-    "Useless unless in combination with `withValue(null)`, but then users can just use `with { null }`...",
-    ReplaceWith("this as Update<T, C?>")
+    UPDATE_AS_NULLABLE_MESSAGE,
+    ReplaceWith(UPDATE_AS_NULLABLE_REPLACE),
+    DeprecationLevel.WARNING,
 )
 public fun <T, C> Update<T, C>.asNullable(): Update<T, C?> = this as Update<T, C?>
 
@@ -752,7 +757,7 @@ public fun <T, C> Update<T, C>.withNull(): DataFrame<T> = with { null }
 public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColumnImpl { 0 as C }
 
 /**
- * ## With Value
+ * ## With Value (Deprecated)
  * Specific version of [with][org.jetbrains.kotlinx.dataframe.api.with] that simply sets the value of each selected row to [value].
  *
  * For example:
@@ -763,5 +768,5 @@ public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColu
  *
  * @param [value] The value to set the selected rows to. In contrast to [with][Update.with], this must be the same exact type.
  */
-@Deprecated("Use with { value } instead", ReplaceWith("this.with { value }"))
+@Deprecated(UPDATE_WITH_VALUE, ReplaceWith(UPDATE_WITH_VALUE_REPLACE), DeprecationLevel.WARNING)
 public fun <T, C> Update<T, C>.withValue(value: C): DataFrame<T> = with { value }

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -1,13 +1,35 @@
 package org.jetbrains.kotlinx.dataframe.util
 
-internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation."
+/*
+ * This file contains deprecation messages for the whole core module.
+ * After each release, all messages should be reviewed and updated.
+ * Level.WARNING -> Level.ERROR
+ * Level.ERROR -> Remove
+ */
 
+// region WARNING in 0.10.0, ERROR in 0.11.0
+
+internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. Removed in 0.11.0."
 internal const val DF_READ_REPLACE_MESSAGE = "this.unfold(*columns)"
 
-internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation."
+internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. Removed in 0.11.0."
 
-internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload."
+// endregion
 
+// region WARNING in 0.11.0, ERROR in 0.12.0
+
+internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. Will be removed in 0.12.0."
 internal const val DIFF_REPLACE_MESSAGE = "this.diffOrNull(expression)"
-
 internal const val DIFF_OR_NULL_IMPORT = "org.jetbrains.kotlinx.dataframe.api.diffOrNull"
+
+internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. Will be removed in 0.12.0."
+internal const val UPDATE_AS_NULLABLE_REPLACE = "this as Update<T, C?>"
+
+internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. Will be removed in 0.12.0."
+internal const val UPDATE_WITH_VALUE_REPLACE = "this.with { value }"
+
+// endregion
+
+// region WARNING in 0.12.0, ERROR in 0.13.0
+
+// endregion

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -9,27 +9,33 @@ package org.jetbrains.kotlinx.dataframe.util
 
 // region WARNING in 0.10.0, ERROR in 0.11.0
 
-internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. Removed in 0.11.0."
+private const val message_0_11_0 = "Was removed in 0.11.0."
+
+internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. $message_0_11_0"
 internal const val DF_READ_REPLACE_MESSAGE = "this.unfold(*columns)"
 
-internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. Removed in 0.11.0."
+internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. $message_0_11_0"
 
 // endregion
 
 // region WARNING in 0.11.0, ERROR in 0.12.0
 
-internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. Will be removed in 0.12.0."
+private const val message_0_12_0 = "Will be removed in 0.12.0."
+
+internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. $message_0_12_0"
 internal const val DIFF_REPLACE_MESSAGE = "this.diffOrNull(expression)"
 internal const val DIFF_OR_NULL_IMPORT = "org.jetbrains.kotlinx.dataframe.api.diffOrNull"
 
-internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. Will be removed in 0.12.0."
+internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. $message_0_12_0"
 internal const val UPDATE_AS_NULLABLE_REPLACE = "this as Update<T, C?>"
 
-internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. Will be removed in 0.12.0."
+internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. $message_0_12_0"
 internal const val UPDATE_WITH_VALUE_REPLACE = "this.with { value }"
 
 // endregion
 
 // region WARNING in 0.12.0, ERROR in 0.13.0
+
+private const val message_0_13_0 = "Will be removed in 0.13.0."
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -12,6 +12,10 @@ import org.jetbrains.kotlinx.dataframe.impl.api.updateImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.updateWithValuePerColumnImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.util.ITERABLE_COLUMNS_DEPRECATION_MESSAGE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_AS_NULLABLE_MESSAGE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_AS_NULLABLE_REPLACE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_WITH_VALUE
+import org.jetbrains.kotlinx.dataframe.util.UPDATE_WITH_VALUE_REPLACE
 import kotlin.reflect.KProperty
 
 /**
@@ -247,8 +251,9 @@ public fun <T, C, R> Update<T, DataRow<C>>.asFrame(expression: DataFrameExpressi
     asFrameImpl(expression)
 
 @Deprecated(
-    "Useless unless in combination with `withValue(null)`, but then users can just use `with { null }`...",
-    ReplaceWith("this as Update<T, C?>")
+    UPDATE_AS_NULLABLE_MESSAGE,
+    ReplaceWith(UPDATE_AS_NULLABLE_REPLACE),
+    DeprecationLevel.WARNING,
 )
 public fun <T, C> Update<T, C>.asNullable(): Update<T, C?> = this as Update<T, C?>
 
@@ -445,12 +450,12 @@ public fun <T, C> Update<T, C>.withNull(): DataFrame<T> = with { null }
 public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColumnImpl { 0 as C }
 
 /**
- * ## With Value
+ * ## With Value (Deprecated)
  * @include [CommonSpecificWithDoc]
  * {@arg [CommonSpecificWithDocFirstArg] [value]}
  * {@arg [CommonSpecificWithDocSecondArg] [withValue][withValue]`(-1)}
  *
  * @param [value] The value to set the selected rows to. In contrast to [with][Update.with], this must be the same exact type.
  */
-@Deprecated("Use with { value } instead", ReplaceWith("this.with { value }"))
+@Deprecated(UPDATE_WITH_VALUE, ReplaceWith(UPDATE_WITH_VALUE_REPLACE), DeprecationLevel.WARNING)
 public fun <T, C> Update<T, C>.withValue(value: C): DataFrame<T> = with { value }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -22,6 +22,12 @@ internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate n
 internal const val DIFF_REPLACE_MESSAGE = "this.diffOrNull(expression)"
 internal const val DIFF_OR_NULL_IMPORT = "org.jetbrains.kotlinx.dataframe.api.diffOrNull"
 
+internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. Will be removed in 0.12.0."
+internal const val UPDATE_AS_NULLABLE_REPLACE = "this as Update<T, C?>"
+
+internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. Will be removed in 0.12.0."
+internal const val UPDATE_WITH_VALUE_REPLACE = "this.with { value }"
+
 // endregion
 
 // region WARNING in 0.12.0, ERROR in 0.13.0

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -1,13 +1,29 @@
 package org.jetbrains.kotlinx.dataframe.util
 
-internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation."
+/*
+ * This file contains deprecation messages for the whole core module.
+ * After each release, all messages should be reviewed and updated.
+ * Level.WARNING -> Level.ERROR
+ * Level.ERROR -> Remove
+ */
 
+// region WARNING in 0.10.0, ERROR in 0.11.0
+
+internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. Removed in 0.11.0."
 internal const val DF_READ_REPLACE_MESSAGE = "this.unfold(*columns)"
 
-internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation."
+internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. Removed in 0.11.0."
 
-internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload."
+// endregion
 
+// region WARNING in 0.11.0, ERROR in 0.12.0
+
+internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. Will be removed in 0.12.0."
 internal const val DIFF_REPLACE_MESSAGE = "this.diffOrNull(expression)"
-
 internal const val DIFF_OR_NULL_IMPORT = "org.jetbrains.kotlinx.dataframe.api.diffOrNull"
+
+// endregion
+
+// region WARNING in 0.12.0, ERROR in 0.13.0
+
+// endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -9,27 +9,33 @@ package org.jetbrains.kotlinx.dataframe.util
 
 // region WARNING in 0.10.0, ERROR in 0.11.0
 
-internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. Removed in 0.11.0."
+private const val message_0_11_0 = "Was removed in 0.11.0."
+
+internal const val DF_READ_DEPRECATION_MESSAGE = "Replaced with `unfold` operation. $message_0_11_0"
 internal const val DF_READ_REPLACE_MESSAGE = "this.unfold(*columns)"
 
-internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. Removed in 0.11.0."
+internal const val ITERABLE_COLUMNS_DEPRECATION_MESSAGE = "Replaced with `toColumnSet()` operation. $message_0_11_0"
 
 // endregion
 
 // region WARNING in 0.11.0, ERROR in 0.12.0
 
-internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. Will be removed in 0.12.0."
+private const val message_0_12_0 = "Will be removed in 0.12.0."
+
+internal const val DIFF_DEPRECATION_MESSAGE = "Replaced to explicitly indicate nullable return value; added a new non-null overload. $message_0_12_0"
 internal const val DIFF_REPLACE_MESSAGE = "this.diffOrNull(expression)"
 internal const val DIFF_OR_NULL_IMPORT = "org.jetbrains.kotlinx.dataframe.api.diffOrNull"
 
-internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. Will be removed in 0.12.0."
+internal const val UPDATE_AS_NULLABLE_MESSAGE = "This function is useless unless in combination with `withValue(null)`, but then you can just use `with { null }`. $message_0_12_0"
 internal const val UPDATE_AS_NULLABLE_REPLACE = "this as Update<T, C?>"
 
-internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. Will be removed in 0.12.0."
+internal const val UPDATE_WITH_VALUE = "Replaced in favor of `with { value }`. $message_0_12_0"
 internal const val UPDATE_WITH_VALUE_REPLACE = "this.with { value }"
 
 // endregion
 
 // region WARNING in 0.12.0, ERROR in 0.13.0
+
+private const val message_0_13_0 = "Will be removed in 0.13.0."
 
 // endregion


### PR DESCRIPTION
As a tip from @zaleslaw in https://github.com/Kotlin/dataframe/pull/372, we currently don't have any central indication as to when deprecated functions will be removed and whatnot. We did already have a `deprecationMessages.kt` file, containing some const messages. 
I updated the file with instructions and added versions to the remove-messages.

I also went through the rest of the core module as well to get the deprecations in the same central place. The columns selection DSL will also deprecate a lot of functions, so it's good to have this present ahead of that. (I won't include that in this PR as that's too large)