### PR TITLE
`df1Row[df2Column] == df1Row[df2Column.name]`

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DataRowImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DataRowImpl.kt
@@ -21,12 +21,24 @@ internal open class DataRowImpl<T>(private val index: Int, private val df: DataF
 
     override operator fun <R> get(column: ColumnReference<R>): R {
         ColumnAccessTracker.registerColumnAccess(column.name())
-        return column.getValue(this)
+
+        // Issue #442: df1Row[df2Column] should be df1Row[df2Column.name], not df2Column[df1Row(.index)]
+        return if (column.name() in df.columnNames()) {
+            df[column.name()][index] as R
+        } else {
+            column.getValue(this)
+        }
     }
 
     override fun <R> getValueOrNull(column: ColumnReference<R>): R? {
         ColumnAccessTracker.registerColumnAccess(column.name())
-        return column.getValueOrNull(this)
+
+        // Issue #442: df1Row[df2Column] should be df1Row[df2Column.name], not df2Column[df1Row(.index)]
+        return if (column.name() in df.columnNames()) {
+            df.getColumnOrNull(column.name())?.get(index) as? R?
+        } else {
+            column.getValueOrNull(this)
+        }
     }
 
     override fun index() = index

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toList.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toList.kt
@@ -68,7 +68,7 @@ internal fun AnyFrame.toListImpl(type: KType): List<Any> {
 
     return rows().map { row ->
         val parameters = convertedColumns.map {
-            row[it]
+            it[row]
         }.toTypedArray()
         constructor.call(*parameters)
     }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
@@ -3,12 +3,11 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.junit.Test
-import java.lang.ClassCastException
-import java.lang.IllegalArgumentException
 
 class GetTests {
 
@@ -30,6 +29,7 @@ class GetTests {
     fun `get value from row`() {
         val a by column<Int>()
         val c by column<Int>()
+
         data class A(val a: Int, val b: Int, val c: Int)
 
         val df = dataFrameOf("a", "b")(1, 2)
@@ -88,5 +88,24 @@ class GetTests {
             df[0].getColumnGroup("a")
         }
         throwable.message shouldContain "Cannot cast null value of a ValueColumn to"
+    }
+
+    @Test
+    fun `Get column from a data row`() {
+        val df1 = dataFrameOf("a")(1, 2, 3)
+        val a by column<String>()
+        val aPath = pathOf("a")
+
+        val df2 = dataFrameOf("a")(4, 5, 6)
+
+        df1.rows().forEach {
+            it["a"] shouldBe df1[it.index()][0]
+            it[a] shouldBe df1[it.index()][0]
+            it[aPath] shouldBe df1[it.index()][0]
+            it[df2["a"].name()] shouldBe df1[it.index()][0]
+            it[df2["a"]] shouldNotBe df2["a"][it]
+            it[df2["a"]] shouldBe it[df2["a"].name()]
+            it[df2["a"]] shouldBe df1[it.index()][0]
+        }
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DataRowImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DataRowImpl.kt
@@ -21,12 +21,24 @@ internal open class DataRowImpl<T>(private val index: Int, private val df: DataF
 
     override operator fun <R> get(column: ColumnReference<R>): R {
         ColumnAccessTracker.registerColumnAccess(column.name())
-        return column.getValue(this)
+
+        // Issue #442: df1Row[df2Column] should be df1Row[df2Column.name], not df2Column[df1Row(.index)]
+        return if (column.name() in df.columnNames()) {
+            df[column.name()][index] as R
+        } else {
+            column.getValue(this)
+        }
     }
 
     override fun <R> getValueOrNull(column: ColumnReference<R>): R? {
         ColumnAccessTracker.registerColumnAccess(column.name())
-        return column.getValueOrNull(this)
+
+        // Issue #442: df1Row[df2Column] should be df1Row[df2Column.name], not df2Column[df1Row(.index)]
+        return if (column.name() in df.columnNames()) {
+            df.getColumnOrNull(column.name())?.get(index) as? R?
+        } else {
+            column.getValueOrNull(this)
+        }
     }
 
     override fun index() = index

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toList.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toList.kt
@@ -68,7 +68,7 @@ internal fun AnyFrame.toListImpl(type: KType): List<Any> {
 
     return rows().map { row ->
         val parameters = convertedColumns.map {
-            row[it]
+            it[row]
         }.toTypedArray()
         constructor.call(*parameters)
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
@@ -3,12 +3,11 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.junit.Test
-import java.lang.ClassCastException
-import java.lang.IllegalArgumentException
 
 class GetTests {
 
@@ -30,6 +29,7 @@ class GetTests {
     fun `get value from row`() {
         val a by column<Int>()
         val c by column<Int>()
+
         data class A(val a: Int, val b: Int, val c: Int)
 
         val df = dataFrameOf("a", "b")(1, 2)
@@ -88,5 +88,24 @@ class GetTests {
             df[0].getColumnGroup("a")
         }
         throwable.message shouldContain "Cannot cast null value of a ValueColumn to"
+    }
+
+    @Test
+    fun `Get column from a data row`() {
+        val df1 = dataFrameOf("a")(1, 2, 3)
+        val a by column<String>()
+        val aPath = pathOf("a")
+
+        val df2 = dataFrameOf("a")(4, 5, 6)
+
+        df1.rows().forEach {
+            it["a"] shouldBe df1[it.index()][0]
+            it[a] shouldBe df1[it.index()][0]
+            it[aPath] shouldBe df1[it.index()][0]
+            it[df2["a"].name()] shouldBe df1[it.index()][0]
+            it[df2["a"]] shouldNotBe df2["a"][it]
+            it[df2["a"]] shouldBe it[df2["a"].name()]
+            it[df2["a"]] shouldBe df1[it.index()][0]
+        }
     }
 }


### PR DESCRIPTION
Implemented fix for https://github.com/Kotlin/dataframe/issues/442.

It used to be that `df1Row[df2Column] == df2Column[df1Row.index]`, but IMO that's confusing. I can see it was done to make `df1Row[df2Column]` and `df2Column[df1Row]` return the same thing but across the library, this is only actually used once (in toList and was fixed by swapping row/cols).

It's also very common for the library to call `df1Row[newColumn]` for reasons I don't fully understand. So my fix checks if the name of `newColumn` already exists in the row, if so, return the value at that name. If not, do the magic you did before and let the column handle the resolving of the value.

This seems to work with all tests and fixes the specific example of the issue.