### PR TITLE
Added message for incompatible libraries in Jupyter notebooks

### DIFF
--- a/docs/StardustDocs/topics/gettingStartedJupyterNotebook.md
+++ b/docs/StardustDocs/topics/gettingStartedJupyterNotebook.md
@@ -33,3 +33,8 @@ If you want to use a specific version of the Kotlin DataFrame library, you can s
 ```
 
 After loading, all essential types will be already imported, so you can start using the Kotlin DataFrame library. Enjoy!
+
+### Note
+Combining Kotlin DataFrame with out of date-, or similar libraries (such as [Krangl](https://github.com/holgerbrandl/krangl))
+in the same notebook might result in unexpected behavior, such as a `NoSuchMethodException`. This could be due
+to overlapping dependencies. Try removing the other library, restart the kernel, and see if the problem persists.


### PR DESCRIPTION
We faced an incompatibility issue by one of our users using Krangl in the same notebook. it broke because Krangl uses Apache commons csv v1.6 while DF uses 1.7: https://kotlinlang.slack.com/archives/C05333T208Y/p1693933250176339

I added a small generic message in the docs regarding this.