### PR TITLE
Public `empty(DataFrameSchema)` API

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
@@ -16,7 +16,9 @@ import org.jetbrains.kotlinx.dataframe.impl.DataFrameSize
 import org.jetbrains.kotlinx.dataframe.impl.getColumnsImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.impl.headPlusIterable
+import org.jetbrains.kotlinx.dataframe.impl.schema.createEmptyDataFrame
 import org.jetbrains.kotlinx.dataframe.impl.schema.createEmptyDataFrameOf
+import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import kotlin.reflect.KType
 
 /**
@@ -32,7 +34,18 @@ public interface DataFrame<out T> : Aggregatable<T>, ColumnsContainer<T> {
         public val Empty: AnyFrame = DataFrameImpl<Unit>(emptyList(), 0)
         public fun empty(nrow: Int = 0): AnyFrame = if (nrow == 0) Empty else DataFrameImpl<Unit>(emptyList(), nrow)
 
+        /**
+         * Creates a DataFrame with empty columns (rows = 0).
+         * Can be used as a "null object" in aggregation operations, operations that work on columns (select, reorder, ...)
+         *
+         */
         public inline fun <reified T> emptyOf(): DataFrame<T> = createEmptyDataFrameOf(T::class).cast()
+
+        /**
+         * Creates a DataFrame with empty columns (rows = 0).
+         * Can be used as a "null object" in aggregation operations, operations that work on columns (select, reorder, ...)
+         */
+        public fun empty(schema: DataFrameSchema): AnyFrame = schema.createEmptyDataFrame()
     }
 
     // region columns

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -20,6 +20,9 @@ import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.values
 
+/**
+ * @property df DataFrame containing [groups] column and key columns. Represents GroupBy.
+ */
 internal class GroupByImpl<T, G>(
     val df: DataFrame<T>,
     override val groups: FrameColumn<G>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataFrame.kt
@@ -16,7 +16,9 @@ import org.jetbrains.kotlinx.dataframe.impl.DataFrameSize
 import org.jetbrains.kotlinx.dataframe.impl.getColumnsImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.impl.headPlusIterable
+import org.jetbrains.kotlinx.dataframe.impl.schema.createEmptyDataFrame
 import org.jetbrains.kotlinx.dataframe.impl.schema.createEmptyDataFrameOf
+import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import kotlin.reflect.KType
 
 /**
@@ -32,7 +34,18 @@ public interface DataFrame<out T> : Aggregatable<T>, ColumnsContainer<T> {
         public val Empty: AnyFrame = DataFrameImpl<Unit>(emptyList(), 0)
         public fun empty(nrow: Int = 0): AnyFrame = if (nrow == 0) Empty else DataFrameImpl<Unit>(emptyList(), nrow)
 
+        /**
+         * Creates a DataFrame with empty columns (rows = 0).
+         * Can be used as a "null object" in aggregation operations, operations that work on columns (select, reorder, ...)
+         *
+         */
         public inline fun <reified T> emptyOf(): DataFrame<T> = createEmptyDataFrameOf(T::class).cast()
+
+        /**
+         * Creates a DataFrame with empty columns (rows = 0).
+         * Can be used as a "null object" in aggregation operations, operations that work on columns (select, reorder, ...)
+         */
+        public fun empty(schema: DataFrameSchema): AnyFrame = schema.createEmptyDataFrame()
     }
 
     // region columns

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -20,6 +20,9 @@ import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.values
 
+/**
+ * @property df DataFrame containing [groups] column and key columns. Represents GroupBy.
+ */
 internal class GroupByImpl<T, G>(
     val df: DataFrame<T>,
     override val groups: FrameColumn<G>,


### PR DESCRIPTION
It's needed in Kandy to create GroupBy with empty groups that can still be aggregated. You can see the difference in the test i added