### PR TITLE
Configure documentation

### DIFF
--- a/docs/StardustDocs/cfg/buildprofiles.xml
+++ b/docs/StardustDocs/cfg/buildprofiles.xml
@@ -16,10 +16,18 @@
         <search-scopes-provider>https://www.jetbrains.com/search/json/</search-scopes-provider>
         <generate-sitemap-url-prefix>https://kotlin.github.io/dataframe/</generate-sitemap-url-prefix>
         <analytics-head-script-file>resize-iframes.js</analytics-head-script-file>
+        <enable-browser-edits>true</enable-browser-edits>
+        <browser-edits-url>https://github.com/Kotlin/dataframe/edit/master/docs/StardustDocs/</browser-edits-url>
     </variables>
     <build-profile instance="d">
         <variables>
             <noindex-content>false</noindex-content>
         </variables>
     </build-profile>
+    <footer>
+        <social type="twitter" href="https://twitter.com/KotlinForData"/>
+        <social type="youtube" href="https://www.youtube.com/@Kotlin"/>
+        <link href="https://github.com/Kotlin/dataframe">GitHub</link>
+        <link href="https://kotlinlang.slack.com/archives/C4W52CFEZ">Slack Community</link>
+    </footer>
 </buildprofiles>


### PR DESCRIPTION
I saw some cool features of the Writerside in Kandy and decided to add media links, logo and enable link to GitHub editing from the documentation pages
Just so you can see how it looks:
![image](https://github.com/Kotlin/dataframe/assets/12936457/52757ff6-f1da-49a2-819d-6a3a3a348dcb)

![image](https://github.com/Kotlin/dataframe/assets/12936457/76a1da5a-059a-48e8-850b-06b0cb573075)

![image](https://github.com/Kotlin/dataframe/assets/12936457/5ddf7dce-d6ca-4f7c-b805-4cb96c53d5d8)
