### PR TITLE
Add the missing renderers for the bunch of intermediate objects

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -10,20 +10,27 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.api.Convert
+import org.jetbrains.kotlinx.dataframe.api.FormatClause
 import org.jetbrains.kotlinx.dataframe.api.FormattedFrame
 import org.jetbrains.kotlinx.dataframe.api.Gather
 import org.jetbrains.kotlinx.dataframe.api.GroupBy
+import org.jetbrains.kotlinx.dataframe.api.GroupClause
+import org.jetbrains.kotlinx.dataframe.api.InsertClause
 import org.jetbrains.kotlinx.dataframe.api.Merge
+import org.jetbrains.kotlinx.dataframe.api.MoveClause
 import org.jetbrains.kotlinx.dataframe.api.Pivot
 import org.jetbrains.kotlinx.dataframe.api.PivotGroupBy
 import org.jetbrains.kotlinx.dataframe.api.ReducedGroupBy
 import org.jetbrains.kotlinx.dataframe.api.ReducedPivot
 import org.jetbrains.kotlinx.dataframe.api.ReducedPivotGroupBy
+import org.jetbrains.kotlinx.dataframe.api.RenameClause
+import org.jetbrains.kotlinx.dataframe.api.ReplaceClause
 import org.jetbrains.kotlinx.dataframe.api.Split
 import org.jetbrains.kotlinx.dataframe.api.SplitWithTransform
 import org.jetbrains.kotlinx.dataframe.api.Update
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.asDataFrame
+import org.jetbrains.kotlinx.dataframe.api.at
 import org.jetbrains.kotlinx.dataframe.api.columnsCount
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.frames
@@ -215,6 +222,13 @@ internal class Integration(
                 applyRowsLimit = false
             )
 
+            render<GroupClause<*, *>>({ "Group" })
+            render<MoveClause<*, *>>({ "Move" })
+            render<RenameClause<*, *>>({ "Rename" })
+            render<ReplaceClause<*, *>>({ "Replace" })
+            render<InsertClause<*>>({ "Insert" })
+            render<FormatClause<*, *>>({ "Format" })
+
             render<DataFrameHtmlData> {
                 // Our integration declares script and css definition. But in Kotlin Notebook outputs are isolated in IFrames
                 // That's why we include them directly in the output
@@ -350,5 +364,11 @@ internal fun convertToDataFrame(dataframeLike: Any): AnyFrame =
         is GroupBy<*, *> -> dataframeLike.toDataFrame()
         is AnyFrame -> dataframeLike
         is DisableRowsLimitWrapper -> dataframeLike.value
+        is MoveClause<*, *> -> dataframeLike.df
+        is RenameClause<*, *> -> dataframeLike.df
+        is ReplaceClause<*, *> -> dataframeLike.df
+        is GroupClause<*, *> -> dataframeLike.into("untitled")
+        is InsertClause<*> -> dataframeLike.at(0)
+        is FormatClause<*, *> -> dataframeLike.df
         else -> throw IllegalArgumentException("Unsupported type: ${dataframeLike::class}")
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/Integration.kt
@@ -10,20 +10,27 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.api.Convert
+import org.jetbrains.kotlinx.dataframe.api.FormatClause
 import org.jetbrains.kotlinx.dataframe.api.FormattedFrame
 import org.jetbrains.kotlinx.dataframe.api.Gather
 import org.jetbrains.kotlinx.dataframe.api.GroupBy
+import org.jetbrains.kotlinx.dataframe.api.GroupClause
+import org.jetbrains.kotlinx.dataframe.api.InsertClause
 import org.jetbrains.kotlinx.dataframe.api.Merge
+import org.jetbrains.kotlinx.dataframe.api.MoveClause
 import org.jetbrains.kotlinx.dataframe.api.Pivot
 import org.jetbrains.kotlinx.dataframe.api.PivotGroupBy
 import org.jetbrains.kotlinx.dataframe.api.ReducedGroupBy
 import org.jetbrains.kotlinx.dataframe.api.ReducedPivot
 import org.jetbrains.kotlinx.dataframe.api.ReducedPivotGroupBy
+import org.jetbrains.kotlinx.dataframe.api.RenameClause
+import org.jetbrains.kotlinx.dataframe.api.ReplaceClause
 import org.jetbrains.kotlinx.dataframe.api.Split
 import org.jetbrains.kotlinx.dataframe.api.SplitWithTransform
 import org.jetbrains.kotlinx.dataframe.api.Update
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.asDataFrame
+import org.jetbrains.kotlinx.dataframe.api.at
 import org.jetbrains.kotlinx.dataframe.api.columnsCount
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.frames
@@ -215,6 +222,13 @@ internal class Integration(
                 applyRowsLimit = false
             )
 
+            render<GroupClause<*, *>>({ "Group" })
+            render<MoveClause<*, *>>({ "Move" })
+            render<RenameClause<*, *>>({ "Rename" })
+            render<ReplaceClause<*, *>>({ "Replace" })
+            render<InsertClause<*>>({ "Insert" })
+            render<FormatClause<*, *>>({ "Format" })
+
             render<DataFrameHtmlData> {
                 // Our integration declares script and css definition. But in Kotlin Notebook outputs are isolated in IFrames
                 // That's why we include them directly in the output
@@ -350,5 +364,11 @@ internal fun convertToDataFrame(dataframeLike: Any): AnyFrame =
         is GroupBy<*, *> -> dataframeLike.toDataFrame()
         is AnyFrame -> dataframeLike
         is DisableRowsLimitWrapper -> dataframeLike.value
+        is MoveClause<*, *> -> dataframeLike.df
+        is RenameClause<*, *> -> dataframeLike.df
+        is ReplaceClause<*, *> -> dataframeLike.df
+        is GroupClause<*, *> -> dataframeLike.into("untitled")
+        is InsertClause<*> -> dataframeLike.at(0)
+        is FormatClause<*, *> -> dataframeLike.df
         else -> throw IllegalArgumentException("Unsupported type: ${dataframeLike::class}")
     }


### PR DESCRIPTION
Add renderers for intermediate results of some Multiplex operations such as Move, Rename, Replace, Group, Insert, and Format.

Fixes KTNB-366