### PR TITLE
remove klaxon usage outside json.kt

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
-import com.beust.klaxon.internal.firstNotNullResult
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
@@ -88,4 +87,12 @@ internal fun <T> concatImpl(dataFrames: List<DataFrame<T>>): DataFrame<T> {
     } else {
         dataFrameOf(columns)
     }.cast()
+}
+
+private inline fun <T, R : Any> Iterable<T>.firstNotNullResult(transform: (T) -> R?): R? {
+    for (element in this) {
+        val result = transform(element)
+        if (result != null) return result
+    }
+    return null
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/concat.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
-import com.beust.klaxon.internal.firstNotNullResult
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
@@ -88,4 +87,12 @@ internal fun <T> concatImpl(dataFrames: List<DataFrame<T>>): DataFrame<T> {
     } else {
         dataFrameOf(columns)
     }.cast()
+}
+
+private inline fun <T, R : Any> Iterable<T>.firstNotNullResult(transform: (T) -> R?): R? {
+    for (element in this) {
+        val result = transform(element)
+        if (result != null) return result
+    }
+    return null
 }


### PR DESCRIPTION
Excluding klaxon transivite dependency which is fine if you don't use JSON reading can lead to an unexpected class not found exception now