### PR TITLE
Added ! to DataColumnArithmetics

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
@@ -6,6 +6,16 @@ import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import java.math.BigDecimal
 
+public operator fun DataColumn<Boolean>.not(): DataColumn<Boolean> = map { !it }
+
+@JvmName("notBooleanNullable")
+public operator fun DataColumn<Boolean?>.not(): DataColumn<Boolean?> = map { it?.not() }
+
+public operator fun ColumnReference<Boolean>.not(): ColumnReference<Boolean> = map { !it }
+
+@JvmName("notBooleanNullable")
+public operator fun ColumnReference<Boolean?>.not(): ColumnReference<Boolean?> = map { it?.not() }
+
 public operator fun DataColumn<Int>.plus(value: Int): DataColumn<Int> = map { it + value }
 
 public operator fun DataColumn<Int>.minus(value: Int): DataColumn<Int> = map { it - value }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
@@ -6,6 +6,16 @@ import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import java.math.BigDecimal
 
+public operator fun DataColumn<Boolean>.not(): DataColumn<Boolean> = map { !it }
+
+@JvmName("notBooleanNullable")
+public operator fun DataColumn<Boolean?>.not(): DataColumn<Boolean?> = map { it?.not() }
+
+public operator fun ColumnReference<Boolean>.not(): ColumnReference<Boolean> = map { !it }
+
+@JvmName("notBooleanNullable")
+public operator fun ColumnReference<Boolean?>.not(): ColumnReference<Boolean?> = map { it?.not() }
+
 public operator fun DataColumn<Int>.plus(value: Int): DataColumn<Int> = map { it + value }
 
 public operator fun DataColumn<Int>.minus(value: Int): DataColumn<Int> = map { it - value }


### PR DESCRIPTION
Very small addition which adds `!booleanColumn` notation across the library similar to the other arithmetics we support.

 As referenced by https://github.com/Kotlin/dataframe/issues/530.