### PR TITLE
Fix performance problem in `rename` implementation

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/rename.kt
@@ -22,14 +22,14 @@ internal fun <T, C> RenameClause<T, C>.renameImpl(newNames: Array<out String>): 
 internal fun <T, C> RenameClause<T, C>.renameImpl(transform: (ColumnWithPath<C>) -> String): DataFrame<T> {
     // get all selected columns and their paths
     val selectedColumnsWithPath = df.getColumnsWithPaths(columns)
-        .associateBy { it.data }
+        .associateBy { it.path }
     // gather a tree of all columns where the nodes will be renamed
     val tree = df.getColumnsWithPaths { all().rec() }.collectTree()
 
     // perform rename in nodes
-    tree.allChildrenNotNull().forEach { node ->
+    tree.allChildrenNotNull().map { it to it.pathFromRoot() }.forEach { (node, originalPath) ->
         // Check if the current node/column is a selected column and, if so, get its ColumnWithPath
-        val column = selectedColumnsWithPath[node.data] ?: return@forEach
+        val column = selectedColumnsWithPath[originalPath] ?: return@forEach
         // Use the found selected ColumnWithPath to query for the new name
         val newColumnName = transform(column)
         node.name = newColumnName


### PR DESCRIPTION
Currently `DataColumn` object is used as a key for `associateBy` in `rename` implementation. It leads to computation of rolling hash function and scanning through all column data. This problem can be seen in stack trace for https://github.com/Kotlin/dataframe/issues/526

Instead, a column path should be used as column id.