### PR TITLE
Add option to prevent Gradle plugin from adding dependency on KSP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ksp = "1.9.0-1.0.12"
+ksp = "1.9.21-1.0.15"
 kotlinJupyter = "0.11.0-358"
 ktlint = "3.4.5"
 kotlin = "1.9.0"

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/toCamelCaseByDelimiters.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/toCamelCaseByDelimiters.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.dataframe.gradle
 
+import java.util.Locale
+
 fun String.toCamelCaseByDelimiters(delimiters: Regex): String {
-    return split(delimiters).joinToCamelCaseString().decapitalize()
+    return split(delimiters).joinToCamelCaseString().replaceFirstChar { it.lowercase(Locale.getDefault()) }
 }
 
 fun List<String>.joinToCamelCaseString(): String {
-    return joinToString(separator = "") { it.capitalize() }
+    return joinToString(separator = "") { s -> s.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }
 }

--- a/plugins/symbol-processor/src/main/kotlin/org/jetbrains/dataframe/ksp/DataSchemaGenerator.kt
+++ b/plugins/symbol-processor/src/main/kotlin/org/jetbrains/dataframe/ksp/DataSchemaGenerator.kt
@@ -48,9 +48,7 @@ class DataSchemaGenerator(
     private val codeGenerator: com.google.devtools.ksp.processing.CodeGenerator,
 ) {
 
-    fun resolveImportStatements() = listOf(
-        ::resolvePathImports,
-    ).flatMap { it(resolver) }
+    fun resolveImportStatements(): List<ImportDataSchemaStatement> = resolvePathImports(resolver).toList()
 
     class ImportDataSchemaStatement(
         val origin: KSFile,


### PR DESCRIPTION
We add plugin automatically for better onboarding experience, but it makes project depend on some specific KSP version. KSP complains when people use it with different version of compiler:
`ksp-1.9.0-1.0.12 is too old for kotlin-1.9.21. Please upgrade ksp or downgrade kotlin-gradle-plugin to 1.9.0.`

Still, it's ok to use preprocessor built for 1.9.0 with KSP 1.9.21. That's why we need an option for people to decide version of KSP they need in their project.
People will be able to use our preprocessor built for older versions of KSP API most of the time without problems thanks to backward compatibility
In dataframe project itself we always need to update Kotlin version in two steps. With this change (and one more PR later) it won't be necessary anymore