### PR TITLE
Ksp fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-ksp = "1.9.21-1.0.15"
+ksp = "1.9.22-1.0.17"
 kotlinJupyter = "0.11.0-358"
 ktlint = "3.4.5"
-kotlin = "1.9.0"
+kotlin = "1.9.22"
 dokka = "1.8.10"
 libsPublisher = "0.0.60-dev-30"
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -33,6 +33,9 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                 target.configurations.getByName("ksp").dependencies.add(
                     target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
                 )
+                target.configurations.getByName("kspTest").dependencies.add(
+                    target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
+                )
                 target.logger.info("Added DataFrame dependency to the KSP plugin.")
             }
         }

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -30,12 +30,20 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
         // configure it to depend on symbol-processor-all
         target.plugins.whenPluginAdded {
             if ("com.google.devtools.ksp" in this.javaClass.packageName) {
-                target.configurations.getByName("ksp").dependencies.add(
-                    target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
-                )
-                target.configurations.getByName("kspTest").dependencies.add(
-                    target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
-                )
+                try {
+                    target.configurations.getByName("ksp").dependencies.add(
+                        target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
+                    )
+                } catch (e: UnknownConfigurationException) {
+                    target.logger.warn("Configuration 'ksp' not found. Please make sure the KSP plugin is applied.")
+                }
+                try {
+                    target.configurations.getByName("kspTest").dependencies.add(
+                        target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
+                    )
+                } catch (e: UnknownConfigurationException) {
+                    target.logger.warn("Configuration 'kspTest' not found. Please make sure the KSP plugin is applied.")
+                }
                 target.logger.info("Added DataFrame dependency to the KSP plugin.")
             }
         }

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -3,6 +3,7 @@ package org.jetbrains.dataframe.gradle
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.kotlin.dsl.findByType
 import java.util.*
 
@@ -20,9 +21,33 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                 target.logger.warn("Invalid value '$property' for '$name' property. Defaulting to '$addKsp'. Please use 'true' or 'false'.")
             }
         }
-        if (addKsp) {
-            target.plugins.apply(KspPluginApplier::class.java)
+
+        val properties = Properties()
+        properties.load(javaClass.getResourceAsStream("plugin.properties"))
+        val preprocessorVersion = properties.getProperty("PREPROCESSOR_VERSION")
+
+        // regardless whether we add KSP or the user adds it, when it's added,
+        // configure it to depend on symbol-processor-all
+        target.plugins.whenPluginAdded {
+            if ("com.google.devtools.ksp" in this.javaClass.packageName) {
+                target.configurations.getByName("ksp").dependencies.add(
+                    target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
+                )
+                target.logger.info("Added DataFrame dependency to the KSP plugin.")
+            }
         }
+
+        if (addKsp) {
+            target.plugins.apply(KspPluginApplierAndConfigurer::class.java)
+        } else {
+            target.logger.warn(
+                "Plugin 'org.jetbrains.kotlinx.dataframe' comes bundled with its own version of KSP which is " +
+                    "currently disabled as 'kotlin.dataframe.add.ksp' is set to 'false' in a 'properties' file. " +
+                    "Either set 'kotlin.dataframe.add.ksp' to 'true' or add the plugin 'com.google.devtools.ksp' " +
+                    "manually."
+            )
+        }
+
         target.afterEvaluate {
             target.extensions.findByType<KspExtension>()?.arg("dataframe.resolutionDir", target.projectDir.absolutePath)
         }
@@ -38,14 +63,13 @@ class DeprecatingSchemaGeneratorPlugin : Plugin<Project> {
     }
 }
 
-internal class KspPluginApplier : Plugin<Project> {
+/**
+ * Applies and configures the KSP plugin in the target project.
+ */
+internal class KspPluginApplierAndConfigurer : Plugin<Project> {
     override fun apply(target: Project) {
         val properties = Properties()
         properties.load(javaClass.getResourceAsStream("plugin.properties"))
-        val preprocessorVersion = properties.getProperty("PREPROCESSOR_VERSION")
         target.plugins.apply("com.google.devtools.ksp")
-        target.configurations.getByName("ksp").dependencies.add(
-            target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
-        )
     }
 }

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.UnknownConfigurationException
-import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByType
 import java.util.*
 
 @Suppress("unused")
@@ -45,11 +45,12 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                     target.logger.warn("Configuration 'kspTest' not found. Please make sure the KSP plugin is applied.")
                 }
                 target.logger.info("Added DataFrame dependency to the KSP plugin.")
+                target.extensions.getByType<KspExtension>().arg("dataframe.resolutionDir", target.projectDir.absolutePath)
             }
         }
 
         if (addKsp) {
-            target.plugins.apply(KspPluginApplierAndConfigurer::class.java)
+            target.plugins.apply(KspPluginApplier::class.java)
         } else {
             target.logger.warn(
                 "Plugin 'org.jetbrains.kotlinx.dataframe' comes bundled with its own version of KSP which is " +
@@ -57,10 +58,6 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                     "Either set 'kotlin.dataframe.add.ksp' to 'true' or add the plugin 'com.google.devtools.ksp' " +
                     "manually."
             )
-        }
-
-        target.afterEvaluate {
-            target.extensions.findByType<KspExtension>()?.arg("dataframe.resolutionDir", target.projectDir.absolutePath)
         }
         target.plugins.apply(SchemaGeneratorPlugin::class.java)
     }
@@ -75,9 +72,9 @@ class DeprecatingSchemaGeneratorPlugin : Plugin<Project> {
 }
 
 /**
- * Applies and configures the KSP plugin in the target project.
+ * Applies the KSP plugin in the target project.
  */
-internal class KspPluginApplierAndConfigurer : Plugin<Project> {
+internal class KspPluginApplier : Plugin<Project> {
     override fun apply(target: Project) {
         val properties = Properties()
         properties.load(javaClass.getResourceAsStream("plugin.properties"))

--- a/plugins/expressions-converter/src/org/jetbrains/kotlinx/dataframe/ExplainerIrTransformer.kt
+++ b/plugins/expressions-converter/src/org/jetbrains/kotlinx/dataframe/ExplainerIrTransformer.kt
@@ -222,7 +222,7 @@ class ExplainerIrTransformer(
                     add(data.function?.name?.asString().irConstImpl())
                     add(IrConstImpl.int(-1, -1, pluginContext.irBuiltIns.intType, data.statementIndex))
                 }
-                body = pluginContext.irFactory.createBlockBody(-1, -1) {
+                body = pluginContext.irFactory.createBlockBody(-1, -1).apply {
                     val callback = FqName("org.jetbrains.kotlinx.dataframe.explainer.PluginCallbackProxy.doAction")
                     val doAction = pluginContext.referenceFunctions(callback).single()
                     statements += IrCallImpl(


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/pull/571 further.

With `kotlin.dataframe.add.ksp=false`, the user-specified KSP still needs to depend on symbol-processor-all like before. This PR configures KSP regardless of the add.ksp setting.