### PR TITLE
Version bumping Dokka to 1.9.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,8 +80,8 @@ val dependencyUpdateExclusions = listOf(
     libs.kotestAssertions.get().name,
     // Can't be updated to 7.4.0+ due to Java 8 compatibility
     libs.android.gradle.api.get().group,
-    // TODO 1.9.10 requires korro and docProcessor to update, https://github.com/Kotlin/dataframe/issues/596
-    libs.plugins.dokka.get().pluginId,
+    // TODO 0.1.6 breaks ktlint, https://github.com/Kotlin/dataframe/issues/598
+    libs.plugins.korro.get().pluginId,
     // Directly dependent on the Gradle version
     "org.gradle.kotlin.kotlin-dsl",
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
         alias(dokka)
         alias(kover)
         alias(kotlinter)
+        alias(korro) apply false
         alias(docProcessor) apply false
         alias(simpleGit) apply false
         alias(dependencyVersions)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ libsPublisher = "1.8.10-dev-43"
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
 dataframe = "0.13.0-dev-2838"
 
-korro = "0.1.6"
+korro = "0.1.5"
 
 # TODO Requires more work to be updated to 0.7.0+
 # https://github.com/Kotlin/dataframe/issues/594

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlinpoet = "1.16.0"
 
 # TODO 1.9.10 requires korro and docProcessor to update
 # https://github.com/Kotlin/dataframe/issues/596
-dokka = "1.8.10"
+dokka = "1.9.10"
 
 libsPublisher = "1.8.10-dev-43"
 
@@ -20,7 +20,7 @@ libsPublisher = "1.8.10-dev-43"
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
 dataframe = "0.13.0-dev-2838"
 
-korro = "0.1.5"
+korro = "0.1.6"
 
 # TODO Requires more work to be updated to 0.7.0+
 # https://github.com/Kotlin/dataframe/issues/594

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,9 +9,6 @@ ktlint = "3.4.5"
 # make sure to sync manually with :generator module
 kotlin = "1.9.22"
 kotlinpoet = "1.16.0"
-
-# TODO 1.9.10 requires korro and docProcessor to update
-# https://github.com/Kotlin/dataframe/issues/596
 dokka = "1.9.10"
 
 libsPublisher = "1.8.10-dev-43"
@@ -20,6 +17,7 @@ libsPublisher = "1.8.10-dev-43"
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
 dataframe = "0.13.0-dev-2838"
 
+# TODO 0.1.6 breaks ktlint, https://github.com/Kotlin/dataframe/issues/598
 korro = "0.1.5"
 
 # TODO Requires more work to be updated to 0.7.0+


### PR DESCRIPTION
Continuation of https://github.com/Kotlin/dataframe/pull/590

Fixes https://github.com/Kotlin/dataframe/issues/596

But I found that korro 0.1.6 does not work in the project: https://github.com/Kotlin/dataframe/issues/598