### PR TITLE
Set docs and readme to 0.13.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ env:
   ALGOLIA_INDEX_NAME: prod_DATAFRAME_HELP
   ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
   CONFIG_JSON_PRODUCT: Dataframe
-  CONFIG_JSON_VERSION: '0.12'
+  CONFIG_JSON_VERSION: '0.13'
 
 jobs:
   build-job:

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ You could find the following articles there:
 ## Setup
 
 ```kotlin
-implementation("org.jetbrains.kotlinx:dataframe:0.12.1")
+implementation("org.jetbrains.kotlinx:dataframe:0.13.1")
 ```
 
 Optional Gradle plugin for enhanced type safety and schema generation
 https://kotlin.github.io/dataframe/schemasgradle.html
 ```kotlin
-id("org.jetbrains.kotlinx.dataframe") version "0.12.1"
+id("org.jetbrains.kotlinx.dataframe") version "0.13.1"
 ```
 
 Check out the [custom setup page](https://kotlin.github.io/dataframe/gettingstartedgradleadvanced.html) if you don't need some of the formats as dependencies,
@@ -69,7 +69,7 @@ df.filter { "stargazers_count"<Int>() > 50 }.print()
 
 Requires Gradle plugin to work
 ```kotlin
-id("org.jetbrains.kotlinx.dataframe") version "0.12.1"
+id("org.jetbrains.kotlinx.dataframe") version "0.13.1"
 ```
 
 Plugin generates extension properties API for provided sample of data. Column names and their types become discoverable in completion.
@@ -219,7 +219,7 @@ This table shows the mapping between main library component versions and minimum
 | 0.11.1                   | 8                    | 1.8.20         | 0.11.0-358             | 3.0.0           | 11.0.0               |
 | 0.12.0                   | 8                    | 1.9.0          | 0.11.0-358             | 3.0.0           | 11.0.0               |
 | 0.12.1                   | 8                    | 1.9.0          | 0.11.0-358             | 3.0.0           | 11.0.0               |
-
+| 0.13.1                   | 8                    | 1.9.22         | 0.12.0-139             | 3.0.0           | 15.0.0               |
 
 ## Code of Conduct
 

--- a/docs/StardustDocs/project.ihp
+++ b/docs/StardustDocs/project.ihp
@@ -4,10 +4,10 @@
 <ihp version="2.0">
     <categories src="c.list"/>
     <topics dir="topics"/>
-    <images dir="images" version="0.12" web-path="images/" />
-    <snippets dir="snippets" version="0.12" web-path="snippets/" />
+    <images dir="images" version="0.13" web-path="images/" />
+    <snippets dir="snippets" version="0.13" web-path="snippets/" />
     <vars src="v.list"/>
-    <instance src="d.tree" version="0.12" id="dataframe"/>
+    <instance src="d.tree" version="0.13" id="dataframe"/>
     <settings>
         <default-property element-name="chapter" property-name="show-structure-depth" value="2"/>
     </settings>

--- a/docs/StardustDocs/v.list
+++ b/docs/StardustDocs/v.list
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE vars SYSTEM "https://resources.jetbrains.com/writerside/1.0/vars.dtd">
 <vars>
-    <var name="dataFrameVersion" value="0.12.1" type="string"/>
+    <var name="dataFrameVersion" value="0.13.1" type="string"/>
 </vars>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectName=dataframe
-version=0.13.1
+version=0.13.2
 jupyterApiTCRepo=
 kotlin.jupyter.add.scanner=false
 org.gradle.jvmargs=-Xmx4G

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ libsPublisher = "1.8.10-dev-43"
 
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
-dataframe = "0.13.1-RC1"
+dataframe = "0.13.1"
 
 # TODO 0.1.6 breaks ktlint, https://github.com/Kotlin/dataframe/issues/598
 korro = "0.1.5"


### PR DESCRIPTION
As the title says. 
Also updates the version in gradle.properties to 0.13.2 for now.

If we decide to enter the next cycle, this will need to be set to 0.14.0 and we can update deprecations