### PR TITLE
add random parameter to shuffle

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/shuffle.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/shuffle.kt
@@ -3,14 +3,19 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.indices
+import kotlin.random.Random
 
 // region DataColumn
+
+public fun <T> DataColumn<T>.shuffle(random: Random): DataColumn<T> = get(indices.shuffled(random))
 
 public fun <T> DataColumn<T>.shuffle(): DataColumn<T> = get(indices.shuffled())
 
 // endregion
 
 // region DataFrame
+
+public fun <T> DataFrame<T>.shuffle(random: Random): DataFrame<T> = getRows(indices.shuffled(random))
 
 public fun <T> DataFrame<T>.shuffle(): DataFrame<T> = getRows(indices.shuffled())
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/shuffle.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/shuffle.kt
@@ -3,14 +3,19 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.indices
+import kotlin.random.Random
 
 // region DataColumn
+
+public fun <T> DataColumn<T>.shuffle(random: Random): DataColumn<T> = get(indices.shuffled(random))
 
 public fun <T> DataColumn<T>.shuffle(): DataColumn<T> = get(indices.shuffled())
 
 // endregion
 
 // region DataFrame
+
+public fun <T> DataFrame<T>.shuffle(random: Random): DataFrame<T> = getRows(indices.shuffled(random))
 
 public fun <T> DataFrame<T>.shuffle(): DataFrame<T> = getRows(indices.shuffled())
 


### PR DESCRIPTION
partially fixes #420
i'm not sure why, but stdlib doesn't use default value for this parameter and instead introduces an overload. I decided to follow this 