### PR TITLE
Add GroupBy variable converter in Jupyter

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
@@ -33,6 +33,8 @@ else cast()
 
 public fun <T> AnyRow.cast(): DataRow<T> = this as DataRow<T>
 
+public fun <T, G> GroupBy<*, *>.cast(): GroupBy<T, G> = this as GroupBy<T, G>
+
 public inline fun <reified T> AnyRow.cast(verify: Boolean = true): DataRow<T> = df().cast<T>(verify)[0]
 
 public fun <T> AnyCol.cast(): DataColumn<T> = this as DataColumn<T>

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.codeGen.Marker
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkerVisibility
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkersExtractor
 import org.jetbrains.kotlinx.dataframe.codeGen.NameNormalizer
+import org.jetbrains.kotlinx.dataframe.codeGen.ProvidedCodeConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.CodeGeneratorImpl
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.FullyQualifiedNames
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ShortNames
@@ -22,7 +23,7 @@ public enum class InterfaceGenerationMode {
     None;
 }
 
-public data class CodeGenResult(val code: CodeWithConverter, val newMarkers: List<Marker>)
+public data class CodeGenResult(val code: CodeWithConverter<ProvidedCodeConverter>, val newMarkers: List<Marker>)
 
 public interface CodeGenerator : ExtensionsCodeGenerator {
 
@@ -43,7 +44,7 @@ public interface CodeGenerator : ExtensionsCodeGenerator {
         interfaceMode: InterfaceGenerationMode,
         extensionProperties: Boolean,
         readDfMethod: DefaultReadDfMethod? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<ProvidedCodeConverter>
 
     public companion object {
         public fun create(useFqNames: Boolean = true): CodeGenerator {
@@ -61,7 +62,7 @@ internal fun CodeGenerator.generate(
     markerClass: KClass<*>,
     interfaceMode: InterfaceGenerationMode,
     extensionProperties: Boolean,
-): CodeWithConverter = generate(
+): CodeWithConverter<ProvidedCodeConverter> = generate(
     MarkersExtractor.get(markerClass),
     interfaceMode,
     extensionProperties
@@ -70,4 +71,4 @@ internal fun CodeGenerator.generate(
 public inline fun <reified T> CodeGenerator.generate(
     interfaceMode: InterfaceGenerationMode,
     extensionProperties: Boolean,
-): CodeWithConverter = generate(T::class, interfaceMode, extensionProperties)
+): CodeWithConverter<ProvidedCodeConverter> = generate(T::class, interfaceMode, extensionProperties)

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeWithConverter.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeWithConverter.kt
@@ -7,14 +7,19 @@ import org.jetbrains.kotlinx.jupyter.api.VariableName
  * Class representing generated code declarations for a [Marker].
  *
  * @param declarations The generated code.
+ * @param converter Needs to provide additional info (name) from org.jetbrains.dataframe.impl.codeGen.CodeGenerator to its callers
+ * But at the same time name doesn't make sense for GroupBy where code to be executed contains two declarations
  * @param converter Optional converter for the [Marker], such as a [org.jetbrains.kotlinx.dataframe.api.cast], often used for Jupyter.
  */
-public data class CodeWithConverter(val declarations: Code, val converter: (VariableName) -> Code = EmptyConverter) {
+public data class CodeWithConverter<T : CodeConverter>(
+    val declarations: Code,
+    val converter: T
+) {
 
     public companion object {
         public const val EmptyDeclarations: Code = ""
-        public val EmptyConverter: (VariableName) -> Code = { it }
-        public val Empty: CodeWithConverter = CodeWithConverter(EmptyDeclarations, EmptyConverter)
+        public val EmptyConverter: CodeConverter = CodeConverter { it }
+        public val Empty: CodeWithConverter<CodeConverter> = CodeWithConverter(EmptyDeclarations, EmptyConverter)
     }
 
     val hasDeclarations: Boolean get() = declarations.isNotBlank()
@@ -25,5 +30,21 @@ public data class CodeWithConverter(val declarations: Code, val converter: (Vari
         !hasConverter -> declarations
         !hasDeclarations -> converter(name)
         else -> declarations + "\n" + converter(name)
+    }
+}
+
+public sealed interface CodeConverter : (VariableName) -> Code
+
+public class CodeConverterImpl(private val f: (VariableName) -> Code) : CodeConverter {
+    override fun invoke(p1: VariableName): Code {
+        return f(p1)
+    }
+}
+
+public fun CodeConverter(f: (VariableName) -> Code): CodeConverter = CodeConverterImpl(f)
+
+public class ProvidedCodeConverter(public val markerName: String) : CodeConverter {
+    override fun invoke(p1: VariableName): Code {
+        return "$p1.cast<$markerName>()"
     }
 }

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ExtensionsCodeGenerator.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ExtensionsCodeGenerator.kt
@@ -4,7 +4,7 @@ import org.jetbrains.kotlinx.dataframe.impl.codeGen.ExtensionsCodeGeneratorImpl
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ShortNames
 
 public interface ExtensionsCodeGenerator {
-    public fun generate(marker: IsolatedMarker): CodeWithConverter
+    public fun generate(marker: IsolatedMarker): CodeWithConverter<*>
 
     public companion object {
         public fun create(): ExtensionsCodeGenerator = ExtensionsCodeGeneratorImpl(ShortNames)

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dataframe.impl.codeGen
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
+import org.jetbrains.kotlinx.dataframe.api.GroupBy
 import org.jetbrains.kotlinx.dataframe.codeGen.CodeWithConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGeneratorImpl
 import org.jetbrains.kotlinx.jupyter.api.Code
@@ -13,14 +14,16 @@ internal interface ReplCodeGenerator {
     fun process(
         df: AnyFrame,
         property: KProperty<*>? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<*>
 
     fun process(
         row: AnyRow,
         property: KProperty<*>? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<*>
 
     fun process(markerClass: KClass<*>): Code
+
+    fun process(groupBy: GroupBy<*, *>): CodeWithConverter<*>
 
     companion object {
         fun create(): ReplCodeGenerator = ReplCodeGeneratorImpl()

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlinx.dataframe.codeGen.IsolatedMarker
 import org.jetbrains.kotlinx.dataframe.codeGen.Marker
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkerVisibility
 import org.jetbrains.kotlinx.dataframe.codeGen.NameNormalizer
+import org.jetbrains.kotlinx.dataframe.codeGen.ProvidedCodeConverter
 import org.jetbrains.kotlinx.dataframe.codeGen.SchemaProcessor
 import org.jetbrains.kotlinx.dataframe.codeGen.ValidFieldName
 import org.jetbrains.kotlinx.dataframe.codeGen.toNullable
@@ -43,7 +44,7 @@ internal fun Iterable<Marker>.filterRequiredForSchema(schema: DataFrameSchema) =
 internal val charsToQuote = """[ `(){}\[\].<>'"/|\\!?@:;%^&*#$-]""".toRegex()
 
 internal fun createCodeWithConverter(code: String, markerName: String) =
-    CodeWithConverter(code) { "$it.cast<$markerName>()" }
+    CodeWithConverter(code, ProvidedCodeConverter(markerName))
 
 private val letterCategories = setOf(
     CharCategory.UPPERCASE_LETTER,
@@ -345,7 +346,7 @@ internal open class ExtensionsCodeGeneratorImpl(
         return declarations.joinToString("\n")
     }
 
-    override fun generate(marker: IsolatedMarker): CodeWithConverter {
+    override fun generate(marker: IsolatedMarker): CodeWithConverter<*> {
         val code = generateExtensionProperties(marker)
         return createCodeWithConverter(code, marker.name)
     }
@@ -370,7 +371,7 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FullyQua
         interfaceMode: InterfaceGenerationMode,
         extensionProperties: Boolean,
         readDfMethod: DefaultReadDfMethod?,
-    ): CodeWithConverter {
+    ): CodeWithConverter<ProvidedCodeConverter> {
         val code = when (interfaceMode) {
             NoFields, WithFields ->
                 generateInterface(
@@ -505,7 +506,7 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FullyQua
     }
 }
 
-public fun CodeWithConverter.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =
+public fun CodeWithConverter<*>.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =
     declarations.toStandaloneSnippet(packageName, additionalImports)
 
 public fun Code.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
@@ -53,6 +53,22 @@ class CodeGenerationTests : DataFrameJupyterTest() {
     }
 
     @Test
+    fun `groupBy`() {
+        """
+            val groupBy = dataFrameOf("a")("1", "11", "2", "22").groupBy { expr { "a"<String>().length } named "k" }
+            groupBy.keys.k
+        """.checkCompilation()
+    }
+
+    @Test
+    fun `groupBy add`() {
+        """
+            val groupBy = dataFrameOf("a")("1", "11", "2", "22").groupBy { expr { "a"<String>().length } named "k" }.add("newCol") { 42 }
+            groupBy.aggregate { newCol into "newCol" }
+        """.checkCompilation()
+    }
+
+    @Test
     fun `interface without body compiled correctly`() {
         """
             val a = dataFrameOf("a")(1, 2, 3)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
@@ -33,6 +33,8 @@ else cast()
 
 public fun <T> AnyRow.cast(): DataRow<T> = this as DataRow<T>
 
+public fun <T, G> GroupBy<*, *>.cast(): GroupBy<T, G> = this as GroupBy<T, G>
+
 public inline fun <reified T> AnyRow.cast(verify: Boolean = true): DataRow<T> = df().cast<T>(verify)[0]
 
 public fun <T> AnyCol.cast(): DataColumn<T> = this as DataColumn<T>

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.codeGen.Marker
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkerVisibility
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkersExtractor
 import org.jetbrains.kotlinx.dataframe.codeGen.NameNormalizer
+import org.jetbrains.kotlinx.dataframe.codeGen.ProvidedCodeConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.CodeGeneratorImpl
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.FullyQualifiedNames
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ShortNames
@@ -22,7 +23,7 @@ public enum class InterfaceGenerationMode {
     None;
 }
 
-public data class CodeGenResult(val code: CodeWithConverter, val newMarkers: List<Marker>)
+public data class CodeGenResult(val code: CodeWithConverter<ProvidedCodeConverter>, val newMarkers: List<Marker>)
 
 public interface CodeGenerator : ExtensionsCodeGenerator {
 
@@ -43,7 +44,7 @@ public interface CodeGenerator : ExtensionsCodeGenerator {
         interfaceMode: InterfaceGenerationMode,
         extensionProperties: Boolean,
         readDfMethod: DefaultReadDfMethod? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<ProvidedCodeConverter>
 
     public companion object {
         public fun create(useFqNames: Boolean = true): CodeGenerator {
@@ -61,7 +62,7 @@ internal fun CodeGenerator.generate(
     markerClass: KClass<*>,
     interfaceMode: InterfaceGenerationMode,
     extensionProperties: Boolean,
-): CodeWithConverter = generate(
+): CodeWithConverter<ProvidedCodeConverter> = generate(
     MarkersExtractor.get(markerClass),
     interfaceMode,
     extensionProperties
@@ -70,4 +71,4 @@ internal fun CodeGenerator.generate(
 public inline fun <reified T> CodeGenerator.generate(
     interfaceMode: InterfaceGenerationMode,
     extensionProperties: Boolean,
-): CodeWithConverter = generate(T::class, interfaceMode, extensionProperties)
+): CodeWithConverter<ProvidedCodeConverter> = generate(T::class, interfaceMode, extensionProperties)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeWithConverter.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeWithConverter.kt
@@ -7,14 +7,19 @@ import org.jetbrains.kotlinx.jupyter.api.VariableName
  * Class representing generated code declarations for a [Marker].
  *
  * @param declarations The generated code.
+ * @param converter Needs to provide additional info (name) from org.jetbrains.dataframe.impl.codeGen.CodeGenerator to its callers
+ * But at the same time name doesn't make sense for GroupBy where code to be executed contains two declarations
  * @param converter Optional converter for the [Marker], such as a [org.jetbrains.kotlinx.dataframe.api.cast], often used for Jupyter.
  */
-public data class CodeWithConverter(val declarations: Code, val converter: (VariableName) -> Code = EmptyConverter) {
+public data class CodeWithConverter<T : CodeConverter>(
+    val declarations: Code,
+    val converter: T
+) {
 
     public companion object {
         public const val EmptyDeclarations: Code = ""
-        public val EmptyConverter: (VariableName) -> Code = { it }
-        public val Empty: CodeWithConverter = CodeWithConverter(EmptyDeclarations, EmptyConverter)
+        public val EmptyConverter: CodeConverter = CodeConverter { it }
+        public val Empty: CodeWithConverter<CodeConverter> = CodeWithConverter(EmptyDeclarations, EmptyConverter)
     }
 
     val hasDeclarations: Boolean get() = declarations.isNotBlank()
@@ -25,5 +30,21 @@ public data class CodeWithConverter(val declarations: Code, val converter: (Vari
         !hasConverter -> declarations
         !hasDeclarations -> converter(name)
         else -> declarations + "\n" + converter(name)
+    }
+}
+
+public sealed interface CodeConverter : (VariableName) -> Code
+
+public class CodeConverterImpl(private val f: (VariableName) -> Code) : CodeConverter {
+    override fun invoke(p1: VariableName): Code {
+        return f(p1)
+    }
+}
+
+public fun CodeConverter(f: (VariableName) -> Code): CodeConverter = CodeConverterImpl(f)
+
+public class ProvidedCodeConverter(public val markerName: String) : CodeConverter {
+    override fun invoke(p1: VariableName): Code {
+        return "$p1.cast<$markerName>()"
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ExtensionsCodeGenerator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ExtensionsCodeGenerator.kt
@@ -4,7 +4,7 @@ import org.jetbrains.kotlinx.dataframe.impl.codeGen.ExtensionsCodeGeneratorImpl
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ShortNames
 
 public interface ExtensionsCodeGenerator {
-    public fun generate(marker: IsolatedMarker): CodeWithConverter
+    public fun generate(marker: IsolatedMarker): CodeWithConverter<*>
 
     public companion object {
         public fun create(): ExtensionsCodeGenerator = ExtensionsCodeGeneratorImpl(ShortNames)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenerator.kt
@@ -2,6 +2,7 @@ package org.jetbrains.dataframe.impl.codeGen
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
+import org.jetbrains.kotlinx.dataframe.api.GroupBy
 import org.jetbrains.kotlinx.dataframe.codeGen.CodeWithConverter
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGeneratorImpl
 import org.jetbrains.kotlinx.jupyter.api.Code
@@ -13,14 +14,16 @@ internal interface ReplCodeGenerator {
     fun process(
         df: AnyFrame,
         property: KProperty<*>? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<*>
 
     fun process(
         row: AnyRow,
         property: KProperty<*>? = null,
-    ): CodeWithConverter
+    ): CodeWithConverter<*>
 
     fun process(markerClass: KClass<*>): Code
+
+    fun process(groupBy: GroupBy<*, *>): CodeWithConverter<*>
 
     companion object {
         fun create(): ReplCodeGenerator = ReplCodeGeneratorImpl()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/CodeGeneratorImpl.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlinx.dataframe.codeGen.IsolatedMarker
 import org.jetbrains.kotlinx.dataframe.codeGen.Marker
 import org.jetbrains.kotlinx.dataframe.codeGen.MarkerVisibility
 import org.jetbrains.kotlinx.dataframe.codeGen.NameNormalizer
+import org.jetbrains.kotlinx.dataframe.codeGen.ProvidedCodeConverter
 import org.jetbrains.kotlinx.dataframe.codeGen.SchemaProcessor
 import org.jetbrains.kotlinx.dataframe.codeGen.ValidFieldName
 import org.jetbrains.kotlinx.dataframe.codeGen.toNullable
@@ -43,7 +44,7 @@ internal fun Iterable<Marker>.filterRequiredForSchema(schema: DataFrameSchema) =
 internal val charsToQuote = """[ `(){}\[\].<>'"/|\\!?@:;%^&*#$-]""".toRegex()
 
 internal fun createCodeWithConverter(code: String, markerName: String) =
-    CodeWithConverter(code) { "$it.cast<$markerName>()" }
+    CodeWithConverter(code, ProvidedCodeConverter(markerName))
 
 private val letterCategories = setOf(
     CharCategory.UPPERCASE_LETTER,
@@ -345,7 +346,7 @@ internal open class ExtensionsCodeGeneratorImpl(
         return declarations.joinToString("\n")
     }
 
-    override fun generate(marker: IsolatedMarker): CodeWithConverter {
+    override fun generate(marker: IsolatedMarker): CodeWithConverter<*> {
         val code = generateExtensionProperties(marker)
         return createCodeWithConverter(code, marker.name)
     }
@@ -370,7 +371,7 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FullyQua
         interfaceMode: InterfaceGenerationMode,
         extensionProperties: Boolean,
         readDfMethod: DefaultReadDfMethod?,
-    ): CodeWithConverter {
+    ): CodeWithConverter<ProvidedCodeConverter> {
         val code = when (interfaceMode) {
             NoFields, WithFields ->
                 generateInterface(
@@ -505,7 +506,7 @@ internal class CodeGeneratorImpl(typeRendering: TypeRenderingStrategy = FullyQua
     }
 }
 
-public fun CodeWithConverter.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =
+public fun CodeWithConverter<*>.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =
     declarations.toStandaloneSnippet(packageName, additionalImports)
 
 public fun Code.toStandaloneSnippet(packageName: String, additionalImports: List<String>): String =

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
@@ -53,6 +53,22 @@ class CodeGenerationTests : DataFrameJupyterTest() {
     }
 
     @Test
+    fun `groupBy`() {
+        """
+            val groupBy = dataFrameOf("a")("1", "11", "2", "22").groupBy { expr { "a"<String>().length } named "k" }
+            groupBy.keys.k
+        """.checkCompilation()
+    }
+
+    @Test
+    fun `groupBy add`() {
+        """
+            val groupBy = dataFrameOf("a")("1", "11", "2", "22").groupBy { expr { "a"<String>().length } named "k" }.add("newCol") { 42 }
+            groupBy.aggregate { newCol into "newCol" }
+        """.checkCompilation()
+    }
+
+    @Test
     fun `interface without body compiled correctly`() {
         """
             val a = dataFrameOf("a")(1, 2, 3)


### PR DESCRIPTION
This was a long standing minor inconvenience. Having this variable in a cell1 you couldn't access `k` in keys in the cell2
cell1:
```kt
val groupBy = dataFrameOf("a")("1", "11", "2", "22")
    .groupBy { expr { "a"<String>().length } named "k" }
```
cell2:
```kt
groupBy.keys.k
```

Other use case is adding a new column to `GroupBy`
```kt
val groupBy = dataFrameOf("a")("1", "11", "2", "22")
    .groupBy { expr { "a"<String>().length } named "k" }
    .add("newCol") { 42 }
```
```kt
groupBy.aggregate { newCol into "newCol" }
```