### PR TITLE
Add nullability inference support to dataframe-jdbc

### DIFF
--- a/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
+++ b/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
@@ -115,7 +115,6 @@ public fun DataFrame.Companion.readSqlTable(
     limit: Int = DEFAULT_LIMIT,
     inferNullability: Boolean = true,
 ): AnyFrame {
-    Infer.Nulls
     DriverManager.getConnection(dbConfig.url, dbConfig.user, dbConfig.password).use { connection ->
         return readSqlTable(connection, tableName, limit, inferNullability)
     }

--- a/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
+++ b/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
@@ -199,8 +199,10 @@ public fun DataFrame.Companion.readSqlQuery(
     limit: Int = DEFAULT_LIMIT,
     inferNullability: Infer = Infer.None,
 ): AnyFrame {
-    require(isValid(sqlQuery)) { "SQL query should start from SELECT and contain one query for reading data without any manipulation. " +
-        "Also it should not contain any separators like `;`." }
+    require(isValid(sqlQuery)) {
+        "SQL query should start from SELECT and contain one query for reading data without any manipulation. " +
+            "Also it should not contain any separators like `;`."
+    }
 
     val url = connection.metaData.url
     val dbType = extractDBTypeFromUrl(url)

--- a/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/h2Test.kt
+++ b/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/h2Test.kt
@@ -697,11 +697,11 @@ class JdbcTest {
 
         // start testing `readSqlTable` method
 
-        // with default inferNullability: Infer = Infer.None
+        // with default inferNullability: Boolean = true
         val tableName = "TestTable1"
         val df = DataFrame.readSqlTable(connection, tableName)
         df.schema().columns["id"]!!.type shouldBe typeOf<Int>()
-        df.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+        df.schema().columns["name"]!!.type shouldBe typeOf<String>()
         df.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
         df.schema().columns["age"]!!.type shouldBe typeOf<Int>()
 
@@ -712,10 +712,10 @@ class JdbcTest {
         dataSchema.columns["surname"]!!.type shouldBe typeOf<String?>()
         dataSchema.columns["age"]!!.type shouldBe typeOf<Int>()
 
-        // with inferNullability: Infer = Infer.None
-        val df1 = DataFrame.readSqlTable(connection, tableName, inferNullability = Infer.Nulls)
+        // with inferNullability: Boolean = false
+        val df1 = DataFrame.readSqlTable(connection, tableName, inferNullability = false)
         df1.schema().columns["id"]!!.type shouldBe typeOf<Int>()
-        df1.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+        df1.schema().columns["name"]!!.type shouldBe typeOf<String?>() // <=== this column changed a type because it doesn't contain nulls
         df1.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
         df1.schema().columns["age"]!!.type shouldBe typeOf<Int>()
 
@@ -723,14 +723,14 @@ class JdbcTest {
 
         // start testing `readSQLQuery` method
 
-        // with default inferNullability: Infer = Infer.None
+        // ith default inferNullability: Boolean = true
         @Language("SQL")
         val sqlQuery = """
             SELECT name, surname, age FROM TestTable1
         """.trimIndent()
 
         val df2 = DataFrame.readSqlQuery(connection, sqlQuery)
-        df2.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+        df2.schema().columns["name"]!!.type shouldBe typeOf<String>()
         df2.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
         df2.schema().columns["age"]!!.type shouldBe typeOf<Int>()
 
@@ -740,9 +740,9 @@ class JdbcTest {
         dataSchema2.columns["surname"]!!.type shouldBe typeOf<String?>()
         dataSchema2.columns["age"]!!.type shouldBe typeOf<Int>()
 
-        // with inferNullability: Infer = Infer.None
-        val df3 = DataFrame.readSqlQuery(connection, sqlQuery, inferNullability = Infer.Nulls)
-        df3.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+        // with inferNullability: Boolean = false
+        val df3 = DataFrame.readSqlQuery(connection, sqlQuery, inferNullability = false)
+        df3.schema().columns["name"]!!.type shouldBe typeOf<String?>() // <=== this column changed a type because it doesn't contain nulls
         df3.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
         df3.schema().columns["age"]!!.type shouldBe typeOf<Int>()
 
@@ -755,10 +755,10 @@ class JdbcTest {
             val selectStatement = "SELECT * FROM TestTable1"
 
             st.executeQuery(selectStatement).use { rs ->
-                // with default inferNullability: Infer = Infer.None
+                // ith default inferNullability: Boolean = true
                 val df4 = DataFrame.readResultSet(rs, H2)
                 df4.schema().columns["id"]!!.type shouldBe typeOf<Int>()
-                df4.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+                df4.schema().columns["name"]!!.type shouldBe typeOf<String>()
                 df4.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
                 df4.schema().columns["age"]!!.type shouldBe typeOf<Int>()
 
@@ -771,12 +771,12 @@ class JdbcTest {
                 dataSchema3.columns["surname"]!!.type shouldBe typeOf<String?>()
                 dataSchema3.columns["age"]!!.type shouldBe typeOf<Int>()
 
-                // with inferNullability: Infer = Infer.None
+                // with inferNullability: Boolean = false
                 rs.beforeFirst()
 
-                val df5 = DataFrame.readResultSet(rs, H2, inferNullability = Infer.Nulls)
+                val df5 = DataFrame.readResultSet(rs, H2, inferNullability = false)
                 df5.schema().columns["id"]!!.type shouldBe typeOf<Int>()
-                df5.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+                df5.schema().columns["name"]!!.type shouldBe typeOf<String?>() // <=== this column changed a type because it doesn't contain nulls
                 df5.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
                 df5.schema().columns["age"]!!.type shouldBe typeOf<Int>()
             }

--- a/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/h2Test.kt
+++ b/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/h2Test.kt
@@ -6,10 +6,7 @@ import org.h2.jdbc.JdbcSQLSyntaxErrorException
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
-import org.jetbrains.kotlinx.dataframe.api.add
-import org.jetbrains.kotlinx.dataframe.api.cast
-import org.jetbrains.kotlinx.dataframe.api.filter
-import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.io.db.H2
 import org.junit.AfterClass
 import org.junit.BeforeClass
@@ -676,5 +673,116 @@ class JdbcTest {
         val saleDataSchema1 = dataSchemas1[1]
         saleDataSchema1.columns.size shouldBe 3
         saleDataSchema1.columns["amount"]!!.type shouldBe typeOf<BigDecimal>()
+    }
+
+    @Test
+    fun `infer nullability`() {
+        // prepare tables and data
+        @Language("SQL")
+        val createTestTable1Query = """
+                CREATE TABLE TestTable1 (
+                    id INT PRIMARY KEY,
+                    name VARCHAR(50),
+                    surname VARCHAR(50),
+                    age INT NOT NULL
+                )
+            """
+
+        connection.createStatement().execute(createTestTable1Query)
+
+        connection.createStatement().execute("INSERT INTO TestTable1 (id, name, surname, age) VALUES (1, 'John', 'Crawford', 40)")
+        connection.createStatement().execute("INSERT INTO TestTable1 (id, name, surname, age) VALUES (2, 'Alice', 'Smith', 25)")
+        connection.createStatement().execute("INSERT INTO TestTable1 (id, name, surname, age) VALUES (3, 'Bob', 'Johnson', 47)")
+        connection.createStatement().execute("INSERT INTO TestTable1 (id, name, surname, age) VALUES (4, 'Sam', NULL, 15)")
+
+        // start testing `readSqlTable` method
+
+        // with default inferNullability: Infer = Infer.None
+        val tableName = "TestTable1"
+        val df = DataFrame.readSqlTable(connection, tableName)
+        df.schema().columns["id"]!!.type shouldBe typeOf<Int>()
+        df.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+        df.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+        df.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+
+        val dataSchema = DataFrame.getSchemaForSqlTable(connection, tableName)
+        dataSchema.columns.size shouldBe 4
+        dataSchema.columns["id"]!!.type shouldBe typeOf<Int>()
+        dataSchema.columns["name"]!!.type shouldBe typeOf<String?>()
+        dataSchema.columns["surname"]!!.type shouldBe typeOf<String?>()
+        dataSchema.columns["age"]!!.type shouldBe typeOf<Int>()
+
+        // with inferNullability: Infer = Infer.None
+        val df1 = DataFrame.readSqlTable(connection, tableName, inferNullability = Infer.Nulls)
+        df1.schema().columns["id"]!!.type shouldBe typeOf<Int>()
+        df1.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+        df1.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+        df1.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+
+        // end testing `readSqlTable` method
+
+        // start testing `readSQLQuery` method
+
+        // with default inferNullability: Infer = Infer.None
+        @Language("SQL")
+        val sqlQuery = """
+            SELECT name, surname, age FROM TestTable1
+        """.trimIndent()
+
+        val df2 = DataFrame.readSqlQuery(connection, sqlQuery)
+        df2.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+        df2.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+        df2.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+
+        val dataSchema2 = DataFrame.getSchemaForSqlQuery(connection, sqlQuery)
+        dataSchema2.columns.size shouldBe 3
+        dataSchema2.columns["name"]!!.type shouldBe typeOf<String?>()
+        dataSchema2.columns["surname"]!!.type shouldBe typeOf<String?>()
+        dataSchema2.columns["age"]!!.type shouldBe typeOf<Int>()
+
+        // with inferNullability: Infer = Infer.None
+        val df3 = DataFrame.readSqlQuery(connection, sqlQuery, inferNullability = Infer.Nulls)
+        df3.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+        df3.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+        df3.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+
+        // end testing `readSQLQuery` method
+
+        // start testing `readResultSet` method
+
+        connection.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE).use { st ->
+            @Language("SQL")
+            val selectStatement = "SELECT * FROM TestTable1"
+
+            st.executeQuery(selectStatement).use { rs ->
+                // with default inferNullability: Infer = Infer.None
+                val df4 = DataFrame.readResultSet(rs, H2)
+                df4.schema().columns["id"]!!.type shouldBe typeOf<Int>()
+                df4.schema().columns["name"]!!.type shouldBe typeOf<String?>()
+                df4.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+                df4.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+
+                rs.beforeFirst()
+
+                val dataSchema3 = DataFrame.getSchemaForResultSet(rs, H2)
+                dataSchema3.columns.size shouldBe 4
+                dataSchema3.columns["id"]!!.type shouldBe typeOf<Int>()
+                dataSchema3.columns["name"]!!.type shouldBe typeOf<String?>()
+                dataSchema3.columns["surname"]!!.type shouldBe typeOf<String?>()
+                dataSchema3.columns["age"]!!.type shouldBe typeOf<Int>()
+
+                // with inferNullability: Infer = Infer.None
+                rs.beforeFirst()
+
+                val df5 = DataFrame.readResultSet(rs, H2, inferNullability = Infer.Nulls)
+                df5.schema().columns["id"]!!.type shouldBe typeOf<Int>()
+                df5.schema().columns["name"]!!.type shouldBe typeOf<String>() // <=== this column changed a type because it doesn't contain nulls
+                df5.schema().columns["surname"]!!.type shouldBe typeOf<String?>()
+                df5.schema().columns["age"]!!.type shouldBe typeOf<Int>()
+            }
+        }
+        // end testing `readResultSet` method
+
+        connection.createStatement().execute("DROP TABLE TestTable1")
     }
 }


### PR DESCRIPTION
This update adds a new parameter `inferNullability` for various dataframe reading functions including `readSqlTable`, `readSqlQuery`, and `readResultSet`. It allows better control over how column nullability should be inferred. The `h2Test` file has been adjusted to test this new feature.

Fixes #541 