### PR TITLE
Remove incomplete documentation topics

### DIFF
--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -173,10 +173,6 @@
         <toc-element topic="columnOperations.md">
             <toc-element topic="columnArithmetics.md" toc-title="Arithmetics"/>
             <toc-element topic="columnStatistics.md" toc-title="Statistics"/>
-            <toc-element topic="specialColumnTypes.md">
-                <toc-element topic="stringColumns.md" toc-title="String"/>
-                <toc-element topic="datetimeColumns.md" toc-title="DateTime"/>
-            </toc-element>
         </toc-element>
         <toc-element topic="ColumnSelectors.md"/>
         <toc-element topic="collectionsInterop.md">

--- a/docs/StardustDocs/sitemap.xml
+++ b/docs/StardustDocs/sitemap.xml
@@ -528,11 +528,6 @@
   <priority>0.41</priority>
 </url>
 <url>
-  <loc>https://kotlin.github.io/dataframe/datetimecolumns.html</loc>
-  <lastmod>2023-06-26T12:33:14+00:00</lastmod>
-  <priority>0.41</priority>
-</url>
-<url>
   <loc>https://kotlin.github.io/dataframe/moverename.html</loc>
   <lastmod>2023-06-26T12:33:14+00:00</lastmod>
   <priority>0.41</priority>
@@ -693,11 +688,6 @@
   <priority>0.41</priority>
 </url>
 <url>
-  <loc>https://kotlin.github.io/dataframe/stringcolumns.html</loc>
-  <lastmod>2023-06-26T12:33:14+00:00</lastmod>
-  <priority>0.33</priority>
-</url>
-<url>
   <loc>https://kotlin.github.io/dataframe/maxby.html</loc>
   <lastmod>2023-06-26T12:33:14+00:00</lastmod>
   <priority>0.33</priority>
@@ -713,15 +703,8 @@
   <priority>0.33</priority>
 </url>
 <url>
-  <loc>https://kotlin.github.io/dataframe/specialcolumntypes.html</loc>
-  <lastmod>2023-06-26T12:33:14+00:00</lastmod>
-  <priority>0.26</priority>
-</url>
-<url>
   <loc>https://kotlin.github.io/dataframe/columnstatistics.html</loc>
   <lastmod>2023-06-26T12:33:14+00:00</lastmod>
   <priority>0.26</priority>
 </url>
-
-
 </urlset>

--- a/docs/StardustDocs/topics/datetimeColumns.md
+++ b/docs/StardustDocs/topics/datetimeColumns.md
@@ -1,3 +1,0 @@
-[//]: # (title: Datetime Columns)
-
-// TODO

--- a/docs/StardustDocs/topics/specialColumnTypes.md
+++ b/docs/StardustDocs/topics/specialColumnTypes.md
@@ -1,3 +1,0 @@
-[//]: # (title: Special column types)
-
-// TODO

--- a/docs/StardustDocs/topics/stringColumns.md
+++ b/docs/StardustDocs/topics/stringColumns.md
@@ -1,3 +1,0 @@
-[//]: # (title: String Columns)
-
-// TODO


### PR DESCRIPTION
Three incomplete documentation topics, namely "Datetime Columns", "Special column types", and "String Columns", have been removed from the StardustDocs. These deletions have been reflected in the documentation tree and the sitemap to keep everything updated and avoid confusion for users.