### PR TITLE
Introduce OtherSamples.kt to generate tables for writerside docs outside Korro

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -136,7 +136,8 @@ val clearSamplesOutputs by tasks.creating {
 
     doFirst {
         delete {
-            delete(fileTree(File(projectDir, "../docs/StardustDocs/snippets")))
+            val generatedSnippets = fileTree(file("../docs/StardustDocs/snippets")).exclude("**/manual/**")
+            delete(generatedSnippets)
         }
     }
 }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/PluginCallbackProxy.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/PluginCallbackProxy.kt
@@ -75,32 +75,7 @@ object PluginCallbackProxy : PluginCallback {
         var output: DataFrameHtmlData
         val manualOutput = this.manualOutput
         if (manualOutput == null) {
-            output = DataFrameHtmlData.tableDefinitions() + DataFrameHtmlData(
-                // copy writerside stlyles
-                style = """
-                    body {
-                        font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
-                    }       
-                    
-                    :root {
-                        color: #19191C;
-                        background-color: #fff;
-                    }
-                    
-                    :root[theme="dark"] {
-                        background-color: #19191C;
-                        color: #FFFFFFCC
-                    }
-                    
-                    details details {
-                        margin-left: 20px; 
-                    }
-                    
-                    summary {
-                        padding: 6px;
-                    }
-                """.trimIndent()
-            )
+            output = DataFrameHtmlData.tableDefinitions() + WritersideStyle
 
             // make copy to avoid concurrent modification exception
             val statements = expressionsByStatement.toMap()
@@ -243,7 +218,7 @@ object PluginCallbackProxy : PluginCallback {
 }
 
 private fun convertToHTML(dataframeLike: Any): DataFrameHtmlData {
-    fun DataFrame<*>.toHTML() = toHTML(SamplesDisplayConfiguration, getFooter = { "" })
+    fun DataFrame<*>.toHTML() = toHTML(SamplesDisplayConfiguration, getFooter = WritersideFooter)
     fun FormattedFrame<*>.toHTML1() = toHTML(SamplesDisplayConfiguration)
 
     return when (dataframeLike) {

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesDisplayConfiguration.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesDisplayConfiguration.kt
@@ -1,5 +1,0 @@
-package org.jetbrains.kotlinx.dataframe.explainer
-
-import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
-
-val SamplesDisplayConfiguration = DisplayConfiguration(enableFallbackStaticTables = false)

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesRenderingUtils.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesRenderingUtils.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlinx.dataframe.explainer
+
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
+import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
+
+val SamplesDisplayConfiguration = DisplayConfiguration(enableFallbackStaticTables = false)
+
+val WritersideStyle = DataFrameHtmlData(
+    // copy writerside stlyles
+    style = """
+    body {
+        font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+    }       
+    
+    :root {
+        color: #19191C;
+        background-color: #fff;
+    }
+    
+    :root[theme="dark"] {
+        background-color: #19191C;
+        color: #FFFFFFCC
+    }
+    
+    details details {
+        margin-left: 20px; 
+    }
+    
+    summary {
+        padding: 6px;
+    }
+    """.trimIndent()
+)
+
+val WritersideFooter: (DataFrame<*>) -> String = { "" }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
@@ -1,0 +1,25 @@
+package org.jetbrains.kotlinx.dataframe.samples.api
+
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.explainer.WritersideFooter
+import org.jetbrains.kotlinx.dataframe.explainer.WritersideStyle
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
+import org.junit.Test
+import java.io.File
+
+// To display code together with a table, we can use TransformDataFrameExpressions annotation together with korro
+// This class provides an ability to save only a table that can be embedded anywhere in the documentation
+class OtherSamples {
+    @Test
+    fun extensionPropertiesApi1() {
+        val df = dataFrameOf("example")(123)
+        writeTable(df, "extensionPropertiesApi1")
+    }
+
+    private fun writeTable(df: AnyFrame, name: String) {
+        val dir = File("../docs/StardustDocs/snippets/manual").also { it.mkdirs() }
+        val html = df.toStandaloneHTML(getFooter = WritersideFooter) + WritersideStyle
+        html.writeHTML(File(dir, "$name.html"))
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/PluginCallbackProxy.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/PluginCallbackProxy.kt
@@ -75,32 +75,7 @@ object PluginCallbackProxy : PluginCallback {
         var output: DataFrameHtmlData
         val manualOutput = this.manualOutput
         if (manualOutput == null) {
-            output = DataFrameHtmlData.tableDefinitions() + DataFrameHtmlData(
-                // copy writerside stlyles
-                style = """
-                    body {
-                        font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
-                    }       
-                    
-                    :root {
-                        color: #19191C;
-                        background-color: #fff;
-                    }
-                    
-                    :root[theme="dark"] {
-                        background-color: #19191C;
-                        color: #FFFFFFCC
-                    }
-                    
-                    details details {
-                        margin-left: 20px; 
-                    }
-                    
-                    summary {
-                        padding: 6px;
-                    }
-                """.trimIndent()
-            )
+            output = DataFrameHtmlData.tableDefinitions() + WritersideStyle
 
             // make copy to avoid concurrent modification exception
             val statements = expressionsByStatement.toMap()
@@ -243,7 +218,7 @@ object PluginCallbackProxy : PluginCallback {
 }
 
 private fun convertToHTML(dataframeLike: Any): DataFrameHtmlData {
-    fun DataFrame<*>.toHTML() = toHTML(SamplesDisplayConfiguration, getFooter = { "" })
+    fun DataFrame<*>.toHTML() = toHTML(SamplesDisplayConfiguration, getFooter = WritersideFooter)
     fun FormattedFrame<*>.toHTML1() = toHTML(SamplesDisplayConfiguration)
 
     return when (dataframeLike) {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesDisplayConfiguration.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesDisplayConfiguration.kt
@@ -1,5 +1,0 @@
-package org.jetbrains.kotlinx.dataframe.explainer
-
-import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
-
-val SamplesDisplayConfiguration = DisplayConfiguration(enableFallbackStaticTables = false)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesRenderingUtils.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/explainer/SamplesRenderingUtils.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlinx.dataframe.explainer
+
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
+import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
+
+val SamplesDisplayConfiguration = DisplayConfiguration(enableFallbackStaticTables = false)
+
+val WritersideStyle = DataFrameHtmlData(
+    // copy writerside stlyles
+    style = """
+    body {
+        font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+    }       
+    
+    :root {
+        color: #19191C;
+        background-color: #fff;
+    }
+    
+    :root[theme="dark"] {
+        background-color: #19191C;
+        color: #FFFFFFCC
+    }
+    
+    details details {
+        margin-left: 20px; 
+    }
+    
+    summary {
+        padding: 6px;
+    }
+    """.trimIndent()
+)
+
+val WritersideFooter: (DataFrame<*>) -> String = { "" }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
@@ -1,0 +1,25 @@
+package org.jetbrains.kotlinx.dataframe.samples.api
+
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.explainer.WritersideFooter
+import org.jetbrains.kotlinx.dataframe.explainer.WritersideStyle
+import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
+import org.junit.Test
+import java.io.File
+
+// To display code together with a table, we can use TransformDataFrameExpressions annotation together with korro
+// This class provides an ability to save only a table that can be embedded anywhere in the documentation
+class OtherSamples {
+    @Test
+    fun extensionPropertiesApi1() {
+        val df = dataFrameOf("example")(123)
+        writeTable(df, "extensionPropertiesApi1")
+    }
+
+    private fun writeTable(df: AnyFrame, name: String) {
+        val dir = File("../docs/StardustDocs/snippets/manual").also { it.mkdirs() }
+        val html = df.toStandaloneHTML(getFooter = WritersideFooter) + WritersideStyle
+        html.writeHTML(File(dir, "$name.html"))
+    }
+}


### PR DESCRIPTION
Later, generated tables can be added anywhere. Example:
```
<dataFrame src="manual/extensionPropertiesApi1.html"/>
```