### PR TITLE
Research: `ColumnDataHolder`/primitive arrays

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/ColumnDataHolder.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/ColumnDataHolder.kt
@@ -1,0 +1,72 @@
+package org.jetbrains.kotlinx.dataframe
+
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnDataHolderImpl
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+public interface ColumnDataHolder<T> : Iterable<T> {
+
+    public val size: Int
+
+    public fun toSet(): Set<T>
+
+    public fun toList(): List<T>
+
+    public fun contains(value: T): Boolean
+
+    public operator fun get(index: Int): T
+
+    public operator fun get(range: IntRange): List<T>
+
+    public val distinct: Lazy<Set<T>>
+
+    public companion object
+}
+
+public fun <T> Collection<T>.toColumnDataHolder(type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    ColumnDataHolderImpl.of(this, type, distinct)
+
+public inline fun <reified T> Collection<T>.toColumnDataHolder(distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    this.toColumnDataHolder(typeOf<T>(), distinct)
+
+public fun <T> Array<T>.toColumnDataHolder(type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    ColumnDataHolderImpl.of(this, type, distinct)
+
+public inline fun <reified T> Array<T>.toColumnDataHolder(distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    this.toColumnDataHolder(typeOf<T>(), distinct)
+
+public fun BooleanArray.asColumnDataHolder(distinct: Lazy<Set<Boolean>>? = null): ColumnDataHolder<Boolean> =
+    ColumnDataHolderImpl.of(this, typeOf<Boolean>(), distinct)
+
+public fun ByteArray.asColumnDataHolder(distinct: Lazy<Set<Byte>>? = null): ColumnDataHolder<Byte> =
+    ColumnDataHolderImpl.of(this, typeOf<Byte>(), distinct)
+
+public fun ShortArray.asColumnDataHolder(distinct: Lazy<Set<Short>>? = null): ColumnDataHolder<Short> =
+    ColumnDataHolderImpl.of(this, typeOf<Short>(), distinct)
+
+public fun IntArray.asColumnDataHolder(distinct: Lazy<Set<Int>>? = null): ColumnDataHolder<Int> =
+    ColumnDataHolderImpl.of(this, typeOf<Int>(), distinct)
+
+public fun LongArray.asColumnDataHolder(distinct: Lazy<Set<Long>>? = null): ColumnDataHolder<Long> =
+    ColumnDataHolderImpl.of(this, typeOf<Long>(), distinct)
+
+public fun FloatArray.asColumnDataHolder(distinct: Lazy<Set<Float>>? = null): ColumnDataHolder<Float> =
+    ColumnDataHolderImpl.of(this, typeOf<Float>(), distinct)
+
+public fun DoubleArray.asColumnDataHolder(distinct: Lazy<Set<Double>>? = null): ColumnDataHolder<Double> =
+    ColumnDataHolderImpl.of(this, typeOf<Double>(), distinct)
+
+public fun CharArray.asColumnDataHolder(distinct: Lazy<Set<Char>>? = null): ColumnDataHolder<Char> =
+    ColumnDataHolderImpl.of(this, typeOf<Char>(), distinct)
+
+public fun UByteArray.asColumnDataHolder(distinct: Lazy<Set<UByte>>? = null): ColumnDataHolder<UByte> =
+    ColumnDataHolderImpl.of(this, typeOf<UByte>(), distinct)
+
+public fun UShortArray.asColumnDataHolder(distinct: Lazy<Set<UShort>>? = null): ColumnDataHolder<UShort> =
+    ColumnDataHolderImpl.of(this, typeOf<UShort>(), distinct)
+
+public fun UIntArray.asColumnDataHolder(distinct: Lazy<Set<UInt>>? = null): ColumnDataHolder<UInt> =
+    ColumnDataHolderImpl.of(this, typeOf<UInt>(), distinct)
+
+public fun ULongArray.asColumnDataHolder(distinct: Lazy<Set<ULong>>? = null): ColumnDataHolder<ULong> =
+    ColumnDataHolderImpl.of(this, typeOf<ULong>(), distinct)

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnDataHolderImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnGroupImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.FrameColumnImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.ValueColumnImpl
@@ -42,6 +43,73 @@ public interface DataColumn<out T> : BaseColumn<T> {
 
     public companion object {
 
+        public fun <T> createValueColumn(
+            name: String,
+            values: ColumnDataHolder<T>,
+            type: KType,
+            defaultValue: T? = null,
+        ): ValueColumn<T> = ValueColumnImpl(values, name, type, defaultValue)
+
+        public fun createValueColumn(
+            name: String,
+            values: BooleanArray,
+        ): ValueColumn<Boolean> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Boolean>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ByteArray,
+        ): ValueColumn<Byte> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Byte>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ShortArray,
+        ): ValueColumn<Short> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Short>())
+
+        public fun createValueColumn(
+            name: String,
+            values: IntArray,
+        ): ValueColumn<Int> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Int>())
+
+        public fun createValueColumn(
+            name: String,
+            values: LongArray,
+        ): ValueColumn<Long> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Long>())
+
+        public fun createValueColumn(
+            name: String,
+            values: FloatArray,
+        ): ValueColumn<Float> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Float>())
+
+        public fun createValueColumn(
+            name: String,
+            values: DoubleArray,
+        ): ValueColumn<Double> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Double>())
+
+        public fun createValueColumn(
+            name: String,
+            values: CharArray,
+        ): ValueColumn<Char> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Char>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UByteArray,
+        ): ValueColumn<UByte> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UByte>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UShortArray,
+        ): ValueColumn<UShort> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UShort>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UIntArray,
+        ): ValueColumn<UInt> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UInt>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ULongArray,
+        ): ValueColumn<ULong> = createValueColumn(name, values.asColumnDataHolder(), typeOf<ULong>())
+
         /**
          * Creates [ValueColumn] using given [name], [values] and [type].
          *
@@ -56,7 +124,15 @@ public interface DataColumn<out T> : BaseColumn<T> {
             type: KType,
             infer: Infer = Infer.None,
             defaultValue: T? = null,
-        ): ValueColumn<T> = ValueColumnImpl(values, name, getValuesType(values, type, infer), defaultValue)
+        ): ValueColumn<T> {
+            val valueType = getValuesType(values, type, infer)
+            return createValueColumn(
+                name = name,
+                values = ColumnDataHolderImpl.of(values, valueType),
+                type = valueType,
+                defaultValue = defaultValue
+            )
+        }
 
         /**
          * Creates [ValueColumn] using given [name], [values] and reified column [type].
@@ -73,12 +149,35 @@ public interface DataColumn<out T> : BaseColumn<T> {
             values: List<T>,
             infer: Infer = Infer.None,
         ): ValueColumn<T> = createValueColumn(
-            name, values,
-            getValuesType(
-                values,
-                typeOf<T>(),
-                infer
+            name = name,
+            values = values,
+            type = getValuesType(values, typeOf<T>(), infer)
+        )
+
+        public fun <T> createValueColumn(
+            name: String,
+            values: Array<T>,
+            type: KType,
+            infer: Infer = Infer.None,
+            defaultValue: T? = null,
+        ): ValueColumn<T> {
+            val valueType = getValuesType(values.asList(), type, infer)
+            return createValueColumn(
+                name = name,
+                values = ColumnDataHolderImpl.of(values, valueType),
+                type = valueType,
+                defaultValue = defaultValue
             )
+        }
+
+        public inline fun <reified T> createValueColumn(
+            name: String,
+            values: Array<T>,
+            infer: Infer = Infer.None,
+        ): ValueColumn<T> = createValueColumn(
+            name = name,
+            values = values,
+            type = getValuesType(values.asList(), typeOf<T>(), infer)
         )
 
         public fun <T> createColumnGroup(name: String, df: DataFrame<T>): ColumnGroup<T> = ColumnGroupImpl(name, df)
@@ -88,13 +187,13 @@ public interface DataColumn<out T> : BaseColumn<T> {
             df: DataFrame<T>,
             startIndices: Iterable<Int>,
         ): FrameColumn<T> =
-            FrameColumnImpl(name, df.splitByIndices(startIndices.asSequence()).toList(), lazy { df.schema() })
+            FrameColumnImpl(name, df.splitByIndices(startIndices.asSequence()).toList().toColumnDataHolder(), lazy { df.schema() })
 
         public fun <T> createFrameColumn(
             name: String,
             groups: List<DataFrame<T>>,
             schema: Lazy<DataFrameSchema>? = null,
-        ): FrameColumn<T> = FrameColumnImpl(name, groups, schema)
+        ): FrameColumn<T> = FrameColumnImpl(name, groups.toColumnDataHolder(), schema)
 
         public fun <T> createWithTypeInference(
             name: String,

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnDataHolderImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnDataHolderImpl.kt
@@ -1,0 +1,153 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package org.jetbrains.kotlinx.dataframe.impl.columns
+
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
+import org.jetbrains.kotlinx.dataframe.impl.asList
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveArray
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+internal class ColumnDataHolderImpl<T> private constructor(
+    private val list: List<T>,
+    distinct: Lazy<Set<T>>?,
+) : ColumnDataHolder<T> {
+
+    override val distinct = distinct ?: lazy { list.toSet() }
+    override val size: Int get() = list.size
+
+    override fun toSet(): Set<T> = distinct.value
+    override fun toList(): List<T> = list
+    override fun get(index: Int): T = list[index]
+    override fun get(range: IntRange): List<T> = list.subList(range.first, range.last + 1)
+    override fun contains(value: T): Boolean = list.contains(value)
+    override fun iterator(): Iterator<T> = list.iterator()
+
+    companion object {
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [list].
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(list: Collection<T>, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> {
+            if (list is ColumnDataHolder<*>) return list as ColumnDataHolder<T>
+
+            return try {
+                when (type) {
+                    BOOLEAN -> ColumnDataHolderImpl((list as Collection<Boolean>).toBooleanArray().asList(), distinct)
+                    BYTE -> ColumnDataHolderImpl((list as Collection<Byte>).toByteArray().asList(), distinct)
+                    SHORT -> ColumnDataHolderImpl((list as Collection<Short>).toShortArray().asList(), distinct)
+                    INT -> ColumnDataHolderImpl((list as Collection<Int>).toIntArray().asList(), distinct)
+                    LONG -> ColumnDataHolderImpl((list as Collection<Long>).toLongArray().asList(), distinct)
+                    FLOAT -> ColumnDataHolderImpl((list as Collection<Float>).toFloatArray().asList(), distinct)
+                    DOUBLE -> ColumnDataHolderImpl((list as Collection<Double>).toDoubleArray().asList(), distinct)
+                    CHAR -> ColumnDataHolderImpl((list as Collection<Char>).toCharArray().asList(), distinct)
+                    UBYTE -> ColumnDataHolderImpl((list as Collection<UByte>).toUByteArray().asList(), distinct)
+                    USHORT -> ColumnDataHolderImpl((list as Collection<UShort>).toUShortArray().asList(), distinct)
+                    UINT -> ColumnDataHolderImpl((list as Collection<UInt>).toUIntArray().asList(), distinct)
+                    ULONG -> ColumnDataHolderImpl((list as Collection<ULong>).toULongArray().asList(), distinct)
+                    else -> ColumnDataHolderImpl(list.asList(), distinct)
+                } as ColumnDataHolder<T>
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Can't create ColumnDataHolder from $list and type $type", e)
+            }
+        }
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [array].
+         * If [array] is an array of primitives, it will be converted to a primitive array first before being
+         * wrapped with [asList].
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(array: Array<T>, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+            try {
+                when (type) {
+                    BOOLEAN -> ColumnDataHolderImpl((array as Array<Boolean>).toBooleanArray().asList(), distinct)
+                    BYTE -> ColumnDataHolderImpl((array as Array<Byte>).toByteArray().asList(), distinct)
+                    SHORT -> ColumnDataHolderImpl((array as Array<Short>).toShortArray().asList(), distinct)
+                    INT -> ColumnDataHolderImpl((array as Array<Int>).toIntArray().asList(), distinct)
+                    LONG -> ColumnDataHolderImpl((array as Array<Long>).toLongArray().asList(), distinct)
+                    FLOAT -> ColumnDataHolderImpl((array as Array<Float>).toFloatArray().asList(), distinct)
+                    DOUBLE -> ColumnDataHolderImpl((array as Array<Double>).toDoubleArray().asList(), distinct)
+                    CHAR -> ColumnDataHolderImpl((array as Array<Char>).toCharArray().asList(), distinct)
+                    UBYTE -> ColumnDataHolderImpl((array as Array<UByte>).toUByteArray().asList(), distinct)
+                    USHORT -> ColumnDataHolderImpl((array as Array<UShort>).toUShortArray().asList(), distinct)
+                    UINT -> ColumnDataHolderImpl((array as Array<UInt>).toUIntArray().asList(), distinct)
+                    ULONG -> ColumnDataHolderImpl((array as Array<ULong>).toULongArray().asList(), distinct)
+                    else -> ColumnDataHolderImpl(array.asList(), distinct)
+                } as ColumnDataHolder<T>
+            } catch (e: Exception) {
+                throw IllegalArgumentException(
+                    "Can't create ColumnDataHolder from $array and mismatching type $type",
+                    e
+                )
+            }
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [primitiveArray].
+         * [primitiveArray] must be an array of primitives, returns `null` if something goes wrong.
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(primitiveArray: Any, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+            when {
+                type == BOOLEAN && primitiveArray is BooleanArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == BYTE && primitiveArray is ByteArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == SHORT && primitiveArray is ShortArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == INT && primitiveArray is IntArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == LONG && primitiveArray is LongArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == FLOAT && primitiveArray is FloatArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == DOUBLE && primitiveArray is DoubleArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == CHAR && primitiveArray is CharArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == UBYTE && primitiveArray is UByteArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == USHORT && primitiveArray is UShortArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == UINT && primitiveArray is UIntArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == ULONG && primitiveArray is ULongArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                !primitiveArray.isPrimitiveArray ->
+                    throw IllegalArgumentException(
+                        "Can't create ColumnDataHolder from non primitive array $primitiveArray and type $type"
+                    )
+
+                else ->
+                    throw IllegalArgumentException(
+                        "Can't create ColumnDataHolder from primitive array $primitiveArray and type $type"
+                    )
+            } as ColumnDataHolder<T>
+    }
+}
+
+private val BOOLEAN = typeOf<Boolean>()
+private val BYTE = typeOf<Byte>()
+private val SHORT = typeOf<Short>()
+private val INT = typeOf<Int>()
+private val LONG = typeOf<Long>()
+private val FLOAT = typeOf<Float>()
+private val DOUBLE = typeOf<Double>()
+private val CHAR = typeOf<Char>()
+private val UBYTE = typeOf<UByte>()
+private val USHORT = typeOf<UShort>()
+private val UINT = typeOf<UInt>()
+private val ULONG = typeOf<ULong>()

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
@@ -1,27 +1,29 @@
 package org.jetbrains.kotlinx.dataframe.impl.columns
 
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import kotlin.reflect.KType
 
 internal abstract class DataColumnImpl<T>(
-    protected val values: List<T>,
+    protected val values: ColumnDataHolder<T>,
     val name: String,
-    val type: KType,
-    distinct: Lazy<Set<T>>? = null
+    val type: KType
 ) : DataColumn<T>, DataColumnInternal<T> {
 
-    protected val distinct = distinct ?: lazy { values.toSet() }
+    protected val distinct
+        get() = values.distinct
 
     override fun name() = name
 
-    override fun values() = values
+    override fun values(): List<T> = values.toList()
 
     override fun type() = type
 
     override fun toSet() = distinct.value
 
-    override fun contains(value: T): Boolean = if (distinct.isInitialized()) distinct.value.contains(value) else values.contains(value)
+    override fun contains(value: T): Boolean =
+        if (distinct.isInitialized()) distinct.value.contains(value) else values.contains(value)
 
     override fun toString() = dataFrameOf(this).toString() // "${name()}: $type"
 
@@ -37,7 +39,8 @@ internal abstract class DataColumnImpl<T>(
 
     override fun hashCode() = hashCode
 
-    override operator fun get(range: IntRange) = createWithValues(values.subList(range.first, range.last + 1))
+    override operator fun get(range: IntRange) =
+        createWithValues(values[range])
 
     protected abstract fun createWithValues(values: List<T>, hasNulls: Boolean? = null): DataColumn<T>
 }

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/FrameColumnImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/FrameColumnImpl.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.impl.columns
 
 import org.jetbrains.kotlinx.dataframe.AnyRow
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.schema
@@ -11,33 +12,37 @@ import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
 import org.jetbrains.kotlinx.dataframe.impl.schema.intersectSchemas
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.toColumnDataHolder
 import kotlin.reflect.KType
 
-internal open class FrameColumnImpl<T> constructor(
+internal open class FrameColumnImpl<T>(
     name: String,
-    values: List<DataFrame<T>>,
+    values: ColumnDataHolder<DataFrame<T>>,
     columnSchema: Lazy<DataFrameSchema>? = null,
-    distinct: Lazy<Set<DataFrame<T>>>? = null
 ) :
     DataColumnImpl<DataFrame<T>>(
         values,
         name,
         DataFrame::class.createStarProjectedType(false),
-        distinct
     ),
     FrameColumn<T> {
 
-    override fun rename(newName: String) = FrameColumnImpl(newName, values, schema, distinct)
+    override fun rename(newName: String) = FrameColumnImpl(newName, values, schema)
 
     override fun defaultValue() = null
 
     override fun addParent(parent: ColumnGroup<*>) = FrameColumnWithParent(parent, this)
 
-    override fun createWithValues(values: List<DataFrame<T>>, hasNulls: Boolean?) = DataColumn.createFrameColumn(name, values)
+    override fun createWithValues(values: List<DataFrame<T>>, hasNulls: Boolean?) =
+        DataColumn.createFrameColumn(name, values)
 
     override fun changeType(type: KType) = throw UnsupportedOperationException()
 
-    override fun distinct() = FrameColumnImpl(name, distinct.value.toList(), schema, distinct)
+    override fun distinct() = FrameColumnImpl(
+        name = name,
+        values = toSet().toColumnDataHolder(type, distinct),
+        columnSchema = schema
+    )
 
     override val schema: Lazy<DataFrameSchema> = columnSchema ?: lazy {
         values.mapNotNull { it.takeIf { it.nrow > 0 }?.schema() }.intersectSchemas()
@@ -45,9 +50,11 @@ internal open class FrameColumnImpl<T> constructor(
 
     override fun forceResolve() = ResolvingFrameColumn(this)
 
-    override fun get(indices: Iterable<Int>): FrameColumn<T> = DataColumn.createFrameColumn(name, indices.map { values[it] })
+    override fun get(indices: Iterable<Int>): FrameColumn<T> =
+        DataColumn.createFrameColumn(name, indices.map { values[it] })
 
-    override fun get(columnName: String) = throw UnsupportedOperationException("Can not get nested column '$columnName' from FrameColumn '$name'")
+    override fun get(columnName: String) =
+        throw UnsupportedOperationException("Can not get nested column '$columnName' from FrameColumn '$name'")
 }
 
 internal class ResolvingFrameColumn<T>(
@@ -56,7 +63,8 @@ internal class ResolvingFrameColumn<T>(
 
     override fun resolve(context: ColumnResolutionContext) = super<FrameColumn>.resolve(context)
 
-    override fun resolveSingle(context: ColumnResolutionContext) = context.df.getColumn<DataFrame<T>>(source.name(), context.unresolvedColumnsPolicy)?.addPath()
+    override fun resolveSingle(context: ColumnResolutionContext) =
+        context.df.getColumn<DataFrame<T>>(source.name(), context.unresolvedColumnsPolicy)?.addPath()
 
     override fun getValue(row: AnyRow) = super<FrameColumn>.getValue(row)
 

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
@@ -69,6 +69,7 @@ internal inline fun <reified T : Any> JupyterHtmlRenderer.render(
     if (notebook.kernelVersion >= KotlinKernelVersion.from(MIN_KERNEL_VERSION_FOR_NEW_TABLES_UI)!!) {
         val ideBuildNumber = KotlinNotebookPluginUtils.getKotlinNotebookIDEBuildNumber()
 
+        // TODO Do we need to handle the improved meta data here as well?
         val jsonEncodedDf = when {
             !ideBuildNumber.supportsDynamicNestedTables() -> {
                 json {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/ColumnDataHolder.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/ColumnDataHolder.kt
@@ -1,0 +1,72 @@
+package org.jetbrains.kotlinx.dataframe
+
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnDataHolderImpl
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+public interface ColumnDataHolder<T> : Iterable<T> {
+
+    public val size: Int
+
+    public fun toSet(): Set<T>
+
+    public fun toList(): List<T>
+
+    public fun contains(value: T): Boolean
+
+    public operator fun get(index: Int): T
+
+    public operator fun get(range: IntRange): List<T>
+
+    public val distinct: Lazy<Set<T>>
+
+    public companion object
+}
+
+public fun <T> Collection<T>.toColumnDataHolder(type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    ColumnDataHolderImpl.of(this, type, distinct)
+
+public inline fun <reified T> Collection<T>.toColumnDataHolder(distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    this.toColumnDataHolder(typeOf<T>(), distinct)
+
+public fun <T> Array<T>.toColumnDataHolder(type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    ColumnDataHolderImpl.of(this, type, distinct)
+
+public inline fun <reified T> Array<T>.toColumnDataHolder(distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+    this.toColumnDataHolder(typeOf<T>(), distinct)
+
+public fun BooleanArray.asColumnDataHolder(distinct: Lazy<Set<Boolean>>? = null): ColumnDataHolder<Boolean> =
+    ColumnDataHolderImpl.of(this, typeOf<Boolean>(), distinct)
+
+public fun ByteArray.asColumnDataHolder(distinct: Lazy<Set<Byte>>? = null): ColumnDataHolder<Byte> =
+    ColumnDataHolderImpl.of(this, typeOf<Byte>(), distinct)
+
+public fun ShortArray.asColumnDataHolder(distinct: Lazy<Set<Short>>? = null): ColumnDataHolder<Short> =
+    ColumnDataHolderImpl.of(this, typeOf<Short>(), distinct)
+
+public fun IntArray.asColumnDataHolder(distinct: Lazy<Set<Int>>? = null): ColumnDataHolder<Int> =
+    ColumnDataHolderImpl.of(this, typeOf<Int>(), distinct)
+
+public fun LongArray.asColumnDataHolder(distinct: Lazy<Set<Long>>? = null): ColumnDataHolder<Long> =
+    ColumnDataHolderImpl.of(this, typeOf<Long>(), distinct)
+
+public fun FloatArray.asColumnDataHolder(distinct: Lazy<Set<Float>>? = null): ColumnDataHolder<Float> =
+    ColumnDataHolderImpl.of(this, typeOf<Float>(), distinct)
+
+public fun DoubleArray.asColumnDataHolder(distinct: Lazy<Set<Double>>? = null): ColumnDataHolder<Double> =
+    ColumnDataHolderImpl.of(this, typeOf<Double>(), distinct)
+
+public fun CharArray.asColumnDataHolder(distinct: Lazy<Set<Char>>? = null): ColumnDataHolder<Char> =
+    ColumnDataHolderImpl.of(this, typeOf<Char>(), distinct)
+
+public fun UByteArray.asColumnDataHolder(distinct: Lazy<Set<UByte>>? = null): ColumnDataHolder<UByte> =
+    ColumnDataHolderImpl.of(this, typeOf<UByte>(), distinct)
+
+public fun UShortArray.asColumnDataHolder(distinct: Lazy<Set<UShort>>? = null): ColumnDataHolder<UShort> =
+    ColumnDataHolderImpl.of(this, typeOf<UShort>(), distinct)
+
+public fun UIntArray.asColumnDataHolder(distinct: Lazy<Set<UInt>>? = null): ColumnDataHolder<UInt> =
+    ColumnDataHolderImpl.of(this, typeOf<UInt>(), distinct)
+
+public fun ULongArray.asColumnDataHolder(distinct: Lazy<Set<ULong>>? = null): ColumnDataHolder<ULong> =
+    ColumnDataHolderImpl.of(this, typeOf<ULong>(), distinct)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnDataHolderImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnGroupImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.FrameColumnImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.ValueColumnImpl
@@ -42,6 +43,73 @@ public interface DataColumn<out T> : BaseColumn<T> {
 
     public companion object {
 
+        public fun <T> createValueColumn(
+            name: String,
+            values: ColumnDataHolder<T>,
+            type: KType,
+            defaultValue: T? = null,
+        ): ValueColumn<T> = ValueColumnImpl(values, name, type, defaultValue)
+
+        public fun createValueColumn(
+            name: String,
+            values: BooleanArray,
+        ): ValueColumn<Boolean> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Boolean>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ByteArray,
+        ): ValueColumn<Byte> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Byte>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ShortArray,
+        ): ValueColumn<Short> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Short>())
+
+        public fun createValueColumn(
+            name: String,
+            values: IntArray,
+        ): ValueColumn<Int> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Int>())
+
+        public fun createValueColumn(
+            name: String,
+            values: LongArray,
+        ): ValueColumn<Long> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Long>())
+
+        public fun createValueColumn(
+            name: String,
+            values: FloatArray,
+        ): ValueColumn<Float> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Float>())
+
+        public fun createValueColumn(
+            name: String,
+            values: DoubleArray,
+        ): ValueColumn<Double> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Double>())
+
+        public fun createValueColumn(
+            name: String,
+            values: CharArray,
+        ): ValueColumn<Char> = createValueColumn(name, values.asColumnDataHolder(), typeOf<Char>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UByteArray,
+        ): ValueColumn<UByte> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UByte>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UShortArray,
+        ): ValueColumn<UShort> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UShort>())
+
+        public fun createValueColumn(
+            name: String,
+            values: UIntArray,
+        ): ValueColumn<UInt> = createValueColumn(name, values.asColumnDataHolder(), typeOf<UInt>())
+
+        public fun createValueColumn(
+            name: String,
+            values: ULongArray,
+        ): ValueColumn<ULong> = createValueColumn(name, values.asColumnDataHolder(), typeOf<ULong>())
+
         /**
          * Creates [ValueColumn] using given [name], [values] and [type].
          *
@@ -56,7 +124,15 @@ public interface DataColumn<out T> : BaseColumn<T> {
             type: KType,
             infer: Infer = Infer.None,
             defaultValue: T? = null,
-        ): ValueColumn<T> = ValueColumnImpl(values, name, getValuesType(values, type, infer), defaultValue)
+        ): ValueColumn<T> {
+            val valueType = getValuesType(values, type, infer)
+            return createValueColumn(
+                name = name,
+                values = ColumnDataHolderImpl.of(values, valueType),
+                type = valueType,
+                defaultValue = defaultValue
+            )
+        }
 
         /**
          * Creates [ValueColumn] using given [name], [values] and reified column [type].
@@ -73,12 +149,35 @@ public interface DataColumn<out T> : BaseColumn<T> {
             values: List<T>,
             infer: Infer = Infer.None,
         ): ValueColumn<T> = createValueColumn(
-            name, values,
-            getValuesType(
-                values,
-                typeOf<T>(),
-                infer
+            name = name,
+            values = values,
+            type = getValuesType(values, typeOf<T>(), infer)
+        )
+
+        public fun <T> createValueColumn(
+            name: String,
+            values: Array<T>,
+            type: KType,
+            infer: Infer = Infer.None,
+            defaultValue: T? = null,
+        ): ValueColumn<T> {
+            val valueType = getValuesType(values.asList(), type, infer)
+            return createValueColumn(
+                name = name,
+                values = ColumnDataHolderImpl.of(values, valueType),
+                type = valueType,
+                defaultValue = defaultValue
             )
+        }
+
+        public inline fun <reified T> createValueColumn(
+            name: String,
+            values: Array<T>,
+            infer: Infer = Infer.None,
+        ): ValueColumn<T> = createValueColumn(
+            name = name,
+            values = values,
+            type = getValuesType(values.asList(), typeOf<T>(), infer)
         )
 
         public fun <T> createColumnGroup(name: String, df: DataFrame<T>): ColumnGroup<T> = ColumnGroupImpl(name, df)
@@ -88,13 +187,13 @@ public interface DataColumn<out T> : BaseColumn<T> {
             df: DataFrame<T>,
             startIndices: Iterable<Int>,
         ): FrameColumn<T> =
-            FrameColumnImpl(name, df.splitByIndices(startIndices.asSequence()).toList(), lazy { df.schema() })
+            FrameColumnImpl(name, df.splitByIndices(startIndices.asSequence()).toList().toColumnDataHolder(), lazy { df.schema() })
 
         public fun <T> createFrameColumn(
             name: String,
             groups: List<DataFrame<T>>,
             schema: Lazy<DataFrameSchema>? = null,
-        ): FrameColumn<T> = FrameColumnImpl(name, groups, schema)
+        ): FrameColumn<T> = FrameColumnImpl(name, groups.toColumnDataHolder(), schema)
 
         public fun <T> createWithTypeInference(
             name: String,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnDataHolderImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnDataHolderImpl.kt
@@ -1,0 +1,153 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package org.jetbrains.kotlinx.dataframe.impl.columns
+
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
+import org.jetbrains.kotlinx.dataframe.impl.asList
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveArray
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+internal class ColumnDataHolderImpl<T> private constructor(
+    private val list: List<T>,
+    distinct: Lazy<Set<T>>?,
+) : ColumnDataHolder<T> {
+
+    override val distinct = distinct ?: lazy { list.toSet() }
+    override val size: Int get() = list.size
+
+    override fun toSet(): Set<T> = distinct.value
+    override fun toList(): List<T> = list
+    override fun get(index: Int): T = list[index]
+    override fun get(range: IntRange): List<T> = list.subList(range.first, range.last + 1)
+    override fun contains(value: T): Boolean = list.contains(value)
+    override fun iterator(): Iterator<T> = list.iterator()
+
+    companion object {
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [list].
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(list: Collection<T>, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> {
+            if (list is ColumnDataHolder<*>) return list as ColumnDataHolder<T>
+
+            return try {
+                when (type) {
+                    BOOLEAN -> ColumnDataHolderImpl((list as Collection<Boolean>).toBooleanArray().asList(), distinct)
+                    BYTE -> ColumnDataHolderImpl((list as Collection<Byte>).toByteArray().asList(), distinct)
+                    SHORT -> ColumnDataHolderImpl((list as Collection<Short>).toShortArray().asList(), distinct)
+                    INT -> ColumnDataHolderImpl((list as Collection<Int>).toIntArray().asList(), distinct)
+                    LONG -> ColumnDataHolderImpl((list as Collection<Long>).toLongArray().asList(), distinct)
+                    FLOAT -> ColumnDataHolderImpl((list as Collection<Float>).toFloatArray().asList(), distinct)
+                    DOUBLE -> ColumnDataHolderImpl((list as Collection<Double>).toDoubleArray().asList(), distinct)
+                    CHAR -> ColumnDataHolderImpl((list as Collection<Char>).toCharArray().asList(), distinct)
+                    UBYTE -> ColumnDataHolderImpl((list as Collection<UByte>).toUByteArray().asList(), distinct)
+                    USHORT -> ColumnDataHolderImpl((list as Collection<UShort>).toUShortArray().asList(), distinct)
+                    UINT -> ColumnDataHolderImpl((list as Collection<UInt>).toUIntArray().asList(), distinct)
+                    ULONG -> ColumnDataHolderImpl((list as Collection<ULong>).toULongArray().asList(), distinct)
+                    else -> ColumnDataHolderImpl(list.asList(), distinct)
+                } as ColumnDataHolder<T>
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Can't create ColumnDataHolder from $list and type $type", e)
+            }
+        }
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [array].
+         * If [array] is an array of primitives, it will be converted to a primitive array first before being
+         * wrapped with [asList].
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(array: Array<T>, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+            try {
+                when (type) {
+                    BOOLEAN -> ColumnDataHolderImpl((array as Array<Boolean>).toBooleanArray().asList(), distinct)
+                    BYTE -> ColumnDataHolderImpl((array as Array<Byte>).toByteArray().asList(), distinct)
+                    SHORT -> ColumnDataHolderImpl((array as Array<Short>).toShortArray().asList(), distinct)
+                    INT -> ColumnDataHolderImpl((array as Array<Int>).toIntArray().asList(), distinct)
+                    LONG -> ColumnDataHolderImpl((array as Array<Long>).toLongArray().asList(), distinct)
+                    FLOAT -> ColumnDataHolderImpl((array as Array<Float>).toFloatArray().asList(), distinct)
+                    DOUBLE -> ColumnDataHolderImpl((array as Array<Double>).toDoubleArray().asList(), distinct)
+                    CHAR -> ColumnDataHolderImpl((array as Array<Char>).toCharArray().asList(), distinct)
+                    UBYTE -> ColumnDataHolderImpl((array as Array<UByte>).toUByteArray().asList(), distinct)
+                    USHORT -> ColumnDataHolderImpl((array as Array<UShort>).toUShortArray().asList(), distinct)
+                    UINT -> ColumnDataHolderImpl((array as Array<UInt>).toUIntArray().asList(), distinct)
+                    ULONG -> ColumnDataHolderImpl((array as Array<ULong>).toULongArray().asList(), distinct)
+                    else -> ColumnDataHolderImpl(array.asList(), distinct)
+                } as ColumnDataHolder<T>
+            } catch (e: Exception) {
+                throw IllegalArgumentException(
+                    "Can't create ColumnDataHolder from $array and mismatching type $type",
+                    e
+                )
+            }
+
+        /**
+         * Constructs [ColumnDataHolderImpl] using an [asList] wrapper around the [primitiveArray].
+         * [primitiveArray] must be an array of primitives, returns `null` if something goes wrong.
+         */
+        @Suppress("UNCHECKED_CAST")
+        internal fun <T> of(primitiveArray: Any, type: KType, distinct: Lazy<Set<T>>? = null): ColumnDataHolder<T> =
+            when {
+                type == BOOLEAN && primitiveArray is BooleanArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == BYTE && primitiveArray is ByteArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == SHORT && primitiveArray is ShortArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == INT && primitiveArray is IntArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == LONG && primitiveArray is LongArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == FLOAT && primitiveArray is FloatArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == DOUBLE && primitiveArray is DoubleArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == CHAR && primitiveArray is CharArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == UBYTE && primitiveArray is UByteArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == USHORT && primitiveArray is UShortArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == UINT && primitiveArray is UIntArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                type == ULONG && primitiveArray is ULongArray ->
+                    ColumnDataHolderImpl(primitiveArray.asList(), distinct)
+
+                !primitiveArray.isPrimitiveArray ->
+                    throw IllegalArgumentException(
+                        "Can't create ColumnDataHolder from non primitive array $primitiveArray and type $type"
+                    )
+
+                else ->
+                    throw IllegalArgumentException(
+                        "Can't create ColumnDataHolder from primitive array $primitiveArray and type $type"
+                    )
+            } as ColumnDataHolder<T>
+    }
+}
+
+private val BOOLEAN = typeOf<Boolean>()
+private val BYTE = typeOf<Byte>()
+private val SHORT = typeOf<Short>()
+private val INT = typeOf<Int>()
+private val LONG = typeOf<Long>()
+private val FLOAT = typeOf<Float>()
+private val DOUBLE = typeOf<Double>()
+private val CHAR = typeOf<Char>()
+private val UBYTE = typeOf<UByte>()
+private val USHORT = typeOf<UShort>()
+private val UINT = typeOf<UInt>()
+private val ULONG = typeOf<ULong>()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
@@ -1,27 +1,29 @@
 package org.jetbrains.kotlinx.dataframe.impl.columns
 
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import kotlin.reflect.KType
 
 internal abstract class DataColumnImpl<T>(
-    protected val values: List<T>,
+    protected val values: ColumnDataHolder<T>,
     val name: String,
-    val type: KType,
-    distinct: Lazy<Set<T>>? = null
+    val type: KType
 ) : DataColumn<T>, DataColumnInternal<T> {
 
-    protected val distinct = distinct ?: lazy { values.toSet() }
+    protected val distinct
+        get() = values.distinct
 
     override fun name() = name
 
-    override fun values() = values
+    override fun values(): List<T> = values.toList()
 
     override fun type() = type
 
     override fun toSet() = distinct.value
 
-    override fun contains(value: T): Boolean = if (distinct.isInitialized()) distinct.value.contains(value) else values.contains(value)
+    override fun contains(value: T): Boolean =
+        if (distinct.isInitialized()) distinct.value.contains(value) else values.contains(value)
 
     override fun toString() = dataFrameOf(this).toString() // "${name()}: $type"
 
@@ -37,7 +39,8 @@ internal abstract class DataColumnImpl<T>(
 
     override fun hashCode() = hashCode
 
-    override operator fun get(range: IntRange) = createWithValues(values.subList(range.first, range.last + 1))
+    override operator fun get(range: IntRange) =
+        createWithValues(values[range])
 
     protected abstract fun createWithValues(values: List<T>, hasNulls: Boolean? = null): DataColumn<T>
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/FrameColumnImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/FrameColumnImpl.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.impl.columns
 
 import org.jetbrains.kotlinx.dataframe.AnyRow
+import org.jetbrains.kotlinx.dataframe.ColumnDataHolder
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.schema
@@ -11,33 +12,37 @@ import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
 import org.jetbrains.kotlinx.dataframe.impl.schema.intersectSchemas
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.toColumnDataHolder
 import kotlin.reflect.KType
 
-internal open class FrameColumnImpl<T> constructor(
+internal open class FrameColumnImpl<T>(
     name: String,
-    values: List<DataFrame<T>>,
+    values: ColumnDataHolder<DataFrame<T>>,
     columnSchema: Lazy<DataFrameSchema>? = null,
-    distinct: Lazy<Set<DataFrame<T>>>? = null
 ) :
     DataColumnImpl<DataFrame<T>>(
         values,
         name,
         DataFrame::class.createStarProjectedType(false),
-        distinct
     ),
     FrameColumn<T> {
 
-    override fun rename(newName: String) = FrameColumnImpl(newName, values, schema, distinct)
+    override fun rename(newName: String) = FrameColumnImpl(newName, values, schema)
 
     override fun defaultValue() = null
 
     override fun addParent(parent: ColumnGroup<*>) = FrameColumnWithParent(parent, this)
 
-    override fun createWithValues(values: List<DataFrame<T>>, hasNulls: Boolean?) = DataColumn.createFrameColumn(name, values)
+    override fun createWithValues(values: List<DataFrame<T>>, hasNulls: Boolean?) =
+        DataColumn.createFrameColumn(name, values)
 
     override fun changeType(type: KType) = throw UnsupportedOperationException()
 
-    override fun distinct() = FrameColumnImpl(name, distinct.value.toList(), schema, distinct)
+    override fun distinct() = FrameColumnImpl(
+        name = name,
+        values = toSet().toColumnDataHolder(type, distinct),
+        columnSchema = schema
+    )
 
     override val schema: Lazy<DataFrameSchema> = columnSchema ?: lazy {
         values.mapNotNull { it.takeIf { it.nrow > 0 }?.schema() }.intersectSchemas()
@@ -45,9 +50,11 @@ internal open class FrameColumnImpl<T> constructor(
 
     override fun forceResolve() = ResolvingFrameColumn(this)
 
-    override fun get(indices: Iterable<Int>): FrameColumn<T> = DataColumn.createFrameColumn(name, indices.map { values[it] })
+    override fun get(indices: Iterable<Int>): FrameColumn<T> =
+        DataColumn.createFrameColumn(name, indices.map { values[it] })
 
-    override fun get(columnName: String) = throw UnsupportedOperationException("Can not get nested column '$columnName' from FrameColumn '$name'")
+    override fun get(columnName: String) =
+        throw UnsupportedOperationException("Can not get nested column '$columnName' from FrameColumn '$name'")
 }
 
 internal class ResolvingFrameColumn<T>(
@@ -56,7 +63,8 @@ internal class ResolvingFrameColumn<T>(
 
     override fun resolve(context: ColumnResolutionContext) = super<FrameColumn>.resolve(context)
 
-    override fun resolveSingle(context: ColumnResolutionContext) = context.df.getColumn<DataFrame<T>>(source.name(), context.unresolvedColumnsPolicy)?.addPath()
+    override fun resolveSingle(context: ColumnResolutionContext) =
+        context.df.getColumn<DataFrame<T>>(source.name(), context.unresolvedColumnsPolicy)?.addPath()
 
     override fun getValue(row: AnyRow) = super<FrameColumn>.getValue(row)
 


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/30, one of our oldest issues.

I introduced `ColumnDataHolder` to replace the `List` in `DataColumnImpl`. This interface can define how the data of columns is stored. `ColumnDataHolderImpl` was created as default implementation and it defaults to store data in primitive arrays whenever possible. Other implementations might be possible in the future as well (to make DF act on top of an existing DB for instance).

Things to be done:

- [ ] Let data sources create `ColumnDataHolder`s directly wherever possible instead of `List`s.
- [ ] Fix cases where `DataColumnImpl.type` mismatches `DataColumnImpl.values`
- [ ] Test performance/memory differences
- [ ] Improve API