### PR TITLE
File and URL names are used in JDK / suggested in IDE auto-import. Rename our classes to avoid conflict

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/guess.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/guess.kt
@@ -35,10 +35,10 @@ public sealed interface SupportedFormat {
 public sealed interface SupportedFormatSample {
 
     @JvmInline
-    public value class File(public val sampleFile: java.io.File) : SupportedFormatSample
+    public value class DataFile(public val sampleFile: File) : SupportedFormatSample
 
     @JvmInline
-    public value class URL(public val sampleUrl: java.net.URL) : SupportedFormatSample
+    public value class DataUrl(public val sampleUrl: URL) : SupportedFormatSample
 
     @JvmInline
     public value class PathString(public val samplePath: String) : SupportedFormatSample
@@ -138,13 +138,13 @@ internal fun guessFormatForExtension(
 internal fun guessFormat(
     file: File,
     formats: List<SupportedFormat> = supportedFormats,
-    sample: SupportedFormatSample.File? = SupportedFormatSample.File(file),
+    sample: SupportedFormatSample.DataFile? = SupportedFormatSample.DataFile(file),
 ): SupportedFormat? = guessFormatForExtension(file.extension.lowercase(), formats, sample = sample)
 
 internal fun guessFormat(
     url: URL,
     formats: List<SupportedFormat> = supportedFormats,
-    sample: SupportedFormatSample.URL? = SupportedFormatSample.URL(url),
+    sample: SupportedFormatSample.DataUrl? = SupportedFormatSample.DataUrl(url),
 ): SupportedFormat? = guessFormatForExtension(url.path.substringAfterLast("."), formats, sample = sample)
 
 internal fun guessFormat(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/guess.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/guess.kt
@@ -35,10 +35,10 @@ public sealed interface SupportedFormat {
 public sealed interface SupportedFormatSample {
 
     @JvmInline
-    public value class File(public val sampleFile: java.io.File) : SupportedFormatSample
+    public value class DataFile(public val sampleFile: File) : SupportedFormatSample
 
     @JvmInline
-    public value class URL(public val sampleUrl: java.net.URL) : SupportedFormatSample
+    public value class DataUrl(public val sampleUrl: URL) : SupportedFormatSample
 
     @JvmInline
     public value class PathString(public val samplePath: String) : SupportedFormatSample
@@ -138,13 +138,13 @@ internal fun guessFormatForExtension(
 internal fun guessFormat(
     file: File,
     formats: List<SupportedFormat> = supportedFormats,
-    sample: SupportedFormatSample.File? = SupportedFormatSample.File(file),
+    sample: SupportedFormatSample.DataFile? = SupportedFormatSample.DataFile(file),
 ): SupportedFormat? = guessFormatForExtension(file.extension.lowercase(), formats, sample = sample)
 
 internal fun guessFormat(
     url: URL,
     formats: List<SupportedFormat> = supportedFormats,
-    sample: SupportedFormatSample.URL? = SupportedFormatSample.URL(url),
+    sample: SupportedFormatSample.DataUrl? = SupportedFormatSample.DataUrl(url),
 ): SupportedFormat? = guessFormatForExtension(url.path.substringAfterLast("."), formats, sample = sample)
 
 internal fun guessFormat(

--- a/dataframe-openapi/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/OpenApi.kt
+++ b/dataframe-openapi/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/OpenApi.kt
@@ -75,9 +75,9 @@ public class OpenApi : SupportedCodeGenerationFormat {
     override fun acceptsSample(sample: SupportedFormatSample): Boolean = try {
         when (sample) {
             is SupportedFormatSample.DataString -> isOpenApiStr(sample.sampleData)
-            is SupportedFormatSample.File -> isOpenApi(sample.sampleFile)
+            is SupportedFormatSample.DataFile -> isOpenApi(sample.sampleFile)
             is SupportedFormatSample.PathString -> isOpenApi(sample.samplePath)
-            is SupportedFormatSample.URL -> isOpenApi(sample.sampleUrl)
+            is SupportedFormatSample.DataUrl -> isOpenApi(sample.sampleUrl)
         }
     } catch (_: Exception) {
         false


### PR DESCRIPTION
Here's the illustration. Let's rename this class since it's in public api
![image](https://github.com/Kotlin/dataframe/assets/12936457/4ed5f0bb-18bf-43ca-9c63-864ef5b8c28d)
