### PR TITLE
`isComparable()` fix for double `describe()`

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
@@ -2,10 +2,13 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.impl.isNothing
+import org.jetbrains.kotlinx.dataframe.impl.projectTo
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.typeClass
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
@@ -26,7 +29,16 @@ public fun AnyCol.isNumber(): Boolean = isSubtypeOf<Number?>()
 
 public fun AnyCol.isList(): Boolean = typeClass == List::class
 
-public fun AnyCol.isComparable(): Boolean = isSubtypeOf<Comparable<*>?>()
+/**
+ * Returns `true` if [this] column is comparable, i.e. its type is a subtype of [Comparable] and its
+ * type argument is not [Nothing].
+ */
+public fun AnyCol.isComparable(): Boolean =
+    isSubtypeOf<Comparable<*>?>() &&
+        type().projectTo(Comparable::class).arguments[0].let {
+            it != KTypeProjection.STAR &&
+                it.type?.isNothing != true
+        }
 
 @PublishedApi
 internal fun AnyCol.isPrimitive(): Boolean = typeClass.isPrimitive()

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
@@ -19,7 +19,8 @@ public fun AnyCol.isFrameColumn(): Boolean = kind() == ColumnKind.Frame
 
 public fun AnyCol.isValueColumn(): Boolean = kind() == ColumnKind.Value
 
-public fun AnyCol.isSubtypeOf(type: KType): Boolean = this.type.isSubtypeOf(type) && (!this.type.isMarkedNullable || type.isMarkedNullable)
+public fun AnyCol.isSubtypeOf(type: KType): Boolean =
+    this.type.isSubtypeOf(type) && (!this.type.isMarkedNullable || type.isMarkedNullable)
 
 public inline fun <reified T> AnyCol.isSubtypeOf(): Boolean = isSubtypeOf(typeOf<T>())
 
@@ -43,4 +44,9 @@ public fun AnyCol.isComparable(): Boolean =
 @PublishedApi
 internal fun AnyCol.isPrimitive(): Boolean = typeClass.isPrimitive()
 
-internal fun KClass<*>.isPrimitive(): Boolean = isSubclassOf(Number::class) || this == String::class || this == Char::class || this == Array::class || isSubclassOf(Collection::class)
+internal fun KClass<*>.isPrimitive(): Boolean =
+    isSubclassOf(Number::class) ||
+        this == String::class ||
+        this == Char::class ||
+        this == Array::class ||
+        isSubclassOf(Collection::class)

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -12,7 +12,9 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVariance
-import kotlin.reflect.KVariance.*
+import kotlin.reflect.KVariance.IN
+import kotlin.reflect.KVariance.INVARIANT
+import kotlin.reflect.KVariance.OUT
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.createType
@@ -462,6 +464,9 @@ internal fun guessValueType(values: Sequence<Any?>, upperBound: KType? = null, l
         }
     }
 }
+
+internal val KType.isNothing: Boolean
+    get() = classifier == Nothing::class
 
 internal fun nothingType(nullable: Boolean): KType =
     if (nullable) {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
@@ -2,10 +2,13 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.impl.isNothing
+import org.jetbrains.kotlinx.dataframe.impl.projectTo
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.typeClass
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
@@ -26,7 +29,16 @@ public fun AnyCol.isNumber(): Boolean = isSubtypeOf<Number?>()
 
 public fun AnyCol.isList(): Boolean = typeClass == List::class
 
-public fun AnyCol.isComparable(): Boolean = isSubtypeOf<Comparable<*>?>()
+/**
+ * Returns `true` if [this] column is comparable, i.e. its type is a subtype of [Comparable] and its
+ * type argument is not [Nothing].
+ */
+public fun AnyCol.isComparable(): Boolean =
+    isSubtypeOf<Comparable<*>?>() &&
+        type().projectTo(Comparable::class).arguments[0].let {
+            it != KTypeProjection.STAR &&
+                it.type?.isNothing != true
+        }
 
 @PublishedApi
 internal fun AnyCol.isPrimitive(): Boolean = typeClass.isPrimitive()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
@@ -19,7 +19,8 @@ public fun AnyCol.isFrameColumn(): Boolean = kind() == ColumnKind.Frame
 
 public fun AnyCol.isValueColumn(): Boolean = kind() == ColumnKind.Value
 
-public fun AnyCol.isSubtypeOf(type: KType): Boolean = this.type.isSubtypeOf(type) && (!this.type.isMarkedNullable || type.isMarkedNullable)
+public fun AnyCol.isSubtypeOf(type: KType): Boolean =
+    this.type.isSubtypeOf(type) && (!this.type.isMarkedNullable || type.isMarkedNullable)
 
 public inline fun <reified T> AnyCol.isSubtypeOf(): Boolean = isSubtypeOf(typeOf<T>())
 
@@ -43,4 +44,9 @@ public fun AnyCol.isComparable(): Boolean =
 @PublishedApi
 internal fun AnyCol.isPrimitive(): Boolean = typeClass.isPrimitive()
 
-internal fun KClass<*>.isPrimitive(): Boolean = isSubclassOf(Number::class) || this == String::class || this == Char::class || this == Array::class || isSubclassOf(Collection::class)
+internal fun KClass<*>.isPrimitive(): Boolean =
+    isSubclassOf(Number::class) ||
+        this == String::class ||
+        this == Char::class ||
+        this == Array::class ||
+        isSubclassOf(Collection::class)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -12,7 +12,9 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVariance
-import kotlin.reflect.KVariance.*
+import kotlin.reflect.KVariance.IN
+import kotlin.reflect.KVariance.INVARIANT
+import kotlin.reflect.KVariance.OUT
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.createType
@@ -462,6 +464,9 @@ internal fun guessValueType(values: Sequence<Any?>, upperBound: KType? = null, l
         }
     }
 }
+
+internal val KType.isNothing: Boolean
+    get() = classifier == Nothing::class
 
 internal fun nothingType(nullable: Boolean): KType =
     if (nullable) {


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/724 by constraining `isComparable()` to check whether the values in the `Comparable` column are actually "comparable", a.k.a., the generic type of `Comparable` is not `*`/`Nothing`