### PR TITLE
Fixes std() not inferring column types

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
@@ -16,6 +16,9 @@ internal object Aggregators {
     private fun <C : Any, R> mergedValues(aggregate: Iterable<C?>.(KType) -> R?) =
         MergedValuesAggregator.Factory(aggregate, true)
 
+    private fun <C : Any, R> mergedValuesChangingTypes(aggregate: Iterable<C?>.(KType) -> R?) =
+        MergedValuesAggregator.Factory(aggregate, false)
+
     private fun <C, R> changesType(aggregate1: Iterable<C>.(KType) -> R, aggregate2: Iterable<R>.(KType) -> R) =
         TwoStepAggregator.Factory(aggregate1, aggregate2, false)
 
@@ -33,7 +36,7 @@ internal object Aggregators {
     val max by preservesType<Comparable<Any?>> { maxOrNull() }
 
     val std by withOption2<Boolean, Int, Number, Double> { skipNA, ddof ->
-        mergedValues { std(it, skipNA, ddof) }
+        mergedValuesChangingTypes { std(it, skipNA, ddof) }
     }
 
     val mean by withOption<Boolean, Number, Double> { skipNA ->

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.statistics
 
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.api.columnOf
+import org.jetbrains.kotlinx.dataframe.api.columnTypes
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.std
 import org.jetbrains.kotlinx.dataframe.math.std
@@ -21,6 +22,7 @@ class StdTests {
         value.std() shouldBe expected
         df[value].std() shouldBe expected
         df.std { value } shouldBe expected
+        df.std().columnTypes().single() shouldBe typeOf<Double>()
     }
 
     @Test

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
@@ -16,6 +16,9 @@ internal object Aggregators {
     private fun <C : Any, R> mergedValues(aggregate: Iterable<C?>.(KType) -> R?) =
         MergedValuesAggregator.Factory(aggregate, true)
 
+    private fun <C : Any, R> mergedValuesChangingTypes(aggregate: Iterable<C?>.(KType) -> R?) =
+        MergedValuesAggregator.Factory(aggregate, false)
+
     private fun <C, R> changesType(aggregate1: Iterable<C>.(KType) -> R, aggregate2: Iterable<R>.(KType) -> R) =
         TwoStepAggregator.Factory(aggregate1, aggregate2, false)
 
@@ -33,7 +36,7 @@ internal object Aggregators {
     val max by preservesType<Comparable<Any?>> { maxOrNull() }
 
     val std by withOption2<Boolean, Int, Number, Double> { skipNA, ddof ->
-        mergedValues { std(it, skipNA, ddof) }
+        mergedValuesChangingTypes { std(it, skipNA, ddof) }
     }
 
     val mean by withOption<Boolean, Number, Double> { skipNA ->

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.statistics
 
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.api.columnOf
+import org.jetbrains.kotlinx.dataframe.api.columnTypes
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.std
 import org.jetbrains.kotlinx.dataframe.math.std
@@ -21,6 +22,7 @@ class StdTests {
         value.std() shouldBe expected
         df[value].std() shouldBe expected
         df.std { value } shouldBe expected
+        df.std().columnTypes().single() shouldBe typeOf<Double>()
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/727

Fixed by by adding an aggregator for `mergedValuesChangingTypes()` and letting `std` use that instead.