### PR TITLE
Enforce the project to be built with Java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -124,6 +125,8 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     }
 }
 
+kotlin.jvmToolchain(11)
+
 allprojects {
     tasks.withType<KotlinCompile> {
         kotlinOptions {
@@ -160,6 +163,9 @@ allprojects {
         } catch (_: UnknownDomainObjectException) {
             logger.warn("Could not set kotlinter config on :${this.name}")
         }
+
+        // set the java toolchain version to 11 for all subprojects for CI stability
+        extensions.findByType<KotlinJvmProjectExtension>()?.jvmToolchain(11)
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,3 +41,7 @@ plugins {
 }
 include("dataframe-excel")
 include("core")
+
+if (JavaVersion.current() != JavaVersion.VERSION_11) {
+    throw GradleException("Building this version of the Kotlin DataFrame project can only be done with Java 11.")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,3 @@ plugins {
 }
 include("dataframe-excel")
 include("core")
-
-if (JavaVersion.current() != JavaVersion.VERSION_11) {
-    throw GradleException("Building this version of the Kotlin DataFrame project can only be done with Java 11.")
-}


### PR DESCRIPTION
Fixes compilation mismatches in FIR/IR (like [here](https://github.com/Kotlin/dataframe/pull/603#issuecomment-2167796838)) by only allowing users to build the project with JDK 11, just like it is on TC.