### PR TITLE
Extend "unfold" operation and support it in the compiler plugin

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.get
@@ -14,6 +15,7 @@ import org.jetbrains.kotlinx.dataframe.impl.api.insertImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.removeImpl
 import kotlin.reflect.KProperty
 
+@Interpretable("Replace0")
 public fun <T, C> DataFrame<T>.replace(columns: ColumnsSelector<T, C>): ReplaceClause<T, C> =
     ReplaceClause(this, columns)
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
@@ -5,6 +5,8 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.unfoldImpl
 import kotlin.reflect.KProperty
@@ -18,6 +20,8 @@ public inline fun <reified T> DataColumn<T>.unfold(noinline body: CreateDataFram
 public inline fun <T, reified C> ReplaceClause<T, C>.unfold(vararg props: KProperty<*>, maxDepth: Int = 0): DataFrame<T> =
     with { it.unfold(props = props, maxDepth) }
 
+@Refine
+@Interpretable("ReplaceUnfold1")
 public inline fun <T, reified C> ReplaceClause<T, C>.unfold(noinline body: CreateDataFrameDsl<C>.() -> Unit): DataFrame<T> =
     with { it.unfoldImpl(skipPrimitive = false, body) }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
@@ -5,22 +5,21 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.api.createDataFrameImpl
-import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.impl.api.unfoldImpl
 import kotlin.reflect.KProperty
 
-public inline fun <reified T> DataColumn<T>.unfold(): AnyCol =
-    when (kind()) {
-        ColumnKind.Group, ColumnKind.Frame -> this
-        else -> when {
-            isPrimitive() -> this
-            else -> values().createDataFrameImpl(typeClass) {
-                (this as CreateDataFrameDsl<T>).properties()
-            }.asColumnGroup(name()).asDataColumn()
-        }
-    }
+public inline fun <reified T> DataColumn<T>.unfold(vararg props: KProperty<*>, maxDepth: Int = 0): AnyCol =
+    unfoldImpl(skipPrimitive = true) { properties(roots = props, maxDepth = maxDepth) }
+
+public inline fun <reified T> DataColumn<T>.unfold(noinline body: CreateDataFrameDsl<T>.() -> Unit): AnyCol =
+    unfoldImpl(skipPrimitive = false, body)
+
+public inline fun <T, reified C> ReplaceClause<T, C>.unfold(vararg props: KProperty<*>, maxDepth: Int = 0): DataFrame<T> =
+    with { it.unfold(props = props, maxDepth) }
+
+public inline fun <T, reified C> ReplaceClause<T, C>.unfold(noinline body: CreateDataFrameDsl<C>.() -> Unit): DataFrame<T> =
+    with { it.unfoldImpl(skipPrimitive = false, body) }
 
 public fun <T> DataFrame<T>.unfold(columns: ColumnsSelector<T, *>): DataFrame<T> = replace(columns).with { it.unfold() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/unfold.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.kotlinx.dataframe.impl.api
+
+import org.jetbrains.kotlinx.dataframe.AnyCol
+import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl
+import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
+import org.jetbrains.kotlinx.dataframe.api.asDataColumn
+import org.jetbrains.kotlinx.dataframe.api.isPrimitive
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.typeClass
+
+@PublishedApi
+internal fun <T> DataColumn<T>.unfoldImpl(skipPrimitive: Boolean, body: CreateDataFrameDsl<T>.() -> Unit): AnyCol {
+    return when (kind()) {
+        ColumnKind.Group, ColumnKind.Frame -> this
+        else -> when {
+            skipPrimitive && isPrimitive() -> this
+            else -> values().createDataFrameImpl(typeClass) {
+                body((this as CreateDataFrameDsl<T>))
+            }.asColumnGroup(name()).asDataColumn()
+        }
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.io.readJsonStr
 import org.junit.Test
 import kotlin.reflect.typeOf
 
@@ -12,5 +14,62 @@ class ReplaceTests {
         val conv = df.replace { "a"<Int>() named "b" }.with { it.convertToDouble() }
         conv.columnNames() shouldBe listOf("b")
         conv.columnTypes() shouldBe listOf(typeOf<Double>())
+    }
+
+    @Test
+    fun `unfold primitive`() {
+        val a by columnOf("123")
+        val df = dataFrameOf(a)
+
+        val conv = df.replace { a }.unfold {
+            "b" from { it }
+            "c" from { DataRow.readJsonStr("""{"prop": 1}""") }
+        }
+
+        val b = conv["a"]["b"]
+        b.type() shouldBe typeOf<String>()
+        b.values() shouldBe listOf("123")
+
+        val c = conv["a"]["c"]["prop"]
+        c.type() shouldBe typeOf<Int>()
+        c.values() shouldBe listOf(1)
+    }
+
+    @Test
+    fun `unfold properties`() {
+        val col by columnOf(A("1", 123, B(3.0)))
+        val df1 = dataFrameOf(col)
+        val conv = df1.replace { col }.unfold(maxDepth = 2)
+
+        val a = conv["col"]["a"]
+        a.type() shouldBe typeOf<String>()
+        a.values() shouldBe listOf("1")
+
+        val b = conv["col"]["b"]
+        b.type() shouldBe typeOf<Int>()
+        b.values() shouldBe listOf(123)
+
+        val d = conv["col"]["bb"]["d"]
+        d.type() shouldBe typeOf<Double>()
+        d.values() shouldBe listOf(3.0)
+    }
+
+    class B(val d: Double)
+    class A(val a: String, val b: Int, val bb: B)
+
+    @Test
+    fun `skip primitive`() {
+        val col1 by columnOf("1", "2")
+        val col2 by columnOf(B(1.0), B(2.0))
+        val df1 = dataFrameOf(col1, col2)
+        val conv = df1.replace { nameStartsWith("col") }.unfold()
+
+        val a = conv["col1"]
+        a.type() shouldBe typeOf<String>()
+        a.values() shouldBe listOf("1", "2")
+
+        val b = conv["col2"]["d"]
+        b.type() shouldBe typeOf<Double>()
+        b.values() shouldBe listOf(1.0, 2.0)
     }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/ExpectedArgumentDelegates.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/ExpectedArgumentDelegates.kt
@@ -70,5 +70,11 @@ fun <T> AbstractInterpreter<T>.kproperty(
 
 internal fun <T> AbstractInterpreter<T>.string(
     name: ArgumentName? = null
-): ExpectedArgumentProvider<String
-    > = arg(name, lens = Interpreter.Value)
+): ExpectedArgumentProvider<String> =
+    arg(name, lens = Interpreter.Value)
+
+internal fun <T> AbstractInterpreter<T>.dsl(
+    name: ArgumentName? = null
+): ExpectedArgumentProvider<(Any, Map<String, Interpreter.Success<Any?>>) -> Unit> =
+    arg(name, lens = Interpreter.Dsl, defaultValue = Present(value = {_, _ -> }))
+

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/add.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/add.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
 import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleCol
 import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleDataColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dsl
 import org.jetbrains.kotlinx.dataframe.plugin.impl.string
 import org.jetbrains.kotlinx.dataframe.plugin.impl.type
 
@@ -48,11 +49,11 @@ class AddDslApproximation(val columns: MutableList<SimpleCol>)
 
 class AddWithDsl : AbstractSchemaModificationInterpreter() {
     val Arguments.receiver: PluginDataFrameSchema by dataFrame()
-    val Arguments.body: (Any) -> Unit by arg(lens = Interpreter.Dsl)
+    val Arguments.body by dsl()
 
     override fun Arguments.interpret(): PluginDataFrameSchema {
         val addDsl = AddDslApproximation(receiver.columns().toMutableList())
-        body(addDsl)
+        body(addDsl, emptyMap())
         return PluginDataFrameSchema(addDsl.columns)
     }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
@@ -29,11 +29,11 @@ class RenameInto : AbstractSchemaModificationInterpreter() {
     override fun Arguments.interpret(): PluginDataFrameSchema {
         require(receiver.columns.size == newNames.size)
         var i = 0
-        return receiver.schema.map(receiver.columns.mapTo(mutableSetOf()) { it.path.path }, nextName = { newNames[i].also { i += 1 } })
+        return receiver.schema.rename(receiver.columns.mapTo(mutableSetOf()) { it.path.path }, nextName = { newNames[i].also { i += 1 } })
     }
 }
 
-internal fun PluginDataFrameSchema.map(selected: ColumnsSet, nextName: () -> String): PluginDataFrameSchema {
+internal fun PluginDataFrameSchema.rename(selected: ColumnsSet, nextName: () -> String): PluginDataFrameSchema {
     return PluginDataFrameSchema(
         f(columns(), nextName, selected, emptyList())
     )

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/unfold.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/unfold.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Interpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleColumnGroup
+import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleFrameColumn
+import org.jetbrains.kotlinx.dataframe.plugin.impl.data.ColumnWithPathApproximation
+import org.jetbrains.kotlinx.dataframe.plugin.impl.data.ReplaceClauseApproximation
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dsl
+
+class ReplaceUnfold1 : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver: ReplaceClauseApproximation by arg()
+    val Arguments.body by dsl()
+    val Arguments.typeArg1: TypeApproximation by arg()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        val configuration = CreateDataFrameDslImplApproximation()
+        body(configuration, mapOf(Properties0.classExtraArgument to Interpreter.Success(typeArg1.type)))
+
+        return receiver.df.map(receiver.columns.map { it.path.path }.toSet()) { a, column ->
+            if (column is SimpleFrameColumn || column is SimpleColumnGroup) return@map column
+            SimpleColumnGroup(column.name, configuration.columns)
+        }
+    }
+}
+
+class Replace0 : AbstractInterpreter<ReplaceClauseApproximation>() {
+    val Arguments.receiver: PluginDataFrameSchema by dataFrame()
+    val Arguments.columns: List<ColumnWithPathApproximation> by arg()
+
+    override fun Arguments.interpret(): ReplaceClauseApproximation {
+        return ReplaceClauseApproximation(receiver, columns)
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/data/ReplaceClauseApproximation.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/data/ReplaceClauseApproximation.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.data
+
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+
+class ReplaceClauseApproximation(val df: PluginDataFrameSchema, val columns: List<ColumnWithPathApproximation>)

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -89,7 +89,7 @@ fun <T> KotlinTypeFacade.interpret(
     val actualArgsMap = refinedArguments.associateBy { it.name.identifier }.toSortedMap()
     val conflictingKeys = additionalArguments.keys intersect actualArgsMap.keys
     if (conflictingKeys.isNotEmpty()) {
-        error("Conflicting keys: $conflictingKeys")
+        interpretationFrameworkError("Conflicting keys: $conflictingKeys")
     }
     val expectedArgsMap = processor.expectedArguments
         .filterNot { it.name.startsWith("typeArg") }
@@ -268,6 +268,10 @@ fun <T> KotlinTypeFacade.interpret(
         return null
     }
 }
+
+fun interpretationFrameworkError(message: String): Nothing = throw InterpretationFrameworkError(message)
+
+class InterpretationFrameworkError(message: String) : Error(message)
 
 interface InterpretationErrorReporter {
     val errorReported: Boolean

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -95,7 +95,8 @@ fun <T> KotlinTypeFacade.interpret(
         .filterNot { it.name.startsWith("typeArg") }
         .associateBy { it.name }.toSortedMap().minus(additionalArguments.keys)
 
-    if (expectedArgsMap.keys - defaultArguments != actualArgsMap.keys - defaultArguments) {
+    val unexpectedArguments = expectedArgsMap.keys - defaultArguments != actualArgsMap.keys - defaultArguments
+    if (unexpectedArguments) {
         val message = buildString {
             appendLine("ERROR: Different set of arguments")
             appendLine("Implementation class: $processor")
@@ -105,8 +106,7 @@ fun <T> KotlinTypeFacade.interpret(
             appendLine("add arguments to an interpeter:")
             appendLine(diff.map { actualArgsMap[it] })
         }
-        reporter.reportInterpretationError(functionCall, message)
-        return null
+        interpretationFrameworkError(message)
     }
 
     val arguments = mutableMapOf<String, Interpreter.Success<Any?>>()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -204,7 +204,8 @@ fun <T> KotlinTypeFacade.interpret(
             }
 
             is Interpreter.Dsl -> {
-                { receiver: Any ->
+                { receiver: Any, dslArguments: Map<String, Interpreter.Success<Any?>> ->
+                    val map = mapOf("dsl" to Interpreter.Success(receiver)) + dslArguments
                     (it.expression as FirAnonymousFunctionExpression)
                         .anonymousFunction.body!!
                         .statements.filterIsInstance<FirFunctionCall>()
@@ -213,7 +214,7 @@ fun <T> KotlinTypeFacade.interpret(
                             interpret(
                                 call,
                                 schemaProcessor,
-                                mapOf("dsl" to Interpreter.Success(receiver)),
+                                map,
                                 reporter
                             )
                         }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -67,6 +67,9 @@ import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameDefault
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameDsl
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameFrom
 
 internal fun FirFunctionCall.loadInterpreter(session: FirSession): Interpreter<*>? {
@@ -161,6 +164,9 @@ internal inline fun <reified T> String.load(): T {
         "ReadDelimStr" -> ReadDelimStr()
         "GroupByToDataFrame" -> GroupByToDataFrame()
         "ToDataFrameFrom0" -> ToDataFrameFrom()
+        "toDataFrameDsl" -> ToDataFrameDsl()
+        "toDataFrame" -> ToDataFrame()
+        "toDataFrameDefault" -> ToDataFrameDefault()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -67,6 +67,8 @@ import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Replace0
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReplaceUnfold1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameDefault
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameDsl
@@ -167,6 +169,8 @@ internal inline fun <reified T> String.load(): T {
         "toDataFrameDsl" -> ToDataFrameDsl()
         "toDataFrame" -> ToDataFrame()
         "toDataFrameDefault" -> ToDataFrameDefault()
+        "Replace0" -> Replace0()
+        "ReplaceUnfold1" -> ReplaceUnfold1()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.fir.ir.txt
+++ b/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.fir.ir.txt
@@ -1,0 +1,737 @@
+FILE fqName:<root> fileName:/unfold_replace_dsl.kt
+  CLASS CLASS name:Declaration modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Declaration
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.Declaration.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL <> ($this:<root>.Declaration) returnType:kotlin.String
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.Declaration'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.<get-name>' type=<root>.Declaration origin=null
+    PROPERTY name:functions visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'functions: <root>.Function declared in <root>.Declaration.<init>' type=<root>.Function origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-functions> visibility:public modality:FINAL <> ($this:<root>.Declaration) returnType:<root>.Function
+        correspondingProperty: PROPERTY name:functions visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-functions> (): <root>.Function declared in <root>.Declaration'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+              receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.<get-functions>' type=<root>.Declaration origin=null
+    CONSTRUCTOR visibility:public <> (name:kotlin.String, functions:<root>.Function) returnType:<root>.Declaration [primary]
+      VALUE_PARAMETER name:name index:0 type:kotlin.String
+      VALUE_PARAMETER name:functions index:1 type:<root>.Function
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Declaration modality:FINAL visibility:public [data] superTypes:[kotlin.Any]'
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL <> ($this:<root>.Declaration) returnType:kotlin.String [operator]
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.Declaration'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.component1' type=<root>.Declaration origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL <> ($this:<root>.Declaration) returnType:<root>.Function [operator]
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): <root>.Function declared in <root>.Declaration'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+            receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.component2' type=<root>.Declaration origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL <> ($this:<root>.Declaration, name:kotlin.String, functions:<root>.Function) returnType:<root>.Declaration
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      VALUE_PARAMETER name:name index:0 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.copy' type=<root>.Declaration origin=null
+      VALUE_PARAMETER name:functions index:1 type:<root>.Function
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+            receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.copy' type=<root>.Declaration origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, functions: <root>.Function): <root>.Declaration declared in <root>.Declaration'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, functions: <root>.Function) declared in <root>.Declaration' type=<root>.Declaration origin=null
+            name: GET_VAR 'name: kotlin.String declared in <root>.Declaration.copy' type=kotlin.String origin=null
+            functions: GET_VAR 'functions: <root>.Function declared in <root>.Declaration.copy' type=<root>.Function origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Declaration, other:kotlin.Any?) returnType:kotlin.Boolean [operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              arg0: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.equals' type=<root>.Declaration origin=null
+              arg1: GET_VAR 'other: kotlin.Any? declared in <root>.Declaration.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Declaration'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.Declaration
+              GET_VAR 'other: kotlin.Any? declared in <root>.Declaration.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Declaration'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.Declaration [val]
+          TYPE_OP type=<root>.Declaration origin=CAST typeOperand=<root>.Declaration
+            GET_VAR 'other: kotlin.Any? declared in <root>.Declaration.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.equals' type=<root>.Declaration origin=null
+                arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_0: <root>.Declaration declared in <root>.Declaration.equals' type=<root>.Declaration origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Declaration'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+                  receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.equals' type=<root>.Declaration origin=null
+                arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+                  receiver: GET_VAR 'val tmp_0: <root>.Declaration declared in <root>.Declaration.equals' type=<root>.Declaration origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Declaration'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Declaration'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN <> ($this:<root>.Declaration) returnType:kotlin.Int
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            $this: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.hashCode' type=<root>.Declaration origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.Declaration.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              $this: GET_VAR 'var result: kotlin.Int declared in <root>.Declaration.hashCode' type=kotlin.Int origin=null
+              other: CONST Int type=kotlin.Int value=31
+            other: CALL 'public open fun hashCode (): kotlin.Int declared in <root>.Function' type=kotlin.Int origin=null
+              $this: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+                receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.hashCode' type=<root>.Declaration origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Declaration'
+          GET_VAR 'var result: kotlin.Int declared in <root>.Declaration.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN <> ($this:<root>.Declaration) returnType:kotlin.String
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Declaration
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.Declaration'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="Declaration("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.toString' type=<root>.Declaration origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="functions="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]' type=<root>.Function origin=null
+              receiver: GET_VAR '<this>: <root>.Declaration declared in <root>.Declaration.toString' type=<root>.Declaration origin=null
+            CONST String type=kotlin.String value=")"
+  CLASS CLASS name:Function modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Function
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.Function.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL <> ($this:<root>.Function) returnType:kotlin.String
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.Function
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.Function'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.<get-name>' type=<root>.Function origin=null
+    CONSTRUCTOR visibility:public <> (name:kotlin.String) returnType:<root>.Function [primary]
+      VALUE_PARAMETER name:name index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Function modality:FINAL visibility:public [data] superTypes:[kotlin.Any]'
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL <> ($this:<root>.Function) returnType:kotlin.String [operator]
+      $this: VALUE_PARAMETER name:<this> type:<root>.Function
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.Function'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.component1' type=<root>.Function origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL <> ($this:<root>.Function, name:kotlin.String) returnType:<root>.Function
+      $this: VALUE_PARAMETER name:<this> type:<root>.Function
+      VALUE_PARAMETER name:name index:0 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.copy' type=<root>.Function origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String): <root>.Function declared in <root>.Function'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String) declared in <root>.Function' type=<root>.Function origin=null
+            name: GET_VAR 'name: kotlin.String declared in <root>.Function.copy' type=kotlin.String origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.Function, other:kotlin.Any?) returnType:kotlin.Boolean [operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Function
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              arg0: GET_VAR '<this>: <root>.Function declared in <root>.Function.equals' type=<root>.Function origin=null
+              arg1: GET_VAR 'other: kotlin.Any? declared in <root>.Function.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Function'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.Function
+              GET_VAR 'other: kotlin.Any? declared in <root>.Function.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Function'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:<root>.Function [val]
+          TYPE_OP type=<root>.Function origin=CAST typeOperand=<root>.Function
+            GET_VAR 'other: kotlin.Any? declared in <root>.Function.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.equals' type=<root>.Function origin=null
+                arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_1: <root>.Function declared in <root>.Function.equals' type=<root>.Function origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Function'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Function'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN <> ($this:<root>.Function) returnType:kotlin.Int
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Function
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Function'
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            $this: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.hashCode' type=<root>.Function origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN <> ($this:<root>.Function) returnType:kotlin.String
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:<root>.Function
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.Function'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="Function("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Function declared in <root>.Function.toString' type=<root>.Function origin=null
+            CONST String type=kotlin.String value=")"
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:df type:org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> [val]
+        CALL 'public final fun let <T, R> (block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> origin=null
+          <T>: kotlin.collections.List<<root>.Declaration>
+          <R>: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48>
+          $receiver: CALL 'public final fun listOf <T> (element: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<<root>.Declaration> origin=null
+            <T>: <root>.Declaration
+            element: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, functions: <root>.Function) declared in <root>.Declaration' type=<root>.Declaration origin=null
+              name: CONST String type=kotlin.String value="DataFrameImpl"
+              functions: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String) declared in <root>.Function' type=<root>.Function origin=null
+                name: CONST String type=kotlin.String value="rowsCount"
+          block: FUN_EXPR type=kotlin.Function1<kotlin.collections.List<<root>.Declaration>, org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48>> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:kotlin.collections.List<<root>.Declaration>) returnType:org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48>
+              VALUE_PARAMETER name:it index:0 type:kotlin.collections.List<<root>.Declaration>
+              BLOCK_BODY
+                CLASS CLASS name:Declaration_48I modality:ABSTRACT visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Declaration_48I
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Declaration_48I [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Declaration_48I modality:ABSTRACT visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:functions visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 1)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-functions> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48I) returnType:<root>.Function
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:functions visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48I
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 0)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48I) returnType:kotlin.String
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48I
+                CLASS CLASS name:Scope0 modality:FINAL visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Scope0
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:functions type:<root>.Function visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-functions> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I>) returnType:<root>.Function
+                      annotations:
+                        JvmName(name = "Declaration_48I_functions")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I>
+                      BLOCK_BODY
+                        RETURN type=<root>.Function from='public final fun <get-functions> (): <root>.Function declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=<root>.Function origin=CAST typeOperand=<root>.Function
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I> declared in <root>.box.<anonymous>.Scope0.<get-functions>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I> origin=null
+                              name: CONST String type=kotlin.String value="functions"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:functions type:org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-functions> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I>) returnType:org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function>
+                      annotations:
+                        JvmName(name = "Declaration_48I_functions")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> from='public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I> declared in <root>.box.<anonymous>.Scope0.<get-functions>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I> origin=null
+                              columnName: CONST String type=kotlin.String value="functions"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I>) returnType:kotlin.String
+                      annotations:
+                        JvmName(name = "Declaration_48I_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I>
+                      BLOCK_BODY
+                        RETURN type=kotlin.String from='public final fun <get-name> (): kotlin.String declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I> declared in <root>.box.<anonymous>.Scope0.<get-name>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Declaration_48I> origin=null
+                              name: CONST String type=kotlin.String value="name"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I>) returnType:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                      annotations:
+                        JvmName(name = "Declaration_48I_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> from='public final fun <get-name> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I> declared in <root>.box.<anonymous>.Scope0.<get-name>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Declaration_48I> origin=null
+                              columnName: CONST String type=kotlin.String value="name"
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Scope0 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Scope0 modality:FINAL visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                CLASS CLASS name:Declaration_48 modality:ABSTRACT visibility:local superTypes:[<root>.box.<anonymous>.Declaration_48I]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Declaration_48
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Declaration_48 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Declaration_48I'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Declaration_48 modality:ABSTRACT visibility:local superTypes:[<root>.box.<anonymous>.Declaration_48I]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.box.<anonymous>.Declaration_48I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in <root>.box.<anonymous>.Declaration_48I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in <root>.box.<anonymous>.Declaration_48I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  PROPERTY FAKE_OVERRIDE name:functions visibility:public modality:ABSTRACT [fake_override,val]
+                    annotations:
+                      Order(order = 1)
+                    overridden:
+                      public abstract functions: <root>.Function declared in <root>.box.<anonymous>.Declaration_48I
+                    FUN FAKE_OVERRIDE name:<get-functions> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48I) returnType:<root>.Function [fake_override]
+                      correspondingProperty: PROPERTY FAKE_OVERRIDE name:functions visibility:public modality:ABSTRACT [fake_override,val]
+                      overridden:
+                        public abstract fun <get-functions> (): <root>.Function declared in <root>.box.<anonymous>.Declaration_48I
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48I
+                  PROPERTY FAKE_OVERRIDE name:name visibility:public modality:ABSTRACT [fake_override,val]
+                    annotations:
+                      Order(order = 0)
+                    overridden:
+                      public abstract name: kotlin.String declared in <root>.box.<anonymous>.Declaration_48I
+                    FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48I) returnType:kotlin.String [fake_override]
+                      correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:ABSTRACT [fake_override,val]
+                      overridden:
+                        public abstract fun <get-name> (): kotlin.String declared in <root>.box.<anonymous>.Declaration_48I
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48I
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-scope0> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48) returnType:<root>.box.<anonymous>.Scope0
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-scope0> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Declaration_48, <set-?>:<root>.box.<anonymous>.Scope0) returnType:kotlin.Unit
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Declaration_48
+                      VALUE_PARAMETER name:<set-?> index:0 type:<root>.box.<anonymous>.Scope0
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.collections.List<<root>.Declaration>): org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> declared in <root>.box'
+                  CALL 'public final fun toDataFrame <T> (): org.jetbrains.kotlinx.dataframe.DataFrame<T of org.jetbrains.kotlinx.dataframe.api.toDataFrame> declared in org.jetbrains.kotlinx.dataframe.api' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> origin=null
+                    <T>: <root>.Declaration
+                    $receiver: GET_VAR 'it: kotlin.collections.List<<root>.Declaration> declared in <root>.box.<anonymous>' type=kotlin.collections.List<<root>.Declaration> origin=null
+      VAR name:a type:kotlin.String [val]
+        CALL 'public abstract fun get (index: kotlin.Int): T of org.jetbrains.kotlinx.dataframe.DataColumn declared in org.jetbrains.kotlinx.dataframe.DataColumn' type=kotlin.String origin=GET_ARRAY_ELEMENT
+          $this: CALL 'public final fun <get-name> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> declared in <root>.box.<anonymous>.Scope0' type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> origin=GET_PROPERTY
+            $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope0' type=<root>.box.<anonymous>.Scope0 origin=null
+            $receiver: GET_VAR 'val df: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> declared in <root>.box' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> origin=null
+          index: CONST Int type=kotlin.Int value=0
+      VAR name:b type:<root>.Function [val]
+        CALL 'public abstract fun get (index: kotlin.Int): T of org.jetbrains.kotlinx.dataframe.DataColumn declared in org.jetbrains.kotlinx.dataframe.DataColumn' type=<root>.Function origin=GET_ARRAY_ELEMENT
+          $this: CALL 'public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> declared in <root>.box.<anonymous>.Scope0' type=org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> origin=GET_PROPERTY
+            $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope0' type=<root>.box.<anonymous>.Scope0 origin=null
+            $receiver: GET_VAR 'val df: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> declared in <root>.box' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> origin=null
+          index: CONST Int type=kotlin.Int value=0
+      VAR name:df1 type:org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> [val]
+        CALL 'public final fun let <T, R> (block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> origin=null
+          <T>: org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function>
+          <R>: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91>
+          $receiver: CALL 'public final fun replace <T, C> (columns: @[ExtensionFunctionType] kotlin.Function2<org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<T of org.jetbrains.kotlinx.dataframe.api.replace>, @[ParameterName(name = "it")] org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<T of org.jetbrains.kotlinx.dataframe.api.replace>, org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver<C of org.jetbrains.kotlinx.dataframe.api.replace>>): org.jetbrains.kotlinx.dataframe.api.ReplaceClause<T of org.jetbrains.kotlinx.dataframe.api.replace, C of org.jetbrains.kotlinx.dataframe.api.replace> declared in org.jetbrains.kotlinx.dataframe.api' type=org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function> origin=null
+            <T>: <root>.box.<anonymous>.Declaration_48
+            <C>: <root>.Function
+            $receiver: GET_VAR 'val df: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> declared in <root>.box' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Declaration_48> origin=null
+            columns: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function2<org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>, @[ParameterName(name = "it")] org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>, org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver<<root>.Function>> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>, it:@[ParameterName(name = "it")] org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>) returnType:org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver<<root>.Function>
+                $receiver: VALUE_PARAMETER name:$this$replace type:org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>
+                VALUE_PARAMETER name:it index:0 type:@[ParameterName(name = "it")] org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: @[ParameterName(name = "it")] org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48>): org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver<<root>.Function> declared in <root>.box'
+                    CALL 'public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> declared in <root>.box.<anonymous>.Scope0' type=org.jetbrains.kotlinx.dataframe.DataColumn<<root>.Function> origin=GET_PROPERTY
+                      $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope0' type=<root>.box.<anonymous>.Scope0 origin=null
+                      $receiver: GET_VAR '$this$replace: org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48> declared in <root>.box.<anonymous>' type=org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl<<root>.box.<anonymous>.Declaration_48> origin=null
+          block: FUN_EXPR type=kotlin.Function1<org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function>, org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91>> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function>) returnType:org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91>
+              VALUE_PARAMETER name:it index:0 type:org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function>
+              BLOCK_BODY
+                CLASS CLASS name:Unfold_91I modality:ABSTRACT visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Unfold_91I
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Unfold_91I [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Unfold_91I modality:ABSTRACT visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:functions visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 1)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-functions> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91I) returnType:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:functions visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91I
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 0)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91I) returnType:kotlin.String
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91I
+                CLASS CLASS name:Scope0 modality:FINAL visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Scope0
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:functions type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-functions> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I>) returnType:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>
+                      annotations:
+                        JvmName(name = "Unfold_91I_functions")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> from='public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I> declared in <root>.box.<anonymous>.Scope0.<get-functions>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I> origin=null
+                              name: CONST String type=kotlin.String value="functions"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:functions type:org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-functions> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I>) returnType:org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251>
+                      annotations:
+                        JvmName(name = "Unfold_91I_functions")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:functions visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> from='public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I> declared in <root>.box.<anonymous>.Scope0.<get-functions>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I> origin=null
+                              columnName: CONST String type=kotlin.String value="functions"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I>) returnType:kotlin.String
+                      annotations:
+                        JvmName(name = "Unfold_91I_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I>
+                      BLOCK_BODY
+                        RETURN type=kotlin.String from='public final fun <get-name> (): kotlin.String declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I> declared in <root>.box.<anonymous>.Scope0.<get-name>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Unfold_91I> origin=null
+                              name: CONST String type=kotlin.String value="name"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope0, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I>) returnType:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                      annotations:
+                        JvmName(name = "Unfold_91I_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope0
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> from='public final fun <get-name> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> declared in <root>.box.<anonymous>.Scope0'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I> declared in <root>.box.<anonymous>.Scope0.<get-name>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Unfold_91I> origin=null
+                              columnName: CONST String type=kotlin.String value="name"
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Scope0 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Scope0 modality:FINAL visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                CLASS CLASS name:Functions_251 modality:ABSTRACT visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Functions_251
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Functions_251 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Functions_251 modality:ABSTRACT visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 0)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Functions_251) returnType:kotlin.String
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:name visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Functions_251
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:nameLength visibility:public modality:ABSTRACT [val]
+                    annotations:
+                      Order(order = 1)
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-nameLength> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Functions_251) returnType:kotlin.Int
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:nameLength visibility:public modality:ABSTRACT [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Functions_251
+                CLASS CLASS name:Scope1 modality:FINAL visibility:local superTypes:[kotlin.Any]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Scope1
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:nameLength visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:nameLength type:kotlin.Int visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-nameLength> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope1, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>) returnType:kotlin.Int
+                      annotations:
+                        JvmName(name = "Functions_251_nameLength")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:nameLength visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope1
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>
+                      BLOCK_BODY
+                        RETURN type=kotlin.Int from='public final fun <get-nameLength> (): kotlin.Int declared in <root>.box.<anonymous>.Scope1'
+                          TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope1.<get-nameLength>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> origin=null
+                              name: CONST String type=kotlin.String value="nameLength"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:nameLength visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:nameLength type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-nameLength> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope1, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251>) returnType:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int>
+                      annotations:
+                        JvmName(name = "Functions_251_nameLength")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:nameLength visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope1
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> from='public final fun <get-nameLength> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> declared in <root>.box.<anonymous>.Scope1'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope1.<get-nameLength>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251> origin=null
+                              columnName: CONST String type=kotlin.String value="nameLength"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope1, $receiver:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>) returnType:kotlin.String
+                      annotations:
+                        JvmName(name = "Functions_251_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope1
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251>
+                      BLOCK_BODY
+                        RETURN type=kotlin.String from='public final fun <get-name> (): kotlin.String declared in <root>.box.<anonymous>.Scope1'
+                          TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                            CALL 'public abstract fun get (name: kotlin.String): kotlin.Any? declared in org.jetbrains.kotlinx.dataframe.DataRow' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope1.<get-name>' type=org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> origin=null
+                              name: CONST String type=kotlin.String value="name"
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                    FIELD PROPERTY_BACKING_FIELD name:name type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> visibility:private [final]
+                    FUN GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:<get-name> visibility:public modality:FINAL <> ($this:<root>.box.<anonymous>.Scope1, $receiver:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251>) returnType:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                      annotations:
+                        JvmName(name = "Functions_251_name")
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] name:name visibility:public modality:FINAL [val]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Scope1
+                      $receiver: VALUE_PARAMETER name:<this> type:org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251>
+                      BLOCK_BODY
+                        RETURN type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> from='public final fun <get-name> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> declared in <root>.box.<anonymous>.Scope1'
+                          TYPE_OP type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> origin=CAST typeOperand=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String>
+                            CALL 'public open fun get (columnName: kotlin.String): org.jetbrains.kotlinx.dataframe.DataColumn<*> declared in org.jetbrains.kotlinx.dataframe.ColumnsContainer' type=kotlin.Any? origin=null
+                              $this: GET_VAR '<this>: org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope1.<get-name>' type=org.jetbrains.kotlinx.dataframe.ColumnsContainer<<root>.box.<anonymous>.Functions_251> origin=null
+                              columnName: CONST String type=kotlin.String value="name"
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Scope1 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Scope1 modality:FINAL visibility:local superTypes:[kotlin.Any]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in kotlin.Any
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                CLASS CLASS name:Unfold_91 modality:ABSTRACT visibility:local superTypes:[<root>.box.<anonymous>.Unfold_91I]
+                  $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.box.<anonymous>.Unfold_91
+                  CONSTRUCTOR GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.DataFramePlugin] visibility:public <> () returnType:<root>.box.<anonymous>.Unfold_91 [primary]
+                    BLOCK_BODY
+                      DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Unfold_91I'
+                      INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Unfold_91 modality:ABSTRACT visibility:local superTypes:[<root>.box.<anonymous>.Unfold_91I]'
+                  FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                    overridden:
+                      public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.box.<anonymous>.Unfold_91I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                    VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+                  FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+                    overridden:
+                      public open fun hashCode (): kotlin.Int declared in <root>.box.<anonymous>.Unfold_91I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+                    overridden:
+                      public open fun toString (): kotlin.String declared in <root>.box.<anonymous>.Unfold_91I
+                    $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+                  PROPERTY FAKE_OVERRIDE name:functions visibility:public modality:ABSTRACT [fake_override,val]
+                    annotations:
+                      Order(order = 1)
+                    overridden:
+                      public abstract functions: org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Unfold_91I
+                    FUN FAKE_OVERRIDE name:<get-functions> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91I) returnType:org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> [fake_override]
+                      correspondingProperty: PROPERTY FAKE_OVERRIDE name:functions visibility:public modality:ABSTRACT [fake_override,val]
+                      overridden:
+                        public abstract fun <get-functions> (): org.jetbrains.kotlinx.dataframe.DataRow<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Unfold_91I
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91I
+                  PROPERTY FAKE_OVERRIDE name:name visibility:public modality:ABSTRACT [fake_override,val]
+                    annotations:
+                      Order(order = 0)
+                    overridden:
+                      public abstract name: kotlin.String declared in <root>.box.<anonymous>.Unfold_91I
+                    FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91I) returnType:kotlin.String [fake_override]
+                      correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:ABSTRACT [fake_override,val]
+                      overridden:
+                        public abstract fun <get-name> (): kotlin.String declared in <root>.box.<anonymous>.Unfold_91I
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91I
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-scope0> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91) returnType:<root>.box.<anonymous>.Scope0
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-scope0> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91, <set-?>:<root>.box.<anonymous>.Scope0) returnType:kotlin.Unit
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope0 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91
+                      VALUE_PARAMETER name:<set-?> index:0 type:<root>.box.<anonymous>.Scope0
+                  PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope1 visibility:public modality:ABSTRACT [var]
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-scope1> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91) returnType:<root>.box.<anonymous>.Scope1
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope1 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91
+                    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-scope1> visibility:public modality:ABSTRACT <> ($this:<root>.box.<anonymous>.Unfold_91, <set-?>:<root>.box.<anonymous>.Scope1) returnType:kotlin.Unit
+                      correspondingProperty: PROPERTY GENERATED[org.jetbrains.kotlinx.dataframe.plugin.extensions.TokenGenerator.Key] name:scope1 visibility:public modality:ABSTRACT [var]
+                      $this: VALUE_PARAMETER name:<this> type:<root>.box.<anonymous>.Unfold_91
+                      VALUE_PARAMETER name:<set-?> index:0 type:<root>.box.<anonymous>.Scope1
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function>): org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> declared in <root>.box'
+                  CALL 'public final fun unfold <T, C> (body: @[ExtensionFunctionType] kotlin.Function1<org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<C of org.jetbrains.kotlinx.dataframe.api.unfold>, kotlin.Unit>): org.jetbrains.kotlinx.dataframe.DataFrame<T of org.jetbrains.kotlinx.dataframe.api.unfold> declared in org.jetbrains.kotlinx.dataframe.api' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> origin=null
+                    <T>: <root>.box.<anonymous>.Declaration_48
+                    <C>: <root>.Function
+                    $receiver: GET_VAR 'it: org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function> declared in <root>.box.<anonymous>' type=org.jetbrains.kotlinx.dataframe.api.ReplaceClause<<root>.box.<anonymous>.Declaration_48, <root>.Function> origin=null
+                    body: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function>, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function>) returnType:kotlin.Unit
+                        $receiver: VALUE_PARAMETER name:$this$unfold type:org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function>
+                        BLOCK_BODY
+                          CALL 'public abstract fun properties (vararg roots: kotlin.reflect.KCallable<*>, maxDepth: kotlin.Int, body: @[ExtensionFunctionType] kotlin.Function1<org.jetbrains.kotlinx.dataframe.api.TraversePropertiesDsl, kotlin.Unit>?): kotlin.Unit declared in org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl' type=kotlin.Unit origin=null
+                            $this: GET_VAR '$this$unfold: org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function> declared in <root>.box.<anonymous>.<anonymous>' type=org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function> origin=null
+                            maxDepth: CONST Int type=kotlin.Int value=0
+                          CALL 'public final fun from <R> (expression: kotlin.Function1<T of org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl, R of org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl.from>): kotlin.Unit declared in org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl' type=kotlin.Unit origin=null
+                            <R>: kotlin.Int
+                            $this: GET_VAR '$this$unfold: org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function> declared in <root>.box.<anonymous>.<anonymous>' type=org.jetbrains.kotlinx.dataframe.api.CreateDataFrameDsl<<root>.Function> origin=null
+                            $receiver: CONST String type=kotlin.String value="nameLength"
+                            expression: FUN_EXPR type=kotlin.Function1<<root>.Function, kotlin.Int> origin=LAMBDA
+                              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (it:<root>.Function) returnType:kotlin.Int
+                                VALUE_PARAMETER name:it index:0 type:<root>.Function
+                                BLOCK_BODY
+                                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: <root>.Function): kotlin.Int declared in <root>.box.<anonymous>.<anonymous>'
+                                    CALL 'public open fun <get-length> (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=GET_PROPERTY
+                                      $this: CALL 'public final fun <get-name> (): kotlin.String declared in <root>.Function' type=kotlin.String origin=GET_PROPERTY
+                                        $this: GET_VAR 'it: <root>.Function declared in <root>.box.<anonymous>.<anonymous>.<anonymous>' type=<root>.Function origin=null
+      VAR name:c type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> [val]
+        CALL 'public final fun <get-name> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> declared in <root>.box.<anonymous>.Scope1' type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.String> origin=GET_PROPERTY
+          $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope1' type=<root>.box.<anonymous>.Scope1 origin=null
+          $receiver: CALL 'public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope0' type=org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> origin=GET_PROPERTY
+            $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope0' type=<root>.box.<anonymous>.Scope0 origin=null
+            $receiver: GET_VAR 'val df1: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> declared in <root>.box' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> origin=null
+      VAR name:d type:org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> [val]
+        CALL 'public final fun <get-nameLength> (): org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> declared in <root>.box.<anonymous>.Scope1' type=org.jetbrains.kotlinx.dataframe.DataColumn<kotlin.Int> origin=GET_PROPERTY
+          $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope1' type=<root>.box.<anonymous>.Scope1 origin=null
+          $receiver: CALL 'public final fun <get-functions> (): org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> declared in <root>.box.<anonymous>.Scope0' type=org.jetbrains.kotlinx.dataframe.columns.ColumnGroup<<root>.box.<anonymous>.Functions_251> origin=GET_PROPERTY
+            $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.box.<anonymous>.Scope0' type=<root>.box.<anonymous>.Scope0 origin=null
+            $receiver: GET_VAR 'val df1: org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> declared in <root>.box' type=org.jetbrains.kotlinx.dataframe.DataFrame<<root>.box.<anonymous>.Unfold_91> origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.fir.txt
+++ b/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.fir.txt
@@ -1,0 +1,163 @@
+FILE: unfold_replace_dsl.kt
+    public final data class Function : R|kotlin/Any| {
+        public constructor(name: R|kotlin/String|): R|Function| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final fun copy(name: R|kotlin/String| = this@R|/Function|.R|/Function.name|): R|Function|
+
+    }
+    public final data class Declaration : R|kotlin/Any| {
+        public constructor(name: R|kotlin/String|, functions: R|Function|): R|Declaration| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final val functions: R|Function| = R|<local>/functions|
+            public get(): R|Function|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final operator fun component2(): R|Function|
+
+        public final fun copy(name: R|kotlin/String| = this@R|/Declaration|.R|/Declaration.name|, functions: R|Function| = this@R|/Declaration|.R|/Declaration.functions|): R|Declaration|
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval df: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Declaration_48>| = R|kotlin/collections/listOf|<R|Declaration|>(R|/Declaration.Declaration|(String(DataFrameImpl), R|/Function.Function|(String(rowsCount)))).R|kotlin/let|<R|kotlin/collections/List<Declaration>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Declaration_48>|>(<L> = fun <anonymous>(it: R|kotlin/collections/List<Declaration>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Declaration_48>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Declaration_48I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val functions: R|Function|
+                    public get(): R|Function|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public constructor(): R|<local>/Declaration_48I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Declaration_48I>|.functions: R|Function|
+                    public get(): R|Function|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Declaration_48I>|.functions: R|org/jetbrains/kotlinx/dataframe/DataColumn<Function>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<Function>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Declaration_48I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Declaration_48I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Declaration_48 : R|<local>/Declaration_48I| {
+                public abstract var scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+                    public set(value: R|<local>/Scope0|): R|kotlin/Unit|
+
+                public constructor(): R|<local>/Declaration_48|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/toDataFrame|<R|Declaration|>()
+        }
+        )
+        lval a: R|kotlin/String| = (this@R|/box|, R|<local>/df|).R|<local>/Scope0.name|.R|SubstitutionOverride<org/jetbrains/kotlinx/dataframe/DataColumn.get: R|kotlin/String|>|(Int(0))
+        lval b: R|Function| = (this@R|/box|, R|<local>/df|).R|<local>/Scope0.functions|.R|SubstitutionOverride<org/jetbrains/kotlinx/dataframe/DataColumn.get: R|Function|>|(Int(0))
+        lval df1: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Unfold_91>| = R|<local>/df|.R|org/jetbrains/kotlinx/dataframe/api/replace|<R|<local>/Declaration_48|, R|Function|>(<L> = replace@fun R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Declaration_48>|.<anonymous>(it: R|@R|kotlin/ParameterName|(name = String(it))  org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Declaration_48>|): R|org/jetbrains/kotlinx/dataframe/columns/ColumnsResolver<Function>| <inline=NoInline>  {
+            ^ (this@R|/box|, this@R|special/anonymous|).R|<local>/Scope0.functions|
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/api/ReplaceClause<<local>/Declaration_48, Function>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Unfold_91>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/ReplaceClause<<local>/Declaration_48, Function>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Unfold_91>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Unfold_91I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val functions: R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public constructor(): R|<local>/Unfold_91I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Unfold_91I>|.functions: R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Unfold_91I>|.functions: R|org/jetbrains/kotlinx/dataframe/columns/ColumnGroup<<local>/Functions_251>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/columns/ColumnGroup<<local>/Functions_251>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Unfold_91I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Unfold_91I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Functions_251 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val nameLength: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public constructor(): R|<local>/Functions_251|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|.nameLength: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Functions_251>|.nameLength: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Functions_251>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsContainer<<local>/Functions_251>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Unfold_91 : R|<local>/Unfold_91I| {
+                public abstract var scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+                    public set(value: R|<local>/Scope0|): R|kotlin/Unit|
+
+                public abstract var scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+                    public set(value: R|<local>/Scope1|): R|kotlin/Unit|
+
+                public constructor(): R|<local>/Unfold_91|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/unfold|<R|<local>/Declaration_48|, R|Function|>(<L> = unfold@fun R|org/jetbrains/kotlinx/dataframe/api/CreateDataFrameDsl<Function>|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+                this@R|special/anonymous|.R|SubstitutionOverride<org/jetbrains/kotlinx/dataframe/api/CreateDataFrameDsl.properties: R|kotlin/Unit|>|(Int(0))
+                (this@R|special/anonymous|, String(nameLength)).R|SubstitutionOverride<org/jetbrains/kotlinx/dataframe/api/CreateDataFrameDsl.from: R|kotlin/Unit|>|<R|kotlin/Int|>(from@fun <anonymous>(it: R|Function|): R|kotlin/Int| <inline=NoInline>  {
+                    ^ R|<local>/it|.R|/Function.name|.R|kotlin/String.length|
+                }
+                )
+            }
+            )
+        }
+        )
+        lval c: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>| = (this@R|/box|, (this@R|/box|, R|<local>/df1|).R|<local>/Scope0.functions|).R|<local>/Scope1.name|
+        lval d: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>| = (this@R|/box|, (this@R|/box|, R|<local>/df1|).R|<local>/Scope0.functions|).R|<local>/Scope1.nameLength|
+        ^box String(OK)
+    }

--- a/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.kt
+++ b/plugins/kotlin-dataframe/testData/box/unfold_replace_dsl.kt
@@ -1,0 +1,23 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.api.*
+
+data class Function(val name: String)
+
+data class Declaration(val name: String, val functions: Function)
+
+fun box(): String {
+    val df = listOf(Declaration("DataFrameImpl", Function("rowsCount")))
+        .toDataFrame()
+
+    val a: String = df.name[0]
+    val b: Function = df.functions[0]
+
+    val df1 = df.replace { functions }.unfold {
+        properties(maxDepth = 0)
+        "nameLength" from { it.name.length }
+    }
+    val c: DataColumn<String> = df1.functions.name
+    val d: DataColumn<Int> = df1.functions.nameLength
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -322,6 +322,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("unfold_replace_dsl.kt")
+  public void testUnfold_replace_dsl() {
+    runTest("testData/box/unfold_replace_dsl.kt");
+  }
+
+  @Test
   @TestMetadata("ungroup.kt")
   public void testUngroup() {
     runTest("testData/box/ungroup.kt");


### PR DESCRIPTION
It covers two interesting use cases:
1. Replace column with multiple, potentially nested. Provides DSL similar to `add` for that 
2. More fine-grained toDataFrame. Instead of converting 20-30 properties to 2-3 level of nesting all at once user can choose to convert toDataFrame(maxDepth = 0) and unfold required properties to whatever level they need 

On the compiler plugin side i will continue to support other overloads later in different PR 