### PR TITLE
Enable parallel forks for tests

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -364,6 +364,7 @@ tasks.withType<KotlinCompile> {
 
 tasks.test {
     maxHeapSize = "2048m"
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
         excludes.set(
             listOf(
@@ -372,6 +373,10 @@ tasks.test {
             )
         )
     }
+}
+
+tasks.getByName<Test>("samplesTest") {
+    maxParallelForks = 1
 }
 
 tasks.processJupyterApiResources {

--- a/plugins/dataframe-gradle-plugin/build.gradle.kts
+++ b/plugins/dataframe-gradle-plugin/build.gradle.kts
@@ -123,6 +123,7 @@ val integrationTestTask = task<Test>("integrationTest") {
     dependsOn(":core:publishCorePublicationToMavenLocal")
     description = "Runs integration tests."
     group = "verification"
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 
     testClassesDirs = sourceSets["integrationTest"].output.classesDirs
     classpath = sourceSets["integrationTest"].runtimeClasspath


### PR DESCRIPTION
Let's see how it affects build server performance. I tried to benchmark locally, but execution time is just way too unstable to tell if it actually helps or not 
Configured according to https://docs.gradle.org/current/userguide/performance.html#execute_tests_in_parallel