### PR TITLE
Update to Kotlin 2.0

### DIFF
--- a/generator/gradle.properties
+++ b/generator/gradle.properties
@@ -1,4 +1,4 @@
-kotlinCompilerVersion=1.9.22
+kotlinCompilerVersion=2.0.0
 
 # 1.15.0+ breaks with NoSuchMethodException: 'java.io.File com.squareup.kotlinpoet.FileSpec.writeTo(java.io.File)'
 kotlinPoetVersion=1.14.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-ksp = "1.9.23-1.0.20"
+ksp = "2.0.0-1.0.23"
 kotlinJupyter = "0.12.0-139"
 
 ktlint = "12.1.1"
 
 # make sure to sync manually with :generator module
-kotlin = "1.9.22"
+kotlin = "2.0.0"
 kotlinpoet = "1.16.0"
 dokka = "1.9.10"
 
@@ -13,7 +13,7 @@ libsPublisher = "1.8.10-dev-43"
 
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
-dataframe = "0.13.1"
+dataframe = "0.14.0-dev"
 
 # TODO 0.1.6 breaks kotlinter (which is no longer in use), https://github.com/Kotlin/dataframe/issues/598
 korro = "0.1.5"
@@ -55,7 +55,7 @@ plugin-publish = "1.2.1"
 shadow = "8.1.1"
 android-gradle-api = "7.3.1" # Can't be updated to 7.4.0+ due to Java 8 compatibility
 ktor-server-netty = "2.3.8"
-kotlin-compile-testing = "1.5.0"
+kotlin-compile-testing = "1.6.0"
 duckdb = "0.10.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ libsPublisher = "1.8.10-dev-43"
 
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
-dataframe = "0.14.0-dev"
+dataframe = "0.13.1"
 
 # TODO 0.1.6 breaks kotlinter (which is no longer in use), https://github.com/Kotlin/dataframe/issues/598
 korro = "0.1.5"

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/runner/KotlinCompilationUtil.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/runner/KotlinCompilationUtil.kt
@@ -1,7 +1,10 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
 package org.jetbrains.dataframe.ksp.runner
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.JvmTarget
 import java.io.File
 import java.io.OutputStream
@@ -22,7 +25,7 @@ internal object KotlinCompilationUtil {
         compilation.sources = sources
         // workaround for https://github.com/tschuchortdev/kotlin-compile-testing/issues/105
         compilation.kotlincArguments += "-Xjava-source-roots=${javaSrcRoot.absolutePath}"
-        compilation.jvmDefault = "enable"
+        compilation.jvmDefault = "all"
         compilation.jvmTarget = JvmTarget.JVM_1_8.description
         compilation.inheritClassPath = false
         compilation.verbose = false

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/runner/KspCompilationTestRunner.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/runner/KspCompilationTestRunner.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
 package org.jetbrains.dataframe.ksp.runner
 
 import com.tschuchort.compiletesting.KotlinCompilation
@@ -6,6 +8,7 @@ import com.tschuchort.compiletesting.kspArgs
 import com.tschuchort.compiletesting.kspSourcesDir
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import org.jetbrains.dataframe.ksp.DataFrameSymbolProcessorProvider
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Paths


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/649
Fixes https://github.com/Kotlin/dataframe/issues/770

~Hmm... Looks like https://github.com/tschuchortdev/kotlin-compile-testing is not 2.0 compatabile yet. It causes our symbol-processor tests to fail.~
