### PR TITLE
Disable the `OpenAPIV3Parser` logs

### DIFF
--- a/dataframe-openapi/src/main/resources/logback.xml
+++ b/dataframe-openapi/src/main/resources/logback.xml
@@ -1,0 +1,5 @@
+<configuration>
+    <root level="DEBUG"/>
+    <logger name="i.swagger.v3.parser.OpenAPIV3Parser" level="ERROR"/>
+    <logger name="io.swagger.v3.parser.OpenAPIV3Parser" level="ERROR"/>
+</configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ postgresql = "42.7.2"
 sqlite = "3.45.1.0"
 jtsCore = "1.18.1"
 kotlinDatetime = "0.6.0"
-openapi = "2.1.20"
+openapi = "2.1.22"
 kotlinLogging = "6.0.3"
 sl4j = "2.0.12"
 


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/785

Needs some more testing to see if this actually disables it and keeps other logs alive