### PR TITLE
Added test suite for PostgreSQL local tests with covering case with URLs

### DIFF
--- a/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/local/postgresConnectionUrlTest.kt
+++ b/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/local/postgresConnectionUrlTest.kt
@@ -1,0 +1,108 @@
+package org.jetbrains.kotlinx.dataframe.io.local
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.filter
+import org.jetbrains.kotlinx.dataframe.io.DbConnectionConfig
+import org.jetbrains.kotlinx.dataframe.io.readDataFrame
+import org.jetbrains.kotlinx.dataframe.io.readSqlTable
+import org.junit.Ignore
+import org.junit.Test
+import java.sql.DriverManager
+
+private const val URL_WITH_LOGIN_PASSWORD = "jdbc:postgresql://localhost:5432/test?" +
+    "user=postgres&password=pass&connectTimeout=10&tcpKeepAlive=true"
+
+private const val URL_NO_LOGIN_PASSWORD = "jdbc:postgresql://localhost:5432/test?connectTimeout=10&tcpKeepAlive=true"
+
+private const val URL_WITH_PASSWORD =
+    "jdbc:postgresql://localhost:5432/test?password=pass&connectTimeout=10&tcpKeepAlive=true"
+
+private const val URL_WITH_LOGIN =
+    "jdbc:postgresql://localhost:5432/test?user=postgres&connectTimeout=10&tcpKeepAlive=true"
+
+private const val TABLE_NAME = "table1"
+
+@Ignore
+class PostgresConnectionUrlTest {
+    @Test
+    fun `read from table with login and password in connection URL`() {
+        DriverManager.getConnection(URL_WITH_LOGIN_PASSWORD).use { connection ->
+            createTestData(connection)
+
+            val df1 = DataFrame.readSqlTable(connection, TABLE_NAME).cast<Table1>()
+            val result1 = df1.filter { it[Table1::id] == 1 }
+
+            result1[0][2] shouldBe 11
+
+            val df2 = connection.readDataFrame(TABLE_NAME).cast<Table1>()
+            val result2 = df2.filter { it[Table1::id] == 1 }
+
+            result2[0][2] shouldBe 11
+
+            clearTestData(connection)
+        }
+    }
+
+    @Test
+    fun `read from table with login and password in connection URL for DBConfig`() {
+        DriverManager.getConnection(URL_WITH_LOGIN_PASSWORD).use { connection ->
+            createTestData(connection)
+
+            val dbConfig = DbConnectionConfig(URL_WITH_LOGIN_PASSWORD)
+            val df1 = DataFrame.readSqlTable(dbConfig = dbConfig, TABLE_NAME).cast<Table1>()
+            val result1 = df1.filter { it[Table1::id] == 1 }
+
+            result1[0][2] shouldBe 11
+
+            val df2 = dbConfig.readDataFrame(TABLE_NAME).cast<Table1>()
+            val result2 = df2.filter { it[Table1::id] == 1 }
+
+            result2[0][2] shouldBe 11
+
+            clearTestData(connection)
+        }
+    }
+
+    @Test
+    fun `read from table without login and password`() {
+        val dbConfig = DbConnectionConfig(URL_NO_LOGIN_PASSWORD)
+
+        shouldThrow<org.postgresql.util.PSQLException> {
+            testReadFromTable(dbConfig)
+        }
+    }
+
+    @Test
+    fun `read from table with password only`() {
+        val dbConfig = DbConnectionConfig(URL_WITH_PASSWORD)
+
+        shouldThrow<org.postgresql.util.PSQLException> {
+            testReadFromTable(dbConfig)
+        }
+    }
+
+    @Test
+    fun `read from table with login only`() {
+        val dbConfig = DbConnectionConfig(URL_WITH_LOGIN)
+
+        shouldThrow<org.postgresql.util.PSQLException> {
+            testReadFromTable(dbConfig)
+        }
+    }
+
+    private fun testReadFromTable(dbConfig: DbConnectionConfig) {
+        DriverManager.getConnection(URL_WITH_LOGIN_PASSWORD).use { connection ->
+            createTestData(connection)
+
+            val df2 = dbConfig.readDataFrame(TABLE_NAME).cast<Table1>()
+            val result2 = df2.filter { it[Table1::id] == 1 }
+
+            result2[0][2] shouldBe 11
+
+            clearTestData(connection)
+        }
+    }
+}

--- a/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/local/postgresTest.kt
+++ b/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/local/postgresTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.io.getSchemaForSqlQuery
 import org.jetbrains.kotlinx.dataframe.io.getSchemaForSqlTable
+import org.jetbrains.kotlinx.dataframe.io.local.PostgresTest.Companion.connection
 import org.jetbrains.kotlinx.dataframe.io.readAllSqlTables
 import org.jetbrains.kotlinx.dataframe.io.readSqlQuery
 import org.jetbrains.kotlinx.dataframe.io.readSqlTable
@@ -17,15 +18,27 @@ import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
+import org.postgresql.geometric.PGbox
+import org.postgresql.geometric.PGcircle
+import org.postgresql.geometric.PGline
+import org.postgresql.geometric.PGlseg
+import org.postgresql.geometric.PGpath
+import org.postgresql.geometric.PGpoint
+import org.postgresql.geometric.PGpolygon
+import org.postgresql.util.PGInterval
 import org.postgresql.util.PGobject
 import java.math.BigDecimal
 import java.sql.Connection
+import java.sql.Date
 import java.sql.DriverManager
 import java.sql.SQLException
+import java.sql.Time
+import java.sql.Timestamp
+import java.sql.Types
 import java.util.UUID
 import kotlin.reflect.typeOf
 
-private const val URL = "jdbc:postgresql://localhost:5432/test"
+private const val BASIC_URL = "jdbc:postgresql://localhost:5432/test"
 private const val USER_NAME = "postgres"
 private const val PASSWORD = "pass"
 
@@ -82,6 +95,153 @@ interface ViewTable {
     val textCol: String?
 }
 
+internal fun createTestData(connection: Connection) {
+    connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table1") }
+    connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table2") }
+
+    @Language("SQL")
+    val createTableStatement = """
+        CREATE TABLE IF NOT EXISTS table1 (
+        id serial PRIMARY KEY,
+        bigintCol bigint not null,
+        smallintCol smallint not null,
+        bigserialCol bigserial not null,
+        booleanCol boolean not null,
+        boxCol box not null,
+        byteaCol bytea not null,
+        characterCol character not null,
+        characterNCol character(10) not null,
+        charCol char not null,
+        circleCol circle not null,
+        dateCol date not null,
+        doubleCol double precision not null,
+        integerCol integer,
+        intervalCol interval not null,
+        jsonCol json not null,
+        jsonbCol jsonb not null
+        )
+        """
+    connection.createStatement().execute(createTableStatement.trimIndent())
+
+    @Language("SQL")
+    val createTableQuery = """
+        CREATE TABLE IF NOT EXISTS table2 (
+        id serial PRIMARY KEY,
+        lineCol line not null,
+        lsegCol lseg not null,
+        macaddrCol macaddr not null,
+        moneyCol money not null,
+        numericCol numeric not null,
+        pathCol path not null,
+        pointCol point not null,
+        polygonCol polygon not null,
+        realCol real not null,
+        smallintCol smallint not null,
+        smallserialCol smallserial not null,
+        serialCol serial not null,
+        textCol text,
+        timeCol time not null,
+        timeWithZoneCol time with time zone not null,
+        timestampCol timestamp not null,
+        timestampWithZoneCol timestamp with time zone not null,
+        uuidCol uuid not null,
+        xmlCol xml not null
+        )
+        """
+    connection.createStatement().execute(createTableQuery.trimIndent())
+
+    @Language("SQL")
+    val insertData1 = """
+        INSERT INTO table1 (
+            bigintCol, smallintCol, bigserialCol,  booleanCol, 
+            boxCol, byteaCol, characterCol, characterNCol, charCol, 
+            circleCol, dateCol, doubleCol, 
+            integerCol, intervalCol, jsonCol, jsonbCol
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+
+    @Language("SQL")
+    val insertData2 = """
+        INSERT INTO table2 (
+            lineCol, lsegCol, macaddrCol, moneyCol, numericCol, 
+            pathCol, pointCol, polygonCol, realCol, smallintCol, 
+            smallserialCol, serialCol, textCol, timeCol, 
+            timeWithZoneCol, timestampCol, timestampWithZoneCol, 
+            uuidCol, xmlCol
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+
+    connection.prepareStatement(insertData1).use { st ->
+        // Insert data into table1
+        for (i in 1..3) {
+            st.setLong(1, i * 1000L)
+            st.setShort(2, 11.toShort())
+            st.setLong(3, 1000000000L + i)
+            st.setBoolean(4, i % 2 == 1)
+            st.setObject(5, PGbox("(1,1),(2,2)"))
+            st.setBytes(6, byteArrayOf(1, 2, 3))
+            st.setString(7, "A")
+            st.setString(8, "Hello")
+            st.setString(9, "A")
+            st.setObject(10, PGcircle("<(1,2),3>"))
+            st.setDate(11, Date.valueOf("2023-08-01"))
+            st.setDouble(12, 12.34)
+            st.setInt(13, 12345 * i)
+            st.setObject(14, PGInterval("1 year"))
+
+            val jsonbObject = PGobject()
+            jsonbObject.type = "jsonb"
+            jsonbObject.value = "{\"key\": \"value\"}"
+
+            st.setObject(15, jsonbObject)
+            st.setObject(16, jsonbObject)
+            st.executeUpdate()
+        }
+    }
+
+    connection.prepareStatement(insertData2).use { st ->
+        // Insert data into table2
+        for (i in 1..3) {
+            st.setObject(1, PGline("{1,2,3}"))
+            st.setObject(2, PGlseg("[(-1,0),(1,0)]"))
+
+            val macaddrObject = PGobject()
+            macaddrObject.type = "macaddr"
+            macaddrObject.value = "00:00:00:00:00:0$i"
+
+            st.setObject(3, macaddrObject)
+            st.setBigDecimal(4, BigDecimal("123.45"))
+            st.setBigDecimal(5, BigDecimal("12.34"))
+            st.setObject(6, PGpath("((1,2),(3,$i))"))
+            st.setObject(7, PGpoint("(1,2)"))
+            st.setObject(8, PGpolygon("((1,1),(2,2),(3,3))"))
+            st.setFloat(9, 12.34f)
+            st.setShort(10, (i * 100).toShort())
+            st.setInt(11, 1000 + i)
+            st.setInt(12, 1000000 + i)
+            st.setString(13, null)
+            st.setTime(14, Time.valueOf("12:34:56"))
+
+            st.setTimestamp(15, Timestamp(System.currentTimeMillis()))
+            st.setTimestamp(16, Timestamp(System.currentTimeMillis()))
+            st.setTimestamp(17, Timestamp(System.currentTimeMillis()))
+
+            st.setObject(18, UUID.randomUUID(), Types.OTHER)
+            val xmlObject = PGobject()
+            xmlObject.type = "xml"
+            xmlObject.value = "<root><element>data</element></root>"
+
+            st.setObject(19, xmlObject)
+            st.executeUpdate()
+        }
+    }
+}
+
+internal fun clearTestData(connection: Connection) {
+    connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table1") }
+    connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table2") }
+}
+
 @Ignore
 class PostgresTest {
     companion object {
@@ -90,155 +250,15 @@ class PostgresTest {
         @BeforeClass
         @JvmStatic
         fun setUpClass() {
-            connection = DriverManager.getConnection(URL, USER_NAME, PASSWORD)
-
-            connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table1") }
-            connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table2") }
-
-            @Language("SQL")
-            val createTableStatement = """
-                CREATE TABLE IF NOT EXISTS table1 (
-                id serial PRIMARY KEY,
-                bigintCol bigint not null,
-                smallintCol smallint not null,
-                bigserialCol bigserial not null,
-                booleanCol boolean not null,
-                boxCol box not null,
-                byteaCol bytea not null,
-                characterCol character not null,
-                characterNCol character(10) not null,
-                charCol char not null,
-                circleCol circle not null,
-                dateCol date not null,
-                doubleCol double precision not null,
-                integerCol integer,
-                intervalCol interval not null,
-                jsonCol json not null,
-                jsonbCol jsonb not null
-            )
-            """
-            connection.createStatement().execute(createTableStatement.trimIndent())
-
-            @Language("SQL")
-            val createTableQuery = """
-                CREATE TABLE IF NOT EXISTS table2 (
-                id serial PRIMARY KEY,
-                lineCol line not null,
-                lsegCol lseg not null,
-                macaddrCol macaddr not null,
-                moneyCol money not null,
-                numericCol numeric not null,
-                pathCol path not null,
-                pointCol point not null,
-                polygonCol polygon not null,
-                realCol real not null,
-                smallintCol smallint not null,
-                smallserialCol smallserial not null,
-                serialCol serial not null,
-                textCol text,
-                timeCol time not null,
-                timeWithZoneCol time with time zone not null,
-                timestampCol timestamp not null,
-                timestampWithZoneCol timestamp with time zone not null,
-                uuidCol uuid not null,
-                xmlCol xml not null
-            )
-            """
-            connection.createStatement().execute(createTableQuery.trimIndent())
-
-            @Language("SQL")
-            val insertData1 = """
-            INSERT INTO table1 (
-                bigintCol, smallintCol, bigserialCol,  booleanCol, 
-                boxCol, byteaCol, characterCol, characterNCol, charCol, 
-                 circleCol, dateCol, doubleCol, 
-                integerCol, intervalCol, jsonCol, jsonbCol
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """
-
-            @Language("SQL")
-            val insertData2 = """
-            INSERT INTO table2 (
-                lineCol, lsegCol, macaddrCol, moneyCol, numericCol, 
-                pathCol, pointCol, polygonCol, realCol, smallintCol, 
-                smallserialCol, serialCol, textCol, timeCol, 
-                timeWithZoneCol, timestampCol, timestampWithZoneCol, 
-                uuidCol, xmlCol
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """
-
-            connection.prepareStatement(insertData1).use { st ->
-                // Insert data into table1
-                for (i in 1..3) {
-                    st.setLong(1, i * 1000L)
-                    st.setShort(2, 11.toShort())
-                    st.setLong(3, 1000000000L + i)
-                    st.setBoolean(4, i % 2 == 1)
-                    st.setObject(5, org.postgresql.geometric.PGbox("(1,1),(2,2)"))
-                    st.setBytes(6, byteArrayOf(1, 2, 3))
-                    st.setString(7, "A")
-                    st.setString(8, "Hello")
-                    st.setString(9, "A")
-                    st.setObject(10, org.postgresql.geometric.PGcircle("<(1,2),3>"))
-                    st.setDate(11, java.sql.Date.valueOf("2023-08-01"))
-                    st.setDouble(12, 12.34)
-                    st.setInt(13, 12345 * i)
-                    st.setObject(14, org.postgresql.util.PGInterval("1 year"))
-
-                    val jsonbObject = PGobject()
-                    jsonbObject.type = "jsonb"
-                    jsonbObject.value = "{\"key\": \"value\"}"
-
-                    st.setObject(15, jsonbObject)
-                    st.setObject(16, jsonbObject)
-                    st.executeUpdate()
-                }
-            }
-
-            connection.prepareStatement(insertData2).use { st ->
-                // Insert data into table2
-                for (i in 1..3) {
-                    st.setObject(1, org.postgresql.geometric.PGline("{1,2,3}"))
-                    st.setObject(2, org.postgresql.geometric.PGlseg("[(-1,0),(1,0)]"))
-
-                    val macaddrObject = PGobject()
-                    macaddrObject.type = "macaddr"
-                    macaddrObject.value = "00:00:00:00:00:0$i"
-
-                    st.setObject(3, macaddrObject)
-                    st.setBigDecimal(4, BigDecimal("123.45"))
-                    st.setBigDecimal(5, BigDecimal("12.34"))
-                    st.setObject(6, org.postgresql.geometric.PGpath("((1,2),(3,$i))"))
-                    st.setObject(7, org.postgresql.geometric.PGpoint("(1,2)"))
-                    st.setObject(8, org.postgresql.geometric.PGpolygon("((1,1),(2,2),(3,3))"))
-                    st.setFloat(9, 12.34f)
-                    st.setShort(10, (i * 100).toShort())
-                    st.setInt(11, 1000 + i)
-                    st.setInt(12, 1000000 + i)
-                    st.setString(13, null)
-                    st.setTime(14, java.sql.Time.valueOf("12:34:56"))
-
-                    st.setTimestamp(15, java.sql.Timestamp(System.currentTimeMillis()))
-                    st.setTimestamp(16, java.sql.Timestamp(System.currentTimeMillis()))
-                    st.setTimestamp(17, java.sql.Timestamp(System.currentTimeMillis()))
-
-                    st.setObject(18, UUID.randomUUID(), java.sql.Types.OTHER)
-                    val xmlObject = PGobject()
-                    xmlObject.type = "xml"
-                    xmlObject.value = "<root><element>data</element></root>"
-
-                    st.setObject(19, xmlObject)
-                    st.executeUpdate()
-                }
-            }
+            connection = DriverManager.getConnection(BASIC_URL, USER_NAME, PASSWORD)
+            createTestData(connection)
         }
 
         @AfterClass
         @JvmStatic
         fun tearDownClass() {
             try {
-                connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table1") }
-                connection.createStatement().use { st -> st.execute("DROP TABLE IF EXISTS table2") }
+                clearTestData(connection)
                 connection.close()
             } catch (e: SQLException) {
                 e.printStackTrace()


### PR DESCRIPTION
Refactored `PostgresTest` for modular, reusable test data setup and introduced `PostgresConnectionUrlTest` to validate different PostgreSQL connection URLs. These changes improve test readability and ensure comprehensive URL configurations handling.

Fixes #497 

@koperagen could you please take a look at the ticket #497 probably you faced with the case, when it was failed
I've combined URLs with login/password and with other GET parameters