### PR TITLE
[Compiler plugin ] Support ColumnName annotation in extension properties codegen 

### DIFF
--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataFramePlugin.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataFramePlugin.kt
@@ -2,4 +2,4 @@ package org.jetbrains.kotlinx.dataframe.plugin.extensions
 
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 
-object DataFramePlugin : GeneratedDeclarationKey()
+class DataFramePlugin(val columnName: String?) : GeneratedDeclarationKey()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/IrBodyFiller.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/IrBodyFiller.kt
@@ -132,16 +132,6 @@ private class DataFrameFileLowering(val context: IrPluginContext) : FileLowering
         irFile.transformChildren(this, null)
     }
 
-    override fun visitClass(declaration: IrClass): IrStatement {
-        val origin = declaration.origin
-        return if (origin is IrDeclarationOrigin.GeneratedByPlugin && origin.pluginKey is DataFramePlugin) {
-            declaration.transformChildren(this, null)
-            declaration
-        } else {
-            super.visitClass(declaration)
-        }
-    }
-
     override fun visitConstructor(declaration: IrConstructor): IrStatement {
         val origin = declaration.origin
         if (!(origin is IrDeclarationOrigin.GeneratedByPlugin && origin.pluginKey is TokenGenerator.Key)) return declaration

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/TokenGenerator.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/TokenGenerator.kt
@@ -140,6 +140,6 @@ class TokenGenerator(session: FirSession) : FirDeclarationGenerationExtension(se
     }
 
     override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
-        return listOf(createConstructor(context.owner, DataFramePlugin, isPrimary = true).symbol)
+        return listOf(createConstructor(context.owner, Key, isPrimary = true).symbol)
     }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlinx.dataframe.plugin.utils
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlinx.dataframe.annotations.ColumnName
 import org.jetbrains.kotlinx.dataframe.annotations.Order
 import org.jetbrains.kotlinx.dataframe.annotations.ScopeProperty
 import kotlin.reflect.KClass
@@ -37,6 +38,8 @@ object Names {
     val ORDER_ANNOTATION = ClassId(annotationsPackage, Name.identifier(Order::class.simpleName!!))
     val ORDER_ARGUMENT = Name.identifier(Order::order.name)
     val SCOPE_PROPERTY_ANNOTATION = ClassId(annotationsPackage, Name.identifier(ScopeProperty::class.simpleName!!))
+    val COLUMN_NAME_ANNOTATION = ClassId(annotationsPackage, Name.identifier(ColumnName::class.simpleName!!))
+    val COLUMN_NAME_ARGUMENT = Name.identifier(ColumnName::name.name)
 
     val DATA_SCHEMA_CLASS_ID = ClassId(annotationsPackage, Name.identifier("DataSchema"))
     val LIST = ClassId(FqName("kotlin.collections"), Name.identifier("List"))

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/firFactories.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/firFactories.kt
@@ -29,6 +29,7 @@ internal fun FirDeclarationGenerationExtension.generateExtensionProperty(
     receiverType: ConeClassLikeTypeImpl,
     propertyName: Name,
     returnTypeRef: FirResolvedTypeRef,
+    columnName: String? = null,
     symbol: FirClassSymbol<*>? = null,
     effectiveVisibility: EffectiveVisibility = EffectiveVisibility.Public
 ): FirProperty {
@@ -36,7 +37,7 @@ internal fun FirDeclarationGenerationExtension.generateExtensionProperty(
     return buildProperty {
         moduleData = session.moduleData
         resolvePhase = FirResolvePhase.BODY_RESOLVE
-        origin = FirDeclarationOrigin.Plugin(DataFramePlugin)
+        origin = FirDeclarationOrigin.Plugin(DataFramePlugin(columnName))
         status = FirResolvedDeclarationStatusImpl(
                 Visibilities.Public,
                 Modality.FINAL,
@@ -66,7 +67,7 @@ internal fun FirDeclarationGenerationExtension.generateExtensionProperty(
         getter = buildPropertyAccessor {
             moduleData = session.moduleData
             resolvePhase = FirResolvePhase.BODY_RESOLVE
-            origin = FirDeclarationOrigin.Plugin(DataFramePlugin)
+            origin = FirDeclarationOrigin.Plugin(DataFramePlugin(columnName))
             this.returnTypeRef = returnTypeRef
             dispatchReceiverType = receiverType
             this.symbol = firPropertyAccessorSymbol

--- a/plugins/kotlin-dataframe/testData/box/columnName.kt
+++ b/plugins/kotlin-dataframe/testData/box/columnName.kt
@@ -1,0 +1,16 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class Record(
+    @ColumnName("a")
+    val abc: String,
+)
+
+fun box(): String {
+    val df = dataFrameOf("a")(1).cast<Record>()
+    df.abc
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -35,6 +35,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("columnName.kt")
+  public void testColumnName() {
+    runTest("testData/box/columnName.kt");
+  }
+
+  @Test
   @TestMetadata("columnWithStarProjection.kt")
   public void testColumnWithStarProjection() {
     runTest("testData/box/columnWithStarProjection.kt");


### PR DESCRIPTION
Before this PR this code would fail with "abc is not found in dataframe" at runtime. After, behavior will be aligned with KSP
```
@DataSchema
data class Record(
    @ColumnName("a")
    val abc: String,
)

fun box(): String {
    val df = dataFrameOf("a")(1).cast<Record>()
    df.abc
    return "OK"
}
```