### PR TITLE
Support for the serialization of DataframeConvertible values in ValueColumns has been added to enhance visualization in the KTNB plugin.

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
@@ -1,6 +1,14 @@
 package org.jetbrains.kotlinx.dataframe.columns
 
-public enum class CellKind {
+/**
+ *	Represents special kinds of elements that can be found within a Column.
+ *	This is similar to the [ColumnKind], but it applies to specific elements of the Column.
+ *	Its main use is to provide metadata during serialization for visualization within the KTNB plugin.
+ */
+internal enum class CellKind {
+    /**
+     * Represents a cell kind within a Column that is specifically convertible to a DataFrame.
+     */
     DataFrameConvertable {
         override fun toString(): String = "DataFrameConvertable"
     },

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.kotlinx.dataframe.columns
+
+public enum class CellKind {
+    DataFrameConvertable {
+        override fun toString(): String = "DataFrameConvertable"
+    },
+}

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/writeJson.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/writeJson.kt
@@ -166,11 +166,11 @@ internal fun encodeRowWithMetadata(
     return JsonObject(values.toMap())
 }
 
-internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEncoder> = emptyList()): JsonElement =
-    when {
-        customEncoders.any { it.canEncode(col[index]) } -> {
-            customEncoders.first { it.canEncode(col[index]) }.encode(col[index])
-        }
+internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEncoder> = emptyList()): JsonElement {
+    val matchingEncoder = customEncoders.firstOrNull { it.canEncode(col[index]) }
+
+    return when {
+        matchingEncoder != null -> matchingEncoder.encode(col[index])
 
         col.isList() -> col[index]?.let { list ->
             val values = (list as List<*>).map { convert(it) }
@@ -181,6 +181,7 @@ internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEnc
 
         else -> JsonPrimitive(col[index]?.toString())
     }
+}
 
 internal class DataframeConvertableEncoder(
     private val encoders: List<CustomEncoder>,

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -303,7 +303,7 @@ public fun AnyFrame.toJsonWithMetadata(
     rowLimit: Int,
     nestedRowLimit: Int? = null,
     prettyPrint: Boolean = false,
-    imageEncodingOptions: Base64ImageEncodingOptions? = null,
+    encodingOptions: List<EncodingOptions> = emptyList(),
 ): String {
     val json = Json {
         this.prettyPrint = prettyPrint
@@ -312,11 +312,18 @@ public fun AnyFrame.toJsonWithMetadata(
     }
     return json.encodeToString(
         JsonElement.serializer(),
-        encodeDataFrameWithMetadata(this@toJsonWithMetadata, rowLimit, nestedRowLimit, imageEncodingOptions),
+        encodeDataFrameWithMetadata(this@toJsonWithMetadata, rowLimit, nestedRowLimit, encodingOptions),
     )
 }
 
 internal const val DEFAULT_IMG_SIZE = 600
+
+/**
+ * Interface representing encoding options that can be applied when converting a data structure to JSON format.
+ * Implementations of this interface can provide specific behaviors for encoding various data types,
+ * such as images or data frames, when serializing to JSON.
+ */
+public interface EncodingOptions
 
 /**
  * Class representing the options for encoding images.
@@ -327,7 +334,7 @@ internal const val DEFAULT_IMG_SIZE = 600
 public class Base64ImageEncodingOptions(
     public val imageSizeLimit: Int = DEFAULT_IMG_SIZE,
     private val options: Int = GZIP_ON or LIMIT_SIZE_ON,
-) {
+) : EncodingOptions {
     public val isGzipOn: Boolean
         get() = options and GZIP_ON == GZIP_ON
 
@@ -340,6 +347,14 @@ public class Base64ImageEncodingOptions(
         public const val LIMIT_SIZE_ON: Int = 2 // 2^1
     }
 }
+
+/**
+ * Represents encoding options for converting to JSON objects that can be convertible to DataFrame
+ *
+ * @param rowsLimit Optional limit on the number of rows to be included in the JSON output.
+ * Default is null, meaning no limit is imposed.
+ */
+public class DataframeConvertableEncodingOptions(public val rowsLimit: Int? = null) : EncodingOptions
 
 public fun AnyRow.toJson(prettyPrint: Boolean = false): String {
     val json = Json {

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
@@ -6,16 +6,17 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.jetbrains.kotlinx.dataframe.api.take
+import org.jetbrains.kotlinx.dataframe.impl.io.BufferedImageEncoder
+import org.jetbrains.kotlinx.dataframe.impl.io.DataframeConvertableEncoder
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.COLUMNS
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.KOTLIN_DATAFRAME
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.NCOL
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.NROW
 import org.jetbrains.kotlinx.dataframe.impl.io.encodeFrame
 import org.jetbrains.kotlinx.dataframe.io.Base64ImageEncodingOptions
+import org.jetbrains.kotlinx.dataframe.io.CustomEncoder
 import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
-import org.jetbrains.kotlinx.dataframe.io.DataframeConvertableEncodingOptions
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
-import org.jetbrains.kotlinx.dataframe.io.EncodingOptions
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toJsonWithMetadata
 import org.jetbrains.kotlinx.dataframe.io.toStaticHtml
@@ -88,19 +89,19 @@ internal inline fun <reified T : Any> JupyterHtmlRenderer.render(
             }
 
             else -> {
-                val encodingOptions = buildList<EncodingOptions> {
+                val encoders = buildList<CustomEncoder> {
                     if (ideBuildNumber.supportsDataFrameConvertableValues()) {
-                        add(DataframeConvertableEncodingOptions())
+                        add(DataframeConvertableEncoder(this))
                     }
                     if (ideBuildNumber.supportsImageViewer()) {
-                        add(Base64ImageEncodingOptions())
+                        add(BufferedImageEncoder(Base64ImageEncodingOptions()))
                     }
                 }
 
                 df.toJsonWithMetadata(
                     rowLimit = limit,
                     nestedRowLimit = reifiedDisplayConfiguration.rowsLimit,
-                    encodingOptions = encodingOptions,
+                    customEncoders = encoders,
                 )
             }
         }

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
@@ -101,6 +101,36 @@ public object KotlinNotebookPluginUtils {
             }.toColumnSet()
         }
 
+    internal fun isDataframeConvertable(dataframeLike: Any?): Boolean =
+        when (dataframeLike) {
+            is Pivot<*>,
+            is ReducedGroupBy<*, *>,
+            is ReducedPivot<*>,
+            is PivotGroupBy<*>,
+            is ReducedPivotGroupBy<*>,
+            is SplitWithTransform<*, *, *>,
+            is Split<*, *>,
+            is Merge<*, *, *>,
+            is Gather<*, *, *, *>,
+            is Update<*, *>,
+            is Convert<*, *>,
+            is FormattedFrame<*>,
+            is AnyCol,
+            is AnyRow,
+            is GroupBy<*, *>,
+            is AnyFrame,
+            is DisableRowsLimitWrapper,
+            is MoveClause<*, *>,
+            is RenameClause<*, *>,
+            is ReplaceClause<*, *>,
+            is GroupClause<*, *>,
+            is InsertClause<*>,
+            is FormatClause<*, *>,
+            -> true
+
+            else -> false
+        }
+
     /**
      * Converts [dataframeLike] to [AnyFrame].
      * If [dataframeLike] is already [AnyFrame] then it is returned as is.

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.impl.io.BufferedImageEncoder
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.KOTLIN_DATAFRAME
 import org.jetbrains.kotlinx.dataframe.impl.io.resizeKeepingAspectRatio
 import org.jetbrains.kotlinx.dataframe.io.Base64ImageEncodingOptions.Companion.ALL_OFF
@@ -65,7 +66,7 @@ class ImageSerializationTests(private val encodingOptions: Base64ImageEncodingOp
         val jsonStr = df.toJsonWithMetadata(
             20,
             nestedRowLimit = 20,
-            encodingOptions = if (encodingOptions != null) listOf(encodingOptions) else emptyList(),
+            customEncoders = listOfNotNull(encodingOptions?.let { BufferedImageEncoder(encodingOptions) }),
         )
 
         return parseJsonStr(jsonStr)

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
@@ -62,7 +62,11 @@ class ImageSerializationTests(private val encodingOptions: Base64ImageEncodingOp
         encodingOptions: Base64ImageEncodingOptions?,
     ): JsonObject {
         val df = dataFrameOf(listOf("imgs"), images)
-        val jsonStr = df.toJsonWithMetadata(20, nestedRowLimit = 20, imageEncodingOptions = encodingOptions)
+        val jsonStr = df.toJsonWithMetadata(
+            20,
+            nestedRowLimit = 20,
+            encodingOptions = if (encodingOptions != null) listOf(encodingOptions) else emptyList(),
+        )
 
         return parseJsonStr(jsonStr)
     }

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/RenderingTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/RenderingTests.kt
@@ -235,7 +235,7 @@ class RenderingTests : JupyterReplTestCase() {
         val expectedOutput =
             """
             {
-              "${'$'}version": "2.1.0",
+              "${'$'}version": "2.1.1",
               "metadata": {
                 "columns": ["group", "col3", "col4"],
                 "types": [{

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
@@ -1,6 +1,14 @@
 package org.jetbrains.kotlinx.dataframe.columns
 
-public enum class CellKind {
+/**
+ *	Represents special kinds of elements that can be found within a Column.
+ *	This is similar to the [ColumnKind], but it applies to specific elements of the Column.
+ *	Its main use is to provide metadata during serialization for visualization within the KTNB plugin.
+ */
+internal enum class CellKind {
+    /**
+     * Represents a cell kind within a Column that is specifically convertible to a DataFrame.
+     */
     DataFrameConvertable {
         override fun toString(): String = "DataFrameConvertable"
     },

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/CellKind.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.kotlinx.dataframe.columns
+
+public enum class CellKind {
+    DataFrameConvertable {
+        override fun toString(): String = "DataFrameConvertable"
+    },
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/writeJson.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/writeJson.kt
@@ -166,11 +166,11 @@ internal fun encodeRowWithMetadata(
     return JsonObject(values.toMap())
 }
 
-internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEncoder> = emptyList()): JsonElement =
-    when {
-        customEncoders.any { it.canEncode(col[index]) } -> {
-            customEncoders.first { it.canEncode(col[index]) }.encode(col[index])
-        }
+internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEncoder> = emptyList()): JsonElement {
+    val matchingEncoder = customEncoders.firstOrNull { it.canEncode(col[index]) }
+
+    return when {
+        matchingEncoder != null -> matchingEncoder.encode(col[index])
 
         col.isList() -> col[index]?.let { list ->
             val values = (list as List<*>).map { convert(it) }
@@ -181,6 +181,7 @@ internal fun encodeValue(col: AnyCol, index: Int, customEncoders: List<CustomEnc
 
         else -> JsonPrimitive(col[index]?.toString())
     }
+}
 
 internal class DataframeConvertableEncoder(
     private val encoders: List<CustomEncoder>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -303,7 +303,7 @@ public fun AnyFrame.toJsonWithMetadata(
     rowLimit: Int,
     nestedRowLimit: Int? = null,
     prettyPrint: Boolean = false,
-    imageEncodingOptions: Base64ImageEncodingOptions? = null,
+    encodingOptions: List<EncodingOptions> = emptyList(),
 ): String {
     val json = Json {
         this.prettyPrint = prettyPrint
@@ -312,11 +312,18 @@ public fun AnyFrame.toJsonWithMetadata(
     }
     return json.encodeToString(
         JsonElement.serializer(),
-        encodeDataFrameWithMetadata(this@toJsonWithMetadata, rowLimit, nestedRowLimit, imageEncodingOptions),
+        encodeDataFrameWithMetadata(this@toJsonWithMetadata, rowLimit, nestedRowLimit, encodingOptions),
     )
 }
 
 internal const val DEFAULT_IMG_SIZE = 600
+
+/**
+ * Interface representing encoding options that can be applied when converting a data structure to JSON format.
+ * Implementations of this interface can provide specific behaviors for encoding various data types,
+ * such as images or data frames, when serializing to JSON.
+ */
+public interface EncodingOptions
 
 /**
  * Class representing the options for encoding images.
@@ -327,7 +334,7 @@ internal const val DEFAULT_IMG_SIZE = 600
 public class Base64ImageEncodingOptions(
     public val imageSizeLimit: Int = DEFAULT_IMG_SIZE,
     private val options: Int = GZIP_ON or LIMIT_SIZE_ON,
-) {
+) : EncodingOptions {
     public val isGzipOn: Boolean
         get() = options and GZIP_ON == GZIP_ON
 
@@ -340,6 +347,14 @@ public class Base64ImageEncodingOptions(
         public const val LIMIT_SIZE_ON: Int = 2 // 2^1
     }
 }
+
+/**
+ * Represents encoding options for converting to JSON objects that can be convertible to DataFrame
+ *
+ * @param rowsLimit Optional limit on the number of rows to be included in the JSON output.
+ * Default is null, meaning no limit is imposed.
+ */
+public class DataframeConvertableEncodingOptions(public val rowsLimit: Int? = null) : EncodingOptions
 
 public fun AnyRow.toJson(prettyPrint: Boolean = false): String {
     val json = Json {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterHtmlRenderer.kt
@@ -6,16 +6,17 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.jetbrains.kotlinx.dataframe.api.take
+import org.jetbrains.kotlinx.dataframe.impl.io.BufferedImageEncoder
+import org.jetbrains.kotlinx.dataframe.impl.io.DataframeConvertableEncoder
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.COLUMNS
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.KOTLIN_DATAFRAME
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.NCOL
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.NROW
 import org.jetbrains.kotlinx.dataframe.impl.io.encodeFrame
 import org.jetbrains.kotlinx.dataframe.io.Base64ImageEncodingOptions
+import org.jetbrains.kotlinx.dataframe.io.CustomEncoder
 import org.jetbrains.kotlinx.dataframe.io.DataFrameHtmlData
-import org.jetbrains.kotlinx.dataframe.io.DataframeConvertableEncodingOptions
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
-import org.jetbrains.kotlinx.dataframe.io.EncodingOptions
 import org.jetbrains.kotlinx.dataframe.io.toHTML
 import org.jetbrains.kotlinx.dataframe.io.toJsonWithMetadata
 import org.jetbrains.kotlinx.dataframe.io.toStaticHtml
@@ -88,19 +89,19 @@ internal inline fun <reified T : Any> JupyterHtmlRenderer.render(
             }
 
             else -> {
-                val encodingOptions = buildList<EncodingOptions> {
+                val encoders = buildList<CustomEncoder> {
                     if (ideBuildNumber.supportsDataFrameConvertableValues()) {
-                        add(DataframeConvertableEncodingOptions())
+                        add(DataframeConvertableEncoder(this))
                     }
                     if (ideBuildNumber.supportsImageViewer()) {
-                        add(Base64ImageEncodingOptions())
+                        add(BufferedImageEncoder(Base64ImageEncodingOptions()))
                     }
                 }
 
                 df.toJsonWithMetadata(
                     rowLimit = limit,
                     nestedRowLimit = reifiedDisplayConfiguration.rowsLimit,
-                    encodingOptions = encodingOptions,
+                    customEncoders = encoders,
                 )
             }
         }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
@@ -101,6 +101,36 @@ public object KotlinNotebookPluginUtils {
             }.toColumnSet()
         }
 
+    internal fun isDataframeConvertable(dataframeLike: Any?): Boolean =
+        when (dataframeLike) {
+            is Pivot<*>,
+            is ReducedGroupBy<*, *>,
+            is ReducedPivot<*>,
+            is PivotGroupBy<*>,
+            is ReducedPivotGroupBy<*>,
+            is SplitWithTransform<*, *, *>,
+            is Split<*, *>,
+            is Merge<*, *, *>,
+            is Gather<*, *, *, *>,
+            is Update<*, *>,
+            is Convert<*, *>,
+            is FormattedFrame<*>,
+            is AnyCol,
+            is AnyRow,
+            is GroupBy<*, *>,
+            is AnyFrame,
+            is DisableRowsLimitWrapper,
+            is MoveClause<*, *>,
+            is RenameClause<*, *>,
+            is ReplaceClause<*, *>,
+            is GroupClause<*, *>,
+            is InsertClause<*>,
+            is FormatClause<*, *>,
+            -> true
+
+            else -> false
+        }
+
     /**
      * Converts [dataframeLike] to [AnyFrame].
      * If [dataframeLike] is already [AnyFrame] then it is returned as is.

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.impl.io.BufferedImageEncoder
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.KOTLIN_DATAFRAME
 import org.jetbrains.kotlinx.dataframe.impl.io.resizeKeepingAspectRatio
 import org.jetbrains.kotlinx.dataframe.io.Base64ImageEncodingOptions.Companion.ALL_OFF
@@ -65,7 +66,7 @@ class ImageSerializationTests(private val encodingOptions: Base64ImageEncodingOp
         val jsonStr = df.toJsonWithMetadata(
             20,
             nestedRowLimit = 20,
-            encodingOptions = if (encodingOptions != null) listOf(encodingOptions) else emptyList(),
+            customEncoders = listOfNotNull(encodingOptions?.let { BufferedImageEncoder(encodingOptions) }),
         )
 
         return parseJsonStr(jsonStr)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ImageSerializationTests.kt
@@ -62,7 +62,11 @@ class ImageSerializationTests(private val encodingOptions: Base64ImageEncodingOp
         encodingOptions: Base64ImageEncodingOptions?,
     ): JsonObject {
         val df = dataFrameOf(listOf("imgs"), images)
-        val jsonStr = df.toJsonWithMetadata(20, nestedRowLimit = 20, imageEncodingOptions = encodingOptions)
+        val jsonStr = df.toJsonWithMetadata(
+            20,
+            nestedRowLimit = 20,
+            encodingOptions = if (encodingOptions != null) listOf(encodingOptions) else emptyList(),
+        )
 
         return parseJsonStr(jsonStr)
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/RenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/RenderingTests.kt
@@ -235,7 +235,7 @@ class RenderingTests : JupyterReplTestCase() {
         val expectedOutput =
             """
             {
-              "${'$'}version": "2.1.0",
+              "${'$'}version": "2.1.1",
               "metadata": {
                 "columns": ["group", "col3", "col4"],
                 "types": [{

--- a/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
+++ b/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
@@ -327,9 +327,9 @@ summary {
 </style>
 </head>
 <body>
-<table class="dataframe" id="df_1291845901"></table>
+<table class="dataframe" id="df_-1627389683"></table>
 
-<table class="dataframe" id="static_df_1291845902"><thead><tr><th class="bottomBorder" style="text-align:left">example</th></tr></thead><tbody><tr><td  style="vertical-align:top">123</td></tr></tbody></table>
+<table class="dataframe" id="static_df_-1627389682"><thead><tr><th class="bottomBorder" style="text-align:left">example</th></tr></thead><tbody><tr><td  style="vertical-align:top">123</td></tr></tbody></table>
 <p class="dataframe_description"></p>
 </body>
 <script>
@@ -609,11 +609,11 @@ summary {
 
 /*<!--*/
 call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: "<span title=\"example: Int\">example</span>", children: [], rightAlign: true, values: ["<span class=\"formatted\" title=\"\"><span class=\"numbers\">123</span></span>"] }, 
-], id: 1291845901, rootId: 1291845901, totalRows: 1 } ) });
+], id: -1627389683, rootId: -1627389683, totalRows: 1 } ) });
 /*-->*/
 
-call_DataFrame(function() { DataFrame.renderTable(1291845901) });
+call_DataFrame(function() { DataFrame.renderTable(-1627389683) });
 
-document.getElementById("static_df_1291845902").style.display = "none";
+document.getElementById("static_df_-1627389682").style.display = "none";
 </script>
 </html>

--- a/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
+++ b/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
@@ -327,9 +327,9 @@ summary {
 </style>
 </head>
 <body>
-<table class="dataframe" id="df_1962934541"></table>
+<table class="dataframe" id="df_1291845901"></table>
 
-<table class="dataframe" id="static_df_1962934542"><thead><tr><th class="bottomBorder" style="text-align:left">example</th></tr></thead><tbody><tr><td  style="vertical-align:top">123</td></tr></tbody></table>
+<table class="dataframe" id="static_df_1291845902"><thead><tr><th class="bottomBorder" style="text-align:left">example</th></tr></thead><tbody><tr><td  style="vertical-align:top">123</td></tr></tbody></table>
 <p class="dataframe_description"></p>
 </body>
 <script>
@@ -609,11 +609,11 @@ summary {
 
 /*<!--*/
 call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: "<span title=\"example: Int\">example</span>", children: [], rightAlign: true, values: ["<span class=\"formatted\" title=\"\"><span class=\"numbers\">123</span></span>"] }, 
-], id: 1962934541, rootId: 1962934541, totalRows: 1 } ) });
+], id: 1291845901, rootId: 1291845901, totalRows: 1 } ) });
 /*-->*/
 
-call_DataFrame(function() { DataFrame.renderTable(1962934541) });
+call_DataFrame(function() { DataFrame.renderTable(1291845901) });
 
-document.getElementById("static_df_1962934542").style.display = "none";
+document.getElementById("static_df_1291845902").style.display = "none";
 </script>
 </html>

--- a/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
+++ b/docs/StardustDocs/snippets/manual/extensionPropertiesApi1.html
@@ -1,0 +1,619 @@
+<html>
+<head>
+<style type="text/css">
+:root {
+    --background: #fff;
+    --background-odd: #f5f5f5;
+    --background-hover: #d9edfd;
+    --header-text-color: #474747;
+    --text-color: #848484;
+    --text-color-dark: #000;
+    --text-color-medium: #737373;
+    --text-color-pale: #b3b3b3;
+    --inner-border-color: #aaa;
+    --bold-border-color: #000;
+    --link-color: #296eaa;
+    --link-color-pale: #296eaa;
+    --link-hover: #1a466c;
+}
+
+:root[theme="dark"], :root [data-jp-theme-light="false"], .dataframe_dark{
+    --background: #303030;
+    --background-odd: #3c3c3c;
+    --background-hover: #464646;
+    --header-text-color: #dddddd;
+    --text-color: #b3b3b3;
+    --text-color-dark: #dddddd;
+    --text-color-medium: #b2b2b2;
+    --text-color-pale: #737373;
+    --inner-border-color: #707070;
+    --bold-border-color: #777777;
+    --link-color: #008dc0;
+    --link-color-pale: #97e1fb;
+    --link-hover: #00688e;
+}
+
+p.dataframe_description {
+    color: var(--text-color-dark);
+}
+
+table.dataframe {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    background-color: var(--background);
+    color: var(--text-color-dark);
+    border: none;
+    border-collapse: collapse;
+}
+
+table.dataframe th, td {
+    padding: 6px;
+    border: 1px solid transparent;
+    text-align: left;
+}
+
+table.dataframe th {
+    background-color: var(--background);
+    color: var(--header-text-color);
+}
+
+table.dataframe td {
+    vertical-align: top;
+}
+
+table.dataframe th.bottomBorder {
+    border-bottom-color: var(--bold-border-color);
+}
+
+table.dataframe tbody > tr:nth-child(odd) {
+    background: var(--background-odd);
+}
+
+table.dataframe tbody > tr:nth-child(even) {
+    background: var(--background);
+}
+
+table.dataframe tbody > tr:hover {
+    background: var(--background-hover);
+}
+
+table.dataframe a {
+    cursor: pointer;
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+table.dataframe tr:hover > td a {
+    color: var(--link-color-pale);
+}
+
+table.dataframe a:hover {
+    color: var(--link-hover);
+    text-decoration: underline;
+}
+
+table.dataframe img {
+    max-width: fit-content;
+}
+
+table.dataframe th.complex {
+    background-color: var(--background);
+    border: 1px solid var(--background);
+}
+
+table.dataframe .leftBorder {
+    border-left-color: var(--inner-border-color);
+}
+
+table.dataframe .rightBorder {
+    border-right-color: var(--inner-border-color);
+}
+
+table.dataframe .rightAlign {
+    text-align: right;
+}
+
+table.dataframe .expanderSvg {
+    width: 8px;
+    height: 8px;
+    margin-right: 3px;
+}
+
+table.dataframe .expander {
+    display: flex;
+    align-items: center;
+}
+
+/* formatting */
+
+table.dataframe .null {
+    color: var(--text-color-pale);
+}
+
+table.dataframe .structural {
+    color: var(--text-color-medium);
+    font-weight: bold;
+}
+
+table.dataframe .dataFrameCaption {
+    font-weight: bold;
+}
+
+table.dataframe .numbers {
+    color: var(--text-color-dark);
+}
+
+table.dataframe td:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+table.dataframe tr:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+
+:root {
+    --background: #fff;
+    --background-odd: #f5f5f5;
+    --background-hover: #d9edfd;
+    --header-text-color: #474747;
+    --text-color: #848484;
+    --text-color-dark: #000;
+    --text-color-medium: #737373;
+    --text-color-pale: #b3b3b3;
+    --inner-border-color: #aaa;
+    --bold-border-color: #000;
+    --link-color: #296eaa;
+    --link-color-pale: #296eaa;
+    --link-hover: #1a466c;
+}
+
+:root[theme="dark"], :root [data-jp-theme-light="false"], .dataframe_dark{
+    --background: #303030;
+    --background-odd: #3c3c3c;
+    --background-hover: #464646;
+    --header-text-color: #dddddd;
+    --text-color: #b3b3b3;
+    --text-color-dark: #dddddd;
+    --text-color-medium: #b2b2b2;
+    --text-color-pale: #737373;
+    --inner-border-color: #707070;
+    --bold-border-color: #777777;
+    --link-color: #008dc0;
+    --link-color-pale: #97e1fb;
+    --link-hover: #00688e;
+}
+
+p.dataframe_description {
+    color: var(--text-color-dark);
+}
+
+table.dataframe {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    background-color: var(--background);
+    color: var(--text-color-dark);
+    border: none;
+    border-collapse: collapse;
+}
+
+table.dataframe th, td {
+    padding: 6px;
+    border: 1px solid transparent;
+    text-align: left;
+}
+
+table.dataframe th {
+    background-color: var(--background);
+    color: var(--header-text-color);
+}
+
+table.dataframe td {
+    vertical-align: top;
+}
+
+table.dataframe th.bottomBorder {
+    border-bottom-color: var(--bold-border-color);
+}
+
+table.dataframe tbody > tr:nth-child(odd) {
+    background: var(--background-odd);
+}
+
+table.dataframe tbody > tr:nth-child(even) {
+    background: var(--background);
+}
+
+table.dataframe tbody > tr:hover {
+    background: var(--background-hover);
+}
+
+table.dataframe a {
+    cursor: pointer;
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+table.dataframe tr:hover > td a {
+    color: var(--link-color-pale);
+}
+
+table.dataframe a:hover {
+    color: var(--link-hover);
+    text-decoration: underline;
+}
+
+table.dataframe img {
+    max-width: fit-content;
+}
+
+table.dataframe th.complex {
+    background-color: var(--background);
+    border: 1px solid var(--background);
+}
+
+table.dataframe .leftBorder {
+    border-left-color: var(--inner-border-color);
+}
+
+table.dataframe .rightBorder {
+    border-right-color: var(--inner-border-color);
+}
+
+table.dataframe .rightAlign {
+    text-align: right;
+}
+
+table.dataframe .expanderSvg {
+    width: 8px;
+    height: 8px;
+    margin-right: 3px;
+}
+
+table.dataframe .expander {
+    display: flex;
+    align-items: center;
+}
+
+/* formatting */
+
+table.dataframe .null {
+    color: var(--text-color-pale);
+}
+
+table.dataframe .structural {
+    color: var(--text-color-medium);
+    font-weight: bold;
+}
+
+table.dataframe .dataFrameCaption {
+    font-weight: bold;
+}
+
+table.dataframe .numbers {
+    color: var(--text-color-dark);
+}
+
+table.dataframe td:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+table.dataframe tr:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+
+body {
+    font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+}       
+
+:root {
+    color: #19191C;
+    background-color: #fff;
+}
+
+:root[theme="dark"] {
+    background-color: #19191C;
+    color: #FFFFFFCC
+}
+
+details details {
+    margin-left: 20px; 
+}
+
+summary {
+    padding: 6px;
+}
+</style>
+</head>
+<body>
+<table class="dataframe" id="df_1962934541"></table>
+
+<table class="dataframe" id="static_df_1962934542"><thead><tr><th class="bottomBorder" style="text-align:left">example</th></tr></thead><tbody><tr><td  style="vertical-align:top">123</td></tr></tbody></table>
+<p class="dataframe_description"></p>
+</body>
+<script>
+(function () {
+    window.DataFrame = window.DataFrame || new (function () {
+        this.addTable = function (df) {
+            let cols = df.cols;
+            for (let i = 0; i < cols.length; i++) {
+                for (let c of cols[i].children) {
+                    cols[c].parent = i;
+                }
+            }
+            df.nrow = 0
+            for (let i = 0; i < df.cols.length; i++) {
+                if (df.cols[i].values.length > df.nrow) df.nrow = df.cols[i].values.length
+            }
+            if (df.id === df.rootId) {
+                df.expandedFrames = new Set()
+                df.childFrames = {}
+                const table = this.getTableElement(df.id)
+                table.df = df
+                for (let i = 0; i < df.cols.length; i++) {
+                    let col = df.cols[i]
+                    if (col.parent === undefined && col.children.length > 0) col.expanded = true
+                }
+            } else {
+                const rootDf = this.getTableData(df.rootId)
+                rootDf.childFrames[df.id] = df
+            }
+        }
+
+        this.computeRenderData = function (df) {
+            let result = []
+            let pos = 0
+            for (let col = 0; col < df.cols.length; col++) {
+                if (df.cols[col].parent === undefined)
+                    pos += this.computeRenderDataRec(df.cols, col, pos, 0, result, false, false)
+            }
+            for (let i = 0; i < result.length; i++) {
+                let row = result[i]
+                for (let j = 0; j < row.length; j++) {
+                    let cell = row[j]
+                    if (j === 0)
+                        cell.leftBd = false
+                    if (j < row.length - 1) {
+                        let nextData = row[j + 1]
+                        if (nextData.leftBd) cell.rightBd = true
+                        else if (cell.rightBd) nextData.leftBd = true
+                    } else cell.rightBd = false
+                }
+            }
+            return result
+        }
+
+        this.computeRenderDataRec = function (cols, colId, pos, depth, result, leftBorder, rightBorder) {
+            if (result.length === depth) {
+                const array = [];
+                if (pos > 0) {
+                    let j = 0
+                    for (let i = 0; j < pos; i++) {
+                        let c = result[depth - 1][i]
+                        j += c.span
+                        let copy = Object.assign({empty: true}, c)
+                        array.push(copy)
+                    }
+                }
+                result.push(array)
+            }
+            const col = cols[colId];
+            let size = 0;
+            if (col.expanded) {
+                let childPos = pos
+                for (let i = 0; i < col.children.length; i++) {
+                    let child = col.children[i]
+                    let childLeft = i === 0 && (col.children.length > 1 || leftBorder)
+                    let childRight = i === col.children.length - 1 && (col.children.length > 1 || rightBorder)
+                    let childSize = this.computeRenderDataRec(cols, child, childPos, depth + 1, result, childLeft, childRight)
+                    childPos += childSize
+                    size += childSize
+                }
+            } else {
+                for (let i = depth + 1; i < result.length; i++)
+                    result[i].push({id: colId, span: 1, leftBd: leftBorder, rightBd: rightBorder, empty: true})
+                size = 1
+            }
+            let left = leftBorder
+            let right = rightBorder
+            if (size > 1) {
+                left = true
+                right = true
+            }
+            result[depth].push({id: colId, span: size, leftBd: left, rightBd: right})
+            return size
+        }
+
+        this.getTableElement = function (id) {
+            return document.getElementById("df_" + id)
+        }
+
+        this.getTableData = function (id) {
+            return this.getTableElement(id).df
+        }
+
+        this.createExpander = function (isExpanded) {
+            const svgNs = "http://www.w3.org/2000/svg"
+            let svg = document.createElementNS(svgNs, "svg")
+            svg.classList.add("expanderSvg")
+            let path = document.createElementNS(svgNs, "path")
+            if (isExpanded) {
+                svg.setAttribute("viewBox", "0 -2 8 8")
+                path.setAttribute("d", "M1 0 l-1 1 4 4 4 -4 -1 -1 -3 3Z")
+            } else {
+                svg.setAttribute("viewBox", "-2 0 8 8")
+                path.setAttribute("d", "M1 0 l-1 1 3 3 -3 3 1 1 4 -4Z")
+            }
+            path.setAttribute("fill", "currentColor")
+            svg.appendChild(path)
+            return svg
+        }
+
+        this.renderTable = function (id) {
+
+            let table = this.getTableElement(id)
+
+            if (table === null) return
+
+            table.innerHTML = ""
+
+            let df = table.df
+            let rootDf = df.rootId === df.id ? df : this.getTableData(df.rootId)
+
+            // header
+            let header = document.createElement("thead")
+            table.appendChild(header)
+
+            let renderData = this.computeRenderData(df)
+            for (let j = 0; j < renderData.length; j++) {
+                let rowData = renderData[j]
+                let tr = document.createElement("tr");
+                let isLastRow = j === renderData.length - 1
+                header.appendChild(tr);
+                for (let i = 0; i < rowData.length; i++) {
+                    let cell = rowData[i]
+                    let th = document.createElement("th");
+                    th.setAttribute("colspan", cell.span)
+                    let colId = cell.id
+                    let col = df.cols[colId];
+                    if (!cell.empty) {
+                        if (col.children.length === 0) {
+                            th.innerHTML = col.name
+                        } else {
+                            let link = document.createElement("a")
+                            link.className = "expander"
+                            let that = this
+                            link.onclick = function () {
+                                col.expanded = !col.expanded
+                                that.renderTable(id)
+                            }
+                            link.appendChild(this.createExpander(col.expanded))
+                            link.innerHTML += col.name
+                            th.appendChild(link)
+                        }
+                    }
+                    let classes = (cell.leftBd ? " leftBorder" : "") + (cell.rightBd ? " rightBorder" : "")
+                    if (col.rightAlign)
+                        classes += " rightAlign"
+                    if (isLastRow)
+                        classes += " bottomBorder"
+                    if (classes.length > 0)
+                        th.setAttribute("class", classes)
+                    tr.appendChild(th)
+                }
+            }
+
+            // body
+            let body = document.createElement("tbody")
+            table.appendChild(body)
+
+            let columns = renderData.pop()
+            for (let row = 0; row < df.nrow; row++) {
+                let tr = document.createElement("tr");
+                body.appendChild(tr)
+                for (let i = 0; i < columns.length; i++) {
+                    let cell = columns[i]
+                    let td = document.createElement("td");
+                    let colId = cell.id
+                    let col = df.cols[colId]
+                    let classes = (cell.leftBd ? " leftBorder" : "") + (cell.rightBd ? " rightBorder" : "")
+                    if (col.rightAlign)
+                        classes += " rightAlign"
+                    if (classes.length > 0)
+                        td.setAttribute("class", classes)
+                    tr.appendChild(td)
+                    let value = col.values[row]
+                    if (value.frameId !== undefined) {
+                        let frameId = value.frameId
+                        let expanded = rootDf.expandedFrames.has(frameId)
+                        let link = document.createElement("a")
+                        link.className = "expander"
+                        let that = this
+                        link.onclick = function () {
+                            if (rootDf.expandedFrames.has(frameId))
+                                rootDf.expandedFrames.delete(frameId)
+                            else rootDf.expandedFrames.add(frameId)
+                            that.renderTable(id)
+                        }
+                        link.appendChild(this.createExpander(expanded))
+                        link.innerHTML += value.value
+                        if (expanded) {
+                            td.appendChild(link)
+                            td.appendChild(document.createElement("p"))
+                            const childTable = document.createElement("table")
+                            childTable.className = "dataframe"
+                            childTable.id = "df_" + frameId
+                            let childDf = rootDf.childFrames[frameId]
+                            childTable.df = childDf
+                            td.appendChild(childTable)
+                            this.renderTable(frameId)
+                            if (childDf.nrow !== childDf.totalRows) {
+                                const footer = document.createElement("p")
+                                footer.innerText = `... showing only top ${childDf.nrow} of ${childDf.totalRows} rows`
+                                td.appendChild(footer)
+                            }
+                        } else {
+                            td.appendChild(link)
+                        }
+                    } else if (value.style !== undefined) {
+                        td.innerHTML = value.value
+                        td.setAttribute("style", value.style)
+                    } else td.innerHTML = value
+                    this.nodeScriptReplace(td)
+                }
+            }
+        }
+
+        this.nodeScriptReplace = function (node) {
+            if (this.nodeScriptIs(node) === true) {
+                node.parentNode.replaceChild(this.nodeScriptClone(node), node);
+            } else {
+                let i = -1, children = node.childNodes;
+                while (++i < children.length) {
+                    this.nodeScriptReplace(children[i]);
+                }
+            }
+
+            return node;
+        }
+
+        this.nodeScriptClone = function (node) {
+            let script = document.createElement("script");
+            script.text = node.innerHTML;
+
+            let i = -1, attrs = node.attributes, attr;
+            while (++i < attrs.length) {
+                script.setAttribute((attr = attrs[i]).name, attr.value);
+            }
+            return script;
+        }
+
+        this.nodeScriptIs = function (node) {
+            return node.tagName === 'SCRIPT';
+        }
+    })()
+
+    window.call_DataFrame = function (f) {
+        return f();
+    };
+
+    let funQueue = window["kotlinQueues"] && window["kotlinQueues"]["DataFrame"];
+    if (funQueue) {
+        funQueue.forEach(function (f) {
+            f();
+        });
+        funQueue = [];
+    }
+})()
+
+/*<!--*/
+call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: "<span title=\"example: Int\">example</span>", children: [], rightAlign: true, values: ["<span class=\"formatted\" title=\"\"><span class=\"numbers\">123</span></span>"] }, 
+], id: 1962934541, rootId: 1962934541, totalRows: 1 } ) });
+/*-->*/
+
+call_DataFrame(function() { DataFrame.renderTable(1962934541) });
+
+document.getElementById("static_df_1962934542").style.display = "none";
+</script>
+</html>

--- a/docs/serialization_format.md
+++ b/docs/serialization_format.md
@@ -12,8 +12,11 @@ rendering Kotlin dataframes in the Kotlin notebooks plugin of IntelliJ IDEA.
  * ...
 
 **2.1.0:**
- * Added a `types` property to dataframe and and row metadata. It contains column
+ * Added a `types` property to dataframe and row metadata. It contains column
    information for all groups, frames and values.
+
+**2.1.1:**
+ * Added a new type of `ValueColumn` value that is DataFrameConvertable type
 
 ### Top level json structure
 ```json
@@ -32,8 +35,8 @@ rendering Kotlin dataframes in the Kotlin notebooks plugin of IntelliJ IDEA.
 ### Row
 ```json
 { 
-    "<value_column_name1>": string|Boolean|Double|Int|Float|Long|Short|Byte|list,,
-    "<value_column_name2>": string|Boolean|Double|Int|Float|Long|Short|Byte|list,,
+    "<value_column_name1>": string|Boolean|Double|Int|Float|Long|Short|Byte|list|DataFrameConvertable,
+    "<value_column_name2>": string|Boolean|Double|Int|Float|Long|Short|Byte|list|DataFrameConvertable,
     ...
     "<column_group_name1>": ColumnGroup,
     "<column_group_name2>": ColumnGroup,
@@ -76,4 +79,16 @@ rendering Kotlin dataframes in the Kotlin notebooks plugin of IntelliJ IDEA.
     "type": FQN + nullability identifier (?), e.g "Kotlin.String?" // Only available if kind == "ValueColumn"
 }
 ```
+
+### DataFrameConvertable
+```json
+{
+    "metadata": {
+        "kind": "DataFrameConvertable"
+    },
+    "data": [ Row, ... ]
+}
+```
+
+
 


### PR DESCRIPTION
If the value within the ValueColumn can be converted to a dataframe, it will be serialized in a manner similar to the FrameColumn values. Consequently, it will be visualized as a nested table in the KTNB plugin.