### PR TITLE
Add toDataFrame(KClass) overload to convert type erased lists

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -28,6 +28,11 @@ public inline fun <reified T> Iterable<T>.toDataFrame(): DataFrame<T> =
         properties()
     }
 
+public fun Iterable<*>.toDataFrame(klass: KClass<*>): DataFrame<*> =
+    createDataFrameImpl(klass) {
+        properties()
+    }
+
 @Refine
 @Interpretable("toDataFrameDsl")
 public inline fun <reified T> Iterable<T>.toDataFrame(noinline body: CreateDataFrameDsl<T>.() -> Unit): DataFrame<T> =

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -452,4 +452,14 @@ class CreateDataFrameTests {
             df.participants[0].city
         }
     }
+
+    @Test
+    fun `convert type erased list to dataframe`() {
+        val data = listOf(Person("Alice", "Cooper", 15, "London"))
+        val erased: List<Any?> = data
+        val df = erased[0]?.let {
+            erased.toDataFrame(it::class)
+        }
+        df shouldBe data.toDataFrame()
+    }
 }


### PR DESCRIPTION
It's not new to have KType / KClass overloads next to inline reified APIs, so i believe this addition would be an easy one.