### PR TITLE
Hide properties of intermediate objects and remove data class attributes

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -91,11 +91,13 @@ public inline fun <T, C, reified R> Convert<T, C?>.notNull(
     }
 
 @HasSchema(schemaArg = 0)
-public data class Convert<T, out C>(val df: DataFrame<T>, val columns: ColumnsSelector<T, C>) {
+public class Convert<T, out C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
     public fun <R> cast(): Convert<T, R> = Convert(df, columns as ColumnsSelector<T, R>)
 
     @Interpretable("To0")
     public inline fun <reified D> to(): DataFrame<T> = to(typeOf<D>())
+
+    override fun toString(): String = "Convert(df=$df, columns=$columns)"
 }
 
 public fun <T> Convert<T, *>.to(type: KType): DataFrame<T> = to { it.convertTo(type) }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -42,7 +42,8 @@ public fun <T, C> FormatClause<T, C>.perRowCol(formatter: RowColFormatter<T, C>)
 public fun <T, C> FormatClause<T, C>.with(formatter: CellFormatter<C>): FormattedFrame<T> =
     formatImpl { row, col -> formatter(row[col]) }
 
-public fun <T, C> FormatClause<T, C>.where(filter: RowValueFilter<T, C>): FormatClause<T, C> = copy(filter = filter)
+public fun <T, C> FormatClause<T, C>.where(filter: RowValueFilter<T, C>): FormatClause<T, C> =
+    FormatClause(filter = filter, df = df, columns = columns, oldFormatter = oldFormatter)
 
 public fun <T> FormattedFrame<T>.format(): FormatClause<T, Any?> = FormatClause(df, null, formatter)
 
@@ -129,12 +130,15 @@ public class FormattedFrame<T>(internal val df: DataFrame<T>, internal val forma
         configuration.copy(cellFormatter = formatter as RowColFormatter<*, *>?)
 }
 
-public data class FormatClause<T, C>(
-    val df: DataFrame<T>,
-    val columns: ColumnsSelector<T, C>? = null,
-    val oldFormatter: RowColFormatter<T, C>? = null,
-    val filter: RowValueFilter<T, C> = { true },
-)
+public class FormatClause<T, C>(
+    internal val df: DataFrame<T>,
+    internal val columns: ColumnsSelector<T, C>? = null,
+    internal val oldFormatter: RowColFormatter<T, C>? = null,
+    internal val filter: RowValueFilter<T, C> = { true },
+) {
+    override fun toString(): String =
+        "FormatClause(df=$df, columns=$columns, oldFormatter=$oldFormatter, filter=$filter)"
+}
 
 public fun <T, C> FormattedFrame<T>.format(columns: ColumnsSelector<T, C>): FormatClause<T, C> =
     FormatClause(df, columns, formatter)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
@@ -28,7 +28,9 @@ public fun <T> DataFrame<T>.group(vararg columns: KProperty<*>): GroupClause<T, 
 
 // region GroupClause
 
-public data class GroupClause<T, C>(val df: DataFrame<T>, val columns: ColumnsSelector<T, C>)
+public class GroupClause<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
+    override fun toString(): String = "GroupClause(df=$df, columns=$columns)"
+}
 
 // region into
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -104,9 +104,11 @@ internal fun <T, G> GroupBy<T, G>.internal(): GroupByImpl<T, G> = this as GroupB
 
 public interface Grouped<out T> : Aggregatable<T>
 
-public data class ReducedGroupBy<T, G>(
+public class ReducedGroupBy<T, G>(
     @PublishedApi internal val groupBy: GroupBy<T, G>,
     @PublishedApi internal val reducer: Selector<DataFrame<G>, DataRow<G>?>,
-)
+) {
+    override fun toString(): String = "ReducedGroupBy(groupBy=$groupBy, reducer=$reducer)"
+}
 
 internal fun <T, G> GroupBy<T, G>.reduce(reducer: Selector<DataFrame<G>, DataRow<G>?>) = ReducedGroupBy(this, reducer)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/insert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/insert.kt
@@ -43,7 +43,9 @@ public inline fun <T, reified R> DataFrame<T>.insert(
 
 // endregion
 
-public data class InsertClause<T>(val df: DataFrame<T>, val column: AnyCol)
+public class InsertClause<T>(internal val df: DataFrame<T>, internal val column: AnyCol) {
+    override fun toString(): String = "InsertClause(df=$df, column=$column)"
+}
 
 // region under
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
@@ -150,6 +150,8 @@ public fun <T, C> MoveClause<T, C>.toLeft(): DataFrame<T> = to(0)
 
 public fun <T, C> MoveClause<T, C>.toRight(): DataFrame<T> = to(df.ncol)
 
-public class MoveClause<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>)
+public class MoveClause<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
+    override fun toString(): String = "MoveClause(df=$df, columns=$columns)"
+}
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
@@ -212,10 +212,12 @@ public interface Pivot<T> : Aggregatable<T>
 
 public typealias PivotColumnsSelector<T, C> = Selector<PivotDsl<T>, ColumnsResolver<C>>
 
-public data class ReducedPivot<T>(
+public class ReducedPivot<T>(
     @PublishedApi internal val pivot: Pivot<T>,
     @PublishedApi internal val reducer: Selector<DataFrame<T>, DataRow<T>?>,
-)
+) {
+    override fun toString(): String = "ReducedPivot(pivot=$pivot, reducer=$reducer)"
+}
 
 internal fun <T> Pivot<T>.reduce(reducer: Selector<DataFrame<T>, DataRow<T>?>) = ReducedPivot(this, reducer)
 
@@ -230,10 +232,12 @@ public interface PivotGroupBy<out T> : Aggregatable<T> {
     public fun default(value: Any?): PivotGroupBy<T>
 }
 
-public data class ReducedPivotGroupBy<T>(
+public class ReducedPivotGroupBy<T>(
     @PublishedApi internal val pivot: PivotGroupBy<T>,
     @PublishedApi internal val reducer: Selector<DataFrame<T>, DataRow<T>?>,
-)
+) {
+    override fun toString(): String = "ReducedPivotGroupBy(pivot=$pivot, reducer=$reducer)"
+}
 
 @PublishedApi
 internal fun <T> PivotGroupBy<T>.reduce(reducer: Selector<DataFrame<T>, DataRow<T>?>): ReducedPivotGroupBy<T> =

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -45,7 +45,9 @@ public fun <T, C> DataFrame<T>.rename(vararg cols: KProperty<C>): RenameClause<T
 public fun <T> DataFrame<T>.rename(vararg cols: String): RenameClause<T, Any?> = rename { cols.toColumnSet() }
 
 @HasSchema(schemaArg = 0)
-public data class RenameClause<T, C>(val df: DataFrame<T>, val columns: ColumnsSelector<T, C>)
+public class RenameClause<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
+    override fun toString(): String = "RenameClause(df=$df, columns=$columns)"
+}
 
 /**
  * ## Rename to camelCase

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
@@ -33,7 +33,9 @@ public fun <T> DataFrame<T>.replaceAll(
     return update(columns).with { map[it] ?: it }
 }
 
-public data class ReplaceClause<T, C>(val df: DataFrame<T>, val columns: ColumnsSelector<T, C>)
+public class ReplaceClause<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
+    override fun toString(): String = "ReplaceClause(df=$df, columns=$columns)"
+}
 
 public fun <T, C> ReplaceClause<T, C>.with(vararg columns: AnyCol): DataFrame<T> = with(columns.toList())
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -28,8 +28,10 @@ public fun <T, C> DataFrame<T>.split(vararg columns: ColumnReference<C?>): Split
 
 public fun <T, C> DataFrame<T>.split(vararg columns: KProperty<C?>): Split<T, C> = split { columns.toColumnSet() }
 
-public data class Split<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C?>) {
+public class Split<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C?>) {
     public fun <P> cast(): Split<T, P> = this as Split<T, P>
+
+    override fun toString(): String = "Split(df=$df, columns=$columns)"
 }
 
 public data class SplitWithTransform<T, C, R>(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -40,13 +40,15 @@ import kotlin.reflect.KProperty
  *
  * For more information: {@include [DocumentationUrls.Update]}
  */
-public data class Update<T, C>(
-    val df: DataFrame<T>,
-    val filter: RowValueFilter<T, C>?,
-    val columns: ColumnsSelector<T, C>,
+public class Update<T, C>(
+    internal val df: DataFrame<T>,
+    internal val filter: RowValueFilter<T, C>?,
+    internal val columns: ColumnsSelector<T, C>,
 ) {
     public fun <R : C> cast(): Update<T, R> =
         Update(df, filter as RowValueFilter<T, R>?, columns as ColumnsSelector<T, R>)
+
+    override fun toString(): String = "Update(df=$df, filter=$filter, columns=$columns)"
 
     /*
      * This argument providing the (clickable) name of the update-like function.
@@ -188,7 +190,7 @@ public fun <T, C> DataFrame<T>.update(vararg columns: ColumnReference<C>): Updat
  * @param [predicate] The [row value filter][RowValueFilter] to select the rows to update.
  */
 public fun <T, C> Update<T, C>.where(predicate: RowValueFilter<T, C>): Update<T, C> =
-    copy(filter = filter and predicate)
+    Update(df = df, filter = filter and predicate, columns = columns)
 
 /** ## At
  * Only update the columns at certain given [row indices][CommonUpdateAtFunctionDoc.RowIndicesParam]:


### PR DESCRIPTION
In the image you can see how it used to be for some of those objects. copy, properties, generated component functions. These are useless, and yet they appear in the completion.
I left "data" for those classes where implementation uses copy more than once, and for some reason component* functions do not appear for Gather and Merge, so idk. 
toString for now is just the same as it was with data class, but in theory it can even be improved in the future for better debugger experience. 

`df.convert { a }.`

![image](https://github.com/user-attachments/assets/c12dbc78-1174-4223-9e6b-79002a628f92)
