### PR TITLE
Update links to demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ You could find the following articles there:
 * [Rendering to HTML](https://kotlin.github.io/dataframe/tohtml.html#jupyter-notebooks)
 
 ### What's new
-Check out new features in development for the next release in this [notebook](examples/notebooks/feature_overviews/0.14.0/new_features.ipynb)
+Check out this [notebook with new features](examples/notebooks/feature_overviews/0.14.0/new_features.ipynb) in development for the next release.
 
-The DataFrame compiler plugin reached public preview state!
-Here's a [demo project](https://github.com/koperagen/df-plugin-demo) that works with IntelliJ IDEA 2024.2.
+The DataFrame compiler plugin has reached public preview!
+Here's a [compiler plugin demo project](https://github.com/koperagen/df-plugin-demo) that works with IntelliJ IDEA 2024.2.
 
 ## Setup
 

--- a/docs/StardustDocs/topics/overview.md
+++ b/docs/StardustDocs/topics/overview.md
@@ -31,7 +31,8 @@ that correspond to the columns of a data frame.
 In interactive notebooks like Jupyter or Datalore, the generation runs after each cell execution. 
 In IntelliJ IDEA there's a Gradle plugin for generation properties based on CSV file or JSON file. 
 Also, we’re working on a compiler plugin that infers and transforms [`DataFrame`](DataFrame.md) schema while typing.
-The generated properties ensures you’ll never misspell column name and don’t mess up with its type, and of course nullability is also preserved.
+You can now clone this [project with many examples](https://github.com/koperagen/df-plugin-demo) showcasing how it allows you to reliably use our most convenient extension properties API.
+The generated properties ensure you’ll never misspell column name and don’t mess up with its type, and of course nullability is also preserved.
 
 * **Generic** — columns can store objects of any type, not only numbers or strings.
 


### PR DESCRIPTION
Links seem to attract more attention than surrounding text, so it should be clear where it leads just from the link text.