### PR TITLE
replacing often-used `typeOf<>()` calls with constants and enforcing kotlinx.datetime bias

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataColumn.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnKind
 import org.jetbrains.kotlinx.dataframe.impl.getValuesType
 import org.jetbrains.kotlinx.dataframe.impl.splitByIndices
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -115,7 +116,7 @@ public interface DataColumn<out T> : BaseColumn<T> {
         public inline fun <reified T> create(name: String, values: List<T>, infer: Infer = Infer.None): DataColumn<T> =
             create(name, values, typeOf<T>(), infer)
 
-        public fun empty(name: String = ""): AnyCol = createValueColumn(name, emptyList<Unit>(), typeOf<Unit>())
+        public fun empty(name: String = ""): AnyCol = createValueColumn(name, emptyList<Unit>(), TypeOf.UNIT)
     }
 
     public fun hasNulls(): Boolean = type().isMarkedNullable

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -36,6 +36,7 @@ import org.jetbrains.kotlinx.dataframe.impl.api.withRowCellImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.io.toDataFrame
 import org.jetbrains.kotlinx.dataframe.path
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigDecimal
 import java.net.URL
 import java.time.LocalTime
@@ -130,8 +131,8 @@ public inline fun <T, C, reified R> Convert<T, C>.perRowCol(
 public inline fun <reified C> AnyCol.convertTo(): DataColumn<C> = convertTo(typeOf<C>()) as DataColumn<C>
 
 public fun AnyCol.convertTo(newType: KType): AnyCol {
-    val isTypesAreCorrect = this.type().withNullability(true).isSubtypeOf(typeOf<String?>()) &&
-        newType.withNullability(true) == typeOf<Double?>()
+    val isTypesAreCorrect = this.type().withNullability(true).isSubtypeOf(TypeOf.NULLABLE_STRING) &&
+        newType.withNullability(true) == TypeOf.NULLABLE_DOUBLE
 
     if (isTypesAreCorrect) {
         return (this as DataColumn<String?>).convertToDouble().setNullable(newType.isMarkedNullable)
@@ -208,8 +209,8 @@ public fun DataColumn<String?>.convertToDouble(locale: Locale? = null): DataColu
                 value?.let {
                     parser(value.trim()) ?: throw TypeConversionException(
                         value = value,
-                        from = typeOf<String>(),
-                        to = typeOf<Double>(),
+                        from = TypeOf.STRING,
+                        to = TypeOf.DOUBLE,
                         column = path,
                     )
                 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.kotlinx.dataframe.AnyBaseCol
@@ -39,7 +40,6 @@ import org.jetbrains.kotlinx.dataframe.path
 import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigDecimal
 import java.net.URL
-import java.time.LocalTime
 import java.util.Locale
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/corr.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/corr.kt
@@ -6,10 +6,10 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.corrImpl
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KProperty
-import kotlin.reflect.typeOf
 
-internal fun AnyCol.isSuitableForCorr() = isSubtypeOf<Number>() || type() == typeOf<Boolean>()
+internal fun AnyCol.isSuitableForCorr() = isSubtypeOf(TypeOf.NUMBER) || type() == TypeOf.BOOLEAN
 
 // region DataFrame
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
@@ -8,25 +8,25 @@ import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.math.cumSum
 import org.jetbrains.kotlinx.dataframe.math.defaultCumSumSkipNA
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigDecimal
 import kotlin.reflect.KProperty
-import kotlin.reflect.typeOf
 
 // region DataColumn
 
 public fun <T : Number?> DataColumn<T>.cumSum(skipNA: Boolean = defaultCumSumSkipNA): DataColumn<T> =
     when (type()) {
-        typeOf<Double>() -> cast<Double>().cumSum(skipNA).cast()
-        typeOf<Double?>() -> cast<Double?>().cumSum(skipNA).cast()
-        typeOf<Float>() -> cast<Float>().cumSum(skipNA).cast()
-        typeOf<Float?>() -> cast<Float?>().cumSum(skipNA).cast()
-        typeOf<Int>() -> cast<Int>().cumSum().cast()
-        typeOf<Int?>() -> cast<Int?>().cumSum(skipNA).cast()
-        typeOf<Long>() -> cast<Long>().cumSum().cast()
-        typeOf<Long?>() -> cast<Long?>().cumSum(skipNA).cast()
-        typeOf<BigDecimal>() -> cast<BigDecimal>().cumSum().cast()
-        typeOf<BigDecimal?>() -> cast<BigDecimal?>().cumSum(skipNA).cast()
-        typeOf<Number?>(), typeOf<Number>() -> convertToDouble().cumSum(skipNA).cast()
+        TypeOf.DOUBLE -> cast<Double>().cumSum(skipNA).cast()
+        TypeOf.NULLABLE_DOUBLE -> cast<Double?>().cumSum(skipNA).cast()
+        TypeOf.FLOAT -> cast<Float>().cumSum(skipNA).cast()
+        TypeOf.NULLABLE_FLOAT -> cast<Float?>().cumSum(skipNA).cast()
+        TypeOf.INT -> cast<Int>().cumSum().cast()
+        TypeOf.NULLABLE_INT -> cast<Int?>().cumSum(skipNA).cast()
+        TypeOf.LONG -> cast<Long>().cumSum().cast()
+        TypeOf.NULLABLE_LONG -> cast<Long?>().cumSum(skipNA).cast()
+        TypeOf.BIG_DECIMAL -> cast<BigDecimal>().cumSum().cast()
+        TypeOf.NULLABLE_BIG_DECIMAL -> cast<BigDecimal?>().cumSum(skipNA).cast()
+        TypeOf.NUMBER, TypeOf.NULLABLE_NUMBER -> convertToDouble().cumSum(skipNA).cast()
         else -> error("Cumsum for type ${type()} is not supported")
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.gatherImpl
 import org.jetbrains.kotlinx.dataframe.impl.columnName
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -19,7 +20,7 @@ public fun <T, C> DataFrame<T>.gather(selector: ColumnsSelector<T, C>): Gather<T
         df = this,
         columns = selector,
         filter = null,
-        keyType = typeOf<String>(),
+        keyType = TypeOf.STRING,
         keyTransform = { it },
         valueTransform = null,
     )

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.removeImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.withRowCellImpl
 import org.jetbrains.kotlinx.dataframe.impl.nameGenerator
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -100,7 +101,7 @@ public fun <T, C, R> Merge<T, C, R>.by(
                 truncated = truncated,
             )
         },
-        resultType = typeOf<String>(),
+        resultType = TypeOf.STRING,
         infer = Infer.Nulls,
     )
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
@@ -7,9 +7,9 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.nameGenerator
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.withNullability
-import kotlin.reflect.typeOf
 
 // region DataSchema
 
@@ -42,7 +42,7 @@ public fun <T> DataColumn<T>.valueCounts(
     val nulls = if (dropNA) false else hasNulls()
     val values = DataColumn.create(name(), grouped.map { it.first }, type().withNullability(nulls))
     val countName = if (resultColumn == name()) resultColumn + "1" else resultColumn
-    val counts = DataColumn.create(countName, grouped.map { it.second }, typeOf<Int>())
+    val counts = DataColumn.create(countName, grouped.map { it.second }, TypeOf.INT)
     return dataFrameOf(values, counts).cast()
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.api.Infer
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
@@ -265,7 +266,7 @@ internal fun Iterable<KType>.commonTypeListifyValues(useStar: Boolean = true): K
     val distinct = distinct()
     val nullable = distinct.any { it.isMarkedNullable }
     return when {
-        distinct.isEmpty() -> typeOf<Any>().withNullability(nullable)
+        distinct.isEmpty() -> TypeOf.ANY.withNullability(nullable)
 
         distinct.size == 1 -> distinct.single()
 
@@ -321,7 +322,7 @@ internal fun Iterable<KType>.commonTypeListifyValues(useStar: Boolean = true): K
 
                 else -> {
                     val kClass = commonParent(distinct.map { it.jvmErasure })
-                        ?: return typeOf<Any>().withNullability(nullable)
+                        ?: return TypeOf.ANY.withNullability(nullable)
                     val projections = distinct
                         .map { it.projectUpTo(kClass).replaceGenericTypeParametersWithUpperbound() }
                     require(projections.all { it.jvmErasure == kClass })
@@ -516,12 +517,7 @@ internal fun guessValueType(values: Sequence<Any?>, upperBound: KType? = null, l
 internal val KType.isNothing: Boolean
     get() = classifier == Nothing::class
 
-internal fun nothingType(nullable: Boolean): KType =
-    if (nullable) {
-        typeOf<List<Nothing?>>()
-    } else {
-        typeOf<List<Nothing>>()
-    }.arguments.first().type!!
+internal fun nothingType(nullable: Boolean): KType = if (nullable) TypeOf.NULLABLE_NOTHING else TypeOf.NOTHING
 
 @OptIn(ExperimentalUnsignedTypes::class)
 private val primitiveArrayClasses = setOf(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/Utils.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.columns.UnresolvedColumnsPolicy
 import org.jetbrains.kotlinx.dataframe.impl.columns.resolve
 import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.nrow
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.reflect.KCallable
@@ -161,14 +162,14 @@ internal fun Iterable<KType?>.commonType(useStar: Boolean = true): KType {
     val distinct = distinct()
     val nullable = distinct.any { it?.isMarkedNullable ?: true }
     return when {
-        distinct.isEmpty() || distinct.contains(null) -> typeOf<Any>().withNullability(nullable)
+        distinct.isEmpty() || distinct.contains(null) -> TypeOf.ANY.withNullability(nullable)
 
         distinct.size == 1 -> distinct.single()!!
 
         else -> {
             // common parent class of all KTypes
             val kClass = commonParent(distinct.map { it!!.jvmErasure })
-                ?: return typeOf<Any>().withNullability(nullable)
+                ?: return TypeOf.ANY.withNullability(nullable)
 
             // all KTypes projected to the common parent class with filled-in generic type parameters (no <T>, but <UpperBound>)
             val projections = distinct

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.impl.api
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.atTime
@@ -10,6 +11,7 @@ import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toJavaLocalTime
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -38,7 +40,6 @@ import org.jetbrains.kotlinx.dataframe.path
 import org.jetbrains.kotlinx.dataframe.type
 import java.math.BigDecimal
 import java.net.URL
-import java.time.LocalTime
 import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -49,6 +50,10 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
+import java.time.Instant as JavaInstant
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 @PublishedApi
 internal fun <T, C, R> Convert<T, C>.withRowCellImpl(
@@ -299,13 +304,19 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 LocalDate::class -> convert<Int> { it.toLong().toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<Long> {
-                    it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
+                LocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<Int> { Instant.fromEpochMilliseconds(it.toLong()) }
+
+                JavaLocalDateTime::class -> convert<Int> {
+                    it.toLong().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Int> { it.toLong().toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                LocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Int> { JavaInstant.ofEpochMilli(it.toLong()) }
 
                 else -> null
             }
@@ -341,13 +352,15 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 Instant::class -> convert<Long> { Instant.fromEpochMilliseconds(it) }
 
-                java.time.LocalDateTime::class -> convert<Long> {
+                JavaLocalDateTime::class -> convert<Long> {
                     it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                LocalTime::class -> convert<Long> { it.toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Long> { it.toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Long> { JavaInstant.ofEpochMilli(it) }
 
                 else -> null
             }
@@ -359,39 +372,45 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 LocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<Instant> {
+                LocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone) }
+
+                JavaLocalDateTime::class -> convert<Instant> {
                     it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                java.time.Instant::class -> convert<Instant> { it.toJavaInstant() }
+                JavaInstant::class -> convert<Instant> { it.toJavaInstant() }
 
-                LocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone).toJavaLocalTime() }
 
                 else -> null
             }
 
-            java.time.Instant::class -> when (toClass) {
-                Long::class -> convert<java.time.Instant> { it.toEpochMilli() }
+            JavaInstant::class -> when (toClass) {
+                Long::class -> convert<JavaInstant> { it.toEpochMilli() }
 
-                LocalDateTime::class -> convert<java.time.Instant> {
+                LocalDateTime::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDateTime(defaultTimeZone)
                 }
 
-                LocalDate::class -> convert<java.time.Instant> { it.toKotlinInstant().toLocalDate(defaultTimeZone) }
+                LocalDate::class -> convert<JavaInstant> { it.toKotlinInstant().toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<java.time.Instant> {
+                LocalTime::class -> convert<JavaInstant> { it.toKotlinInstant().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<JavaInstant> { it.toKotlinInstant() }
+
+                JavaLocalDateTime::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<java.time.Instant> {
+                JavaLocalDate::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDate(defaultTimeZone).toJavaLocalDate()
                 }
 
-                Instant::class -> convert<java.time.Instant> { it.toKotlinInstant() }
-
-                LocalTime::class -> convert<java.time.Instant> { it.toKotlinInstant().toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<JavaInstant> {
+                    it.toKotlinInstant().toLocalTime(defaultTimeZone).toJavaLocalTime()
+                }
 
                 else -> null
             }
@@ -417,30 +436,38 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
             LocalDateTime::class -> when (toClass) {
                 LocalDate::class -> convert<LocalDateTime> { it.date }
+                LocalTime::class -> convert<LocalDateTime> { it.time }
                 Instant::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone) }
                 Long::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone).toEpochMilliseconds() }
-                java.time.LocalDateTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime() }
-                java.time.LocalDate::class -> convert<LocalDateTime> { it.date.toJavaLocalDate() }
-                java.time.LocalTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime().toLocalTime() }
+                JavaLocalDateTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime() }
+                JavaLocalDate::class -> convert<LocalDateTime> { it.date.toJavaLocalDate() }
+                JavaLocalTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime().toLocalTime() }
+                JavaInstant::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone).toJavaInstant() }
                 else -> null
             }
 
-            java.time.LocalDateTime::class -> when (toClass) {
-                LocalDate::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime().date }
+            JavaLocalDateTime::class -> when (toClass) {
+                LocalDate::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime().date }
 
-                LocalDateTime::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime() }
+                LocalTime::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime().time }
 
-                Instant::class -> convert<java.time.LocalDateTime> {
+                LocalDateTime::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime() }
+
+                Instant::class -> convert<JavaLocalDateTime> {
                     it.toKotlinLocalDateTime().toInstant(defaultTimeZone)
                 }
 
-                Long::class -> convert<java.time.LocalDateTime> {
+                Long::class -> convert<JavaLocalDateTime> {
                     it.toKotlinLocalDateTime().toInstant(defaultTimeZone).toEpochMilliseconds()
                 }
 
-                java.time.LocalDate::class -> convert<java.time.LocalDateTime> { it.toLocalDate() }
+                JavaLocalDate::class -> convert<JavaLocalDateTime> { it.toLocalDate() }
 
-                java.time.LocalTime::class -> convert<java.time.LocalDateTime> { it.toLocalTime() }
+                JavaLocalTime::class -> convert<JavaLocalDateTime> { it.toLocalTime() }
+
+                JavaInstant::class -> convert<JavaLocalDateTime> {
+                    it.toKotlinLocalDateTime().toInstant(defaultTimeZone).toJavaInstant()
+                }
 
                 else -> null
             }
@@ -449,25 +476,30 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 LocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0) }
                 Instant::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone) }
                 Long::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone).toEpochMilliseconds() }
-                java.time.LocalDate::class -> convert<LocalDate> { it.toJavaLocalDate() }
-                java.time.LocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0).toJavaLocalDateTime() }
+                JavaLocalDate::class -> convert<LocalDate> { it.toJavaLocalDate() }
+                JavaLocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0).toJavaLocalDateTime() }
+                JavaInstant::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone).toJavaInstant() }
                 else -> null
             }
 
-            java.time.LocalDate::class -> when (toClass) {
-                LocalDate::class -> convert<java.time.LocalDate> { it.toKotlinLocalDate() }
+            JavaLocalDate::class -> when (toClass) {
+                LocalDate::class -> convert<JavaLocalDate> { it.toKotlinLocalDate() }
 
-                LocalDateTime::class -> convert<java.time.LocalDate> { it.atTime(0, 0).toKotlinLocalDateTime() }
+                LocalDateTime::class -> convert<JavaLocalDate> { it.atTime(0, 0).toKotlinLocalDateTime() }
 
-                Instant::class -> convert<java.time.LocalDate> {
+                Instant::class -> convert<JavaLocalDate> {
                     it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone)
                 }
 
-                Long::class -> convert<java.time.LocalDate> {
+                Long::class -> convert<JavaLocalDate> {
                     it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone).toEpochMilliseconds()
                 }
 
-                java.time.LocalDateTime::class -> convert<java.time.LocalDate> { it.atStartOfDay() }
+                JavaLocalDateTime::class -> convert<JavaLocalDate> { it.atStartOfDay() }
+
+                JavaInstant::class -> convert<JavaLocalDate> {
+                    it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone).toJavaInstant()
+                }
 
                 else -> null
             }
@@ -488,12 +520,10 @@ internal fun Long.toLocalDateTime(zone: TimeZone = defaultTimeZone) =
 
 internal fun Long.toLocalDate(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).date
 
-internal fun Long.toLocalTime(zone: TimeZone = defaultTimeZone) =
-    toLocalDateTime(zone).toJavaLocalDateTime().toLocalTime()
+internal fun Long.toLocalTime(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).time
 
 internal fun Instant.toLocalDate(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).date
 
-internal fun Instant.toLocalTime(zone: TimeZone = defaultTimeZone) =
-    toLocalDateTime(zone).toJavaLocalDateTime().toLocalTime()
+internal fun Instant.toLocalTime(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).time
 
 internal val defaultTimeZone = TimeZone.currentSystemDefault()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/implode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/implode.kt
@@ -14,15 +14,15 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.extractDataFrame
 import org.jetbrains.kotlinx.dataframe.impl.getListType
-import kotlin.reflect.typeOf
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 
 internal fun <T, C> DataFrame<T>.implodeImpl(dropNA: Boolean = false, columns: ColumnsSelector<T, C>): DataFrame<T> =
     groupBy { allExcept(columns) }.updateGroups {
         replace(columns).with { column ->
             val (value, type) = when (column.kind()) {
                 ColumnKind.Value -> (if (dropNA) column.dropNA() else column).toList() to getListType(column.type())
-                ColumnKind.Group -> column.asColumnGroup().extractDataFrame() to typeOf<AnyFrame>()
-                ColumnKind.Frame -> column.asAnyFrameColumn().concat() to typeOf<List<AnyFrame>>()
+                ColumnKind.Group -> column.asColumnGroup().extractDataFrame() to TypeOf.ANY_FRAME
+                ColumnKind.Frame -> column.asAnyFrameColumn().concat() to TypeOf.LIST_ANY_FRAME
             }
             var first = true
             column.map(type) {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
 import org.jetbrains.kotlinx.dataframe.io.isURL
 import org.jetbrains.kotlinx.dataframe.io.readJsonStr
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.net.URL
 import java.text.NumberFormat
 import java.text.ParsePosition
@@ -60,7 +61,7 @@ internal open class DelegatedStringParser<T>(override val type: KType, val handl
             if (str in nulls) {
                 null
             } else {
-                handle(str) ?: throw TypeConversionException(it, typeOf<String>(), type, null)
+                handle(str) ?: throw TypeConversionException(it, TypeOf.STRING, type, null)
             }
         }
     }
@@ -80,7 +81,7 @@ internal class StringParserWithFormat<T>(
             if (str in nulls) {
                 null
             } else {
-                handler(str) ?: throw TypeConversionException(it, typeOf<String>(), type, null)
+                handler(str) ?: throw TypeConversionException(it, TypeOf.STRING, type, null)
             }
         }
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -1,8 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -32,9 +36,6 @@ import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.net.URL
 import java.text.NumberFormat
 import java.text.ParsePosition
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.util.Locale
@@ -44,6 +45,11 @@ import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import kotlin.time.Duration
+import java.time.Duration as JavaDuration
+import java.time.Instant as JavaInstant
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 internal interface StringParser<T> {
     fun toConverter(options: ParserOptions?): TypeConverter
@@ -133,17 +139,20 @@ internal object Parsers : GlobalParserOptions {
         resetToDefault()
     }
 
-    private fun String.toLocalDateTimeOrNull(formatter: DateTimeFormatter?): LocalDateTime? {
+    private fun String.toJavaLocalDateTimeOrNull(formatter: DateTimeFormatter?): JavaLocalDateTime? {
         if (formatter != null) {
-            return catchSilent { java.time.LocalDateTime.parse(this, formatter) }
+            return catchSilent { JavaLocalDateTime.parse(this, formatter) }
         } else {
-            catchSilent { LocalDateTime.parse(this) }?.let { return it }
+            catchSilent { JavaLocalDateTime.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { java.time.LocalDateTime.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalDateTime.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
+
+    private fun String.toLocalDateTimeOrNull(formatter: DateTimeFormatter?): LocalDateTime? =
+        toJavaLocalDateTimeOrNull(formatter)?.toKotlinLocalDateTime()
 
     private fun String.toUrlOrNull(): URL? = if (isURL(this)) catchSilent { URL(this) } else null
 
@@ -158,29 +167,35 @@ internal object Parsers : GlobalParserOptions {
             else -> null
         }
 
-    private fun String.toLocalDateOrNull(formatter: DateTimeFormatter?): LocalDate? {
+    private fun String.toJavaLocalDateOrNull(formatter: DateTimeFormatter?): JavaLocalDate? {
         if (formatter != null) {
-            return catchSilent { java.time.LocalDate.parse(this, formatter) }
+            return catchSilent { JavaLocalDate.parse(this, formatter) }
         } else {
-            catchSilent { LocalDate.parse(this) }?.let { return it }
+            catchSilent { JavaLocalDate.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { java.time.LocalDate.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalDate.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
 
-    private fun String.toLocalTimeOrNull(formatter: DateTimeFormatter?): LocalTime? {
+    private fun String.toLocalDateOrNull(formatter: DateTimeFormatter?): LocalDate? =
+        toJavaLocalDateOrNull(formatter)?.toKotlinLocalDate()
+
+    private fun String.toJavaLocalTimeOrNull(formatter: DateTimeFormatter?): JavaLocalTime? {
         if (formatter != null) {
-            return catchSilent { LocalTime.parse(this, formatter) }
+            return catchSilent { JavaLocalTime.parse(this, formatter) }
         } else {
-            catchSilent { LocalTime.parse(this) }?.let { return it }
+            catchSilent { JavaLocalTime.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { LocalTime.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalTime.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
+
+    private fun String.toLocalTimeOrNull(formatter: DateTimeFormatter?): LocalTime? =
+        toJavaLocalTimeOrNull(formatter)?.toKotlinLocalTime()
 
     private fun String.parseDouble(format: NumberFormat) =
         when (uppercase(Locale.getDefault())) {
@@ -235,39 +250,45 @@ internal object Parsers : GlobalParserOptions {
         // kotlinx.datetime.Instant
         stringParser { catchSilent { Instant.parse(it) } },
         // java.time.Instant
-        stringParser { catchSilent { java.time.Instant.parse(it) } },
+        stringParser { catchSilent { JavaInstant.parse(it) } },
         // kotlinx.datetime.LocalDateTime
-        stringParserWithOptions { options ->
-            val formatter = options?.getDateTimeFormatter()
-            val parser = { it: String -> it.toLocalDateTimeOrNull(formatter)?.toKotlinLocalDateTime() }
-            parser
-        },
-        // java.time.LocalDateTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalDateTimeOrNull(formatter) }
             parser
         },
-        // kotlinx.datetime.LocalDate
+        // java.time.LocalDateTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
-            val parser = { it: String -> it.toLocalDateOrNull(formatter)?.toKotlinLocalDate() }
+            val parser = { it: String -> it.toJavaLocalDateTimeOrNull(formatter) }
             parser
         },
-        // java.time.LocalDate
+        // kotlinx.datetime.LocalDate
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalDateOrNull(formatter) }
             parser
         },
+        // java.time.LocalDate
+        stringParserWithOptions { options ->
+            val formatter = options?.getDateTimeFormatter()
+            val parser = { it: String -> it.toJavaLocalDateOrNull(formatter) }
+            parser
+        },
         // kotlin.time.Duration
         stringParser { catchSilent { Duration.parse(it) } },
         // java.time.Duration
-        stringParser { catchSilent { java.time.Duration.parse(it) } },
-        // java.time.LocalTime
+        stringParser { catchSilent { JavaDuration.parse(it) } },
+        // kotlinx.datetime.LocalTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalTimeOrNull(formatter) }
+            parser
+        },
+        // java.time.LocalTime
+        stringParserWithOptions { options ->
+            val formatter = options?.getDateTimeFormatter()
+            val parser = { it: String -> it.toJavaLocalTimeOrNull(formatter) }
             parser
         },
         // java.net.URL

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/reorder.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/reorder.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnExpression
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -19,7 +18,7 @@ import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.tree.ColumnPosition
 import org.jetbrains.kotlinx.dataframe.impl.columns.tree.TreeNode
-import kotlin.reflect.typeOf
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 
 internal fun <T, C, V : Comparable<V>> Reorder<T, C>.reorderImpl(
     desc: Boolean,
@@ -62,7 +61,7 @@ internal fun <T, C, V : Comparable<V>> Reorder<T, C>.reorderImpl(
                 var column = c.column
                 if (inFrameColumns && column.isFrameColumn()) {
                     column = column.asAnyFrameColumn()
-                        .map(typeOf<AnyFrame>()) { it.cast<T>().reorder(columns).reorderImpl(desc, expression) }
+                        .map(TypeOf.ANY_FRAME) { it.cast<T>().reorder(columns).reorderImpl(desc, expression) }
                         .cast()
                 }
                 ColumnToInsert(path, column, src.treeNode)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlinx.dataframe.impl.isArray
 import org.jetbrains.kotlinx.dataframe.impl.isGetterLike
 import org.jetbrains.kotlinx.dataframe.impl.projectUpTo
 import org.jetbrains.kotlinx.dataframe.impl.schema.sortWithConstructor
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.time.temporal.Temporal
@@ -35,7 +36,6 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
-import kotlin.reflect.typeOf
 
 private val valueTypes = setOf(
     String::class,
@@ -245,7 +245,7 @@ internal fun convertToDataFrame(
             if (type.classifier is KClass<*>) {
                 type
             } else {
-                typeOf<Any>()
+                TypeOf.ANY
             }
         }
         val kClass = returnType.classifier as KClass<*>

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readJson.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readJson.kt
@@ -56,6 +56,7 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.jetbrains.kotlinx.dataframe.values
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
@@ -363,7 +364,7 @@ internal fun fromJsonListAnyColumns(
                         schema = lazy {
                             DataFrameSchemaImpl(
                                 columns = mapOf(
-                                    KeyValueProperty<*>::key.name to ColumnSchema.Value(typeOf<String>()),
+                                    KeyValueProperty<*>::key.name to ColumnSchema.Value(TypeOf.STRING),
                                     KeyValueProperty<*>::value.name to valueColumnSchema,
                                 ),
                             )

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/Utils.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlinx.dataframe.impl.isGetterLike
 import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
@@ -55,7 +56,7 @@ internal fun Iterable<DataFrameSchema>.intersectSchemas(): DataFrameSchema {
         val columnKinds = columnSchemas.map { it.kind }.distinct()
         val kind = columnKinds.first()
         when {
-            columnKinds.size > 1 -> ColumnSchema.Value(typeOf<Any>().withNullability(columnSchemas.any { it.nullable }))
+            columnKinds.size > 1 -> ColumnSchema.Value(TypeOf.ANY.withNullability(columnSchemas.any { it.nullable }))
 
             kind == ColumnKind.Value -> ColumnSchema.Value(
                 type = columnSchemas

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlinx.dataframe.codeGen.DefaultReadDfMethod
 import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
 import org.jetbrains.kotlinx.dataframe.impl.api.Parsers
 import org.jetbrains.kotlinx.dataframe.impl.api.parse
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.jetbrains.kotlinx.dataframe.values
 import java.io.BufferedInputStream
 import java.io.BufferedReader
@@ -40,7 +41,6 @@ import java.time.LocalTime
 import java.util.zip.GZIPInputStream
 import kotlin.reflect.KClass
 import kotlin.reflect.full.withNullability
-import kotlin.reflect.typeOf
 
 public class CSV(private val delimiter: Char = ',') : SupportedDataFrameFormat {
     override fun readDataFrame(stream: InputStream, header: List<String>): AnyFrame =
@@ -56,7 +56,7 @@ public class CSV(private val delimiter: Char = ',') : SupportedDataFrameFormat {
     override val testOrder: Int = 20000
 
     override fun createDefaultReadMethod(pathRepresentation: String?): DefaultReadDfMethod {
-        val arguments = MethodArguments().add("delimiter", typeOf<Char>(), "'%L'", delimiter)
+        val arguments = MethodArguments().add("delimiter", TypeOf.CHAR, "'%L'", delimiter)
         return DefaultReadCsvMethod(pathRepresentation, arguments)
     }
 }
@@ -365,7 +365,7 @@ public fun DataFrame.Companion.readDelim(
                 null
             }
         }
-        val column = DataColumn.createValueColumn(colName, values, typeOf<String>().withNullability(hasNulls))
+        val column = DataColumn.createValueColumn(colName, values, TypeOf.STRING.withNullability(hasNulls))
         when (colType) {
             null -> column.tryParse(parserOptions)
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVRecord
 import org.apache.commons.io.input.BOMInputStream
@@ -35,9 +38,6 @@ import java.io.StringWriter
 import java.math.BigDecimal
 import java.net.URL
 import java.nio.charset.Charset
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.util.zip.GZIPInputStream
 import kotlin.reflect.KClass
 import kotlin.reflect.full.withNullability

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -56,6 +56,8 @@ public class JSON(
 
     override val testOrder: Int = 10_000
 
+    private val typeClashTacticType = typeOf<TypeClashTactic>()
+
     override fun createDefaultReadMethod(pathRepresentation: String?): DefaultReadDfMethod =
         DefaultReadJsonMethod(
             path = pathRepresentation,
@@ -71,7 +73,7 @@ public class JSON(
                 )
                 .add(
                     "typeClashTactic",
-                    typeOf<TypeClashTactic>(),
+                    typeClashTacticType,
                     "org.jetbrains.kotlinx.dataframe.io.JSON.TypeClashTactic.${typeClashTactic.name}",
                 ),
         )

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchema.kt
@@ -5,10 +5,10 @@ import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.isSupertypeOf
-import kotlin.reflect.typeOf
 
 public abstract class ColumnSchema {
 
@@ -53,7 +53,7 @@ public abstract class ColumnSchema {
 
         /** A column group is never null, instead, make the columns inside nullable. */
         override val nullable: Boolean = false
-        override val type: KType get() = typeOf<AnyRow>()
+        override val type: KType get() = TypeOf.ANY_ROW
 
         public fun compare(other: Group): CompareResult = schema.compare(other.schema)
     }
@@ -64,7 +64,7 @@ public abstract class ColumnSchema {
         override val contentType: KType?,
     ) : ColumnSchema() {
         public override val kind: ColumnKind = ColumnKind.Frame
-        override val type: KType get() = typeOf<AnyFrame>()
+        override val type: KType get() = TypeOf.ANY_FRAME
 
         public fun compare(other: Frame): CompareResult =
             schema.compare(other.schema).combine(CompareResult.compareNullability(nullable, other.nullable))

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/kTypes.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/kTypes.kt
@@ -1,0 +1,69 @@
+package org.jetbrains.kotlinx.dataframe.util
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.AnyRow
+import org.jetbrains.kotlinx.dataframe.dataTypes.IMG
+import java.math.BigDecimal
+import java.net.URL
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+public object TypeOf {
+    public val STRING: KType by lazy { typeOf<String>() }
+    public val BOOLEAN: KType by lazy { typeOf<Boolean>() }
+    public val BYTE: KType by lazy { typeOf<Byte>() }
+    public val SHORT: KType by lazy { typeOf<Short>() }
+    public val INT: KType by lazy { typeOf<Int>() }
+    public val LONG: KType by lazy { typeOf<Long>() }
+    public val FLOAT: KType by lazy { typeOf<Float>() }
+    public val DOUBLE: KType by lazy { typeOf<Double>() }
+    public val CHAR: KType by lazy { typeOf<Char>() }
+    public val UBYTE: KType by lazy { typeOf<UByte>() }
+    public val USHORT: KType by lazy { typeOf<UShort>() }
+    public val UINT: KType by lazy { typeOf<UInt>() }
+    public val ULONG: KType by lazy { typeOf<ULong>() }
+    public val ANY: KType by lazy { typeOf<Any>() }
+    public val UNIT: KType by lazy { typeOf<Unit>() }
+    public val NUMBER: KType by lazy { typeOf<Number>() }
+    public val BIG_DECIMAL: KType by lazy { typeOf<BigDecimal>() }
+    public val ANY_FRAME: KType by lazy { typeOf<AnyFrame>() }
+    public val ANY_ROW: KType by lazy { typeOf<AnyRow>() }
+    public val LIST_ANY_FRAME: KType by lazy { typeOf<List<AnyFrame>>() }
+    public val LOCAL_DATE: KType by lazy { typeOf<LocalDate>() }
+    public val LOCAL_DATE_TIME: KType by lazy { typeOf<LocalDateTime>() }
+    public val LOCAL_TIME: KType by lazy { typeOf<LocalTime>() }
+    public val INSTANT: KType by lazy { typeOf<Instant>() }
+    public val URL: KType by lazy { typeOf<URL>() }
+    public val IMG: KType by lazy { typeOf<IMG>() }
+    public val NOTHING: KType by lazy { typeOf<List<Nothing>>().arguments.first().type!! }
+    public val NULLABLE_STRING: KType by lazy { typeOf<String?>() }
+    public val NULLABLE_BOOLEAN: KType by lazy { typeOf<Boolean?>() }
+    public val NULLABLE_BYTE: KType by lazy { typeOf<Byte?>() }
+    public val NULLABLE_SHORT: KType by lazy { typeOf<Short?>() }
+    public val NULLABLE_INT: KType by lazy { typeOf<Int?>() }
+    public val NULLABLE_LONG: KType by lazy { typeOf<Long?>() }
+    public val NULLABLE_FLOAT: KType by lazy { typeOf<Float?>() }
+    public val NULLABLE_DOUBLE: KType by lazy { typeOf<Double?>() }
+    public val NULLABLE_CHAR: KType by lazy { typeOf<Char?>() }
+    public val NULLABLE_UBYTE: KType by lazy { typeOf<UByte?>() }
+    public val NULLABLE_USHORT: KType by lazy { typeOf<UShort?>() }
+    public val NULLABLE_UINT: KType by lazy { typeOf<UInt?>() }
+    public val NULLABLE_ULONG: KType by lazy { typeOf<ULong?>() }
+    public val NULLABLE_ANY: KType by lazy { typeOf<Any?>() }
+    public val NULLABLE_NUMBER: KType by lazy { typeOf<Number?>() }
+    public val NULLABLE_BIG_DECIMAL: KType by lazy { typeOf<BigDecimal?>() }
+    public val NULLABLE_ANY_FRAME: KType by lazy { typeOf<AnyFrame?>() }
+    public val NULLABLE_ANY_ROW: KType by lazy { typeOf<AnyRow?>() }
+    public val NULLABLE_LIST_ANY_FRAME: KType by lazy { typeOf<List<AnyFrame>?>() }
+    public val NULLABLE_LOCAL_DATE: KType by lazy { typeOf<LocalDate?>() }
+    public val NULLABLE_LOCAL_DATE_TIME: KType by lazy { typeOf<LocalDateTime?>() }
+    public val NULLABLE_LOCAL_TIME: KType by lazy { typeOf<LocalTime?>() }
+    public val NULLABLE_INSTANT: KType by lazy { typeOf<Instant?>() }
+    public val NULLABLE_URL: KType by lazy { typeOf<URL?>() }
+    public val NULLABLE_IMG: KType by lazy { typeOf<IMG?>() }
+    public val NULLABLE_NOTHING: KType by lazy { typeOf<List<Nothing?>>().arguments.first().type!! }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
@@ -5,8 +5,8 @@ import org.jetbrains.kotlinx.dataframe.samples.api.city
 import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class ColsOfTests : ColumnsSelectionDslTests() {
 
@@ -31,12 +31,12 @@ class ColsOfTests : ColumnsSelectionDslTests() {
             df.select { name { firstName and lastName } },
             df.select { name.colsOf<String>() },
             df.select { name.colsOf<String> { "Name" in it.name } },
-            df.select { "name".colsOf<String>(typeOf<String>()) },
-            df.select { "name".colsOf<String>(typeOf<String>()) { "Name" in it.name } },
-            df.select { Person::name.colsOf<String>(typeOf<String>()) },
-            df.select { Person::name.colsOf<String>(typeOf<String>()) { "Name" in it.name } },
-            df.select { pathOf("name").colsOf<String>(typeOf<String>()) },
-            df.select { pathOf("name").colsOf<String>(typeOf<String>()) { "Name" in it.name } },
+            df.select { "name".colsOf<String>(TypeOf.STRING) },
+            df.select { "name".colsOf<String>(TypeOf.STRING) { "Name" in it.name } },
+            df.select { Person::name.colsOf<String>(TypeOf.STRING) },
+            df.select { Person::name.colsOf<String>(TypeOf.STRING) { "Name" in it.name } },
+            df.select { pathOf("name").colsOf<String>(TypeOf.STRING) },
+            df.select { pathOf("name").colsOf<String>(TypeOf.STRING) { "Name" in it.name } },
         ).shouldAllBeEqual()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalTime
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
@@ -14,7 +15,6 @@ import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.hasNulls
 import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import java.time.LocalTime
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.hours
 
@@ -25,7 +25,7 @@ class ConvertTests {
         val time by columnOf("11?22?33", null)
         val converted = time.toDataFrame().convert { time }.toLocalTime("HH?mm?ss")[time]
         converted.hasNulls shouldBe true
-        converted[0] shouldBe LocalTime.of(11, 22, 33)
+        converted[0] shouldBe LocalTime(11, 22, 33)
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.exceptions.CellConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.hasNulls
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.time.LocalTime
 import kotlin.reflect.typeOf
@@ -98,7 +99,7 @@ class ConvertTests {
     fun `convert from value class exceptions`() {
         shouldThrow<TypeConversionException> {
             columnOf(StringClass("a")).convertTo<Int>()
-        }.from shouldBe typeOf<String>()
+        }.from shouldBe TypeOf.STRING
 
         shouldThrow<TypeConverterNotFoundException> {
             columnOf(IntClass(1)).convertTo<EnumClass>()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -11,8 +11,8 @@ import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.kind
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class ConvertToTests {
@@ -31,7 +31,7 @@ class ConvertToTests {
         val converted = df.convertTo<DataFrameSchema>()
 
         converted[groups].forEach {
-            it["a"].type() shouldBe typeOf<Int>()
+            it["a"].type() shouldBe TypeOf.INT
         }
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/emptyDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/emptyDataFrame.kt
@@ -3,8 +3,8 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class EmptyDataFrameTests {
 
@@ -39,10 +39,10 @@ class EmptyDataFrameTests {
             rowsCount() shouldBe 0
             columnsCount() shouldBe 3
             columnNames() shouldBe listOf("a", "group", "frame")
-            get("a").type() shouldBe typeOf<Int>()
+            get("a").type() shouldBe TypeOf.INT
             getColumnGroup("group").let {
                 it.columnNames() shouldBe listOf("c", "d")
-                it["c"].type() shouldBe typeOf<Int>()
+                it["c"].type() shouldBe TypeOf.INT
             }
             getFrameColumn("frame").let {
                 it.schema.value.columns.keys shouldBe listOf("e")

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
@@ -2,8 +2,8 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.samples.api.age
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class ExprTests : ColumnsSelectionDslTests() {
 
@@ -28,17 +28,17 @@ class ExprTests : ColumnsSelectionDslTests() {
             }.toList() shouldBe listOf(1, 1, 2, 3, 5, 8, 13)
 
         df.select {
-            expr<_, Int?>(infer = Infer.None) { 1 }.type() shouldBe typeOf<Int?>()
-            expr<_, Int>(infer = Infer.None) { 1 }.type() shouldBe typeOf<Int>()
-            expr<_, Any?>(infer = Infer.None) { 1 }.type() shouldBe typeOf<Any?>()
+            expr<_, Int?>(infer = Infer.None) { 1 }.type() shouldBe TypeOf.NULLABLE_INT
+            expr<_, Int>(infer = Infer.None) { 1 }.type() shouldBe TypeOf.INT
+            expr<_, Any?>(infer = Infer.None) { 1 }.type() shouldBe TypeOf.NULLABLE_ANY
 
-            expr<_, Int?>(infer = Infer.Nulls) { 1 }.type() shouldBe typeOf<Int>()
-            expr<_, Int>(infer = Infer.Nulls) { 1 }.type() shouldBe typeOf<Int>()
-            expr<_, Any?>(infer = Infer.Nulls) { 1 }.type() shouldBe typeOf<Any>()
+            expr<_, Int?>(infer = Infer.Nulls) { 1 }.type() shouldBe TypeOf.INT
+            expr<_, Int>(infer = Infer.Nulls) { 1 }.type() shouldBe TypeOf.INT
+            expr<_, Any?>(infer = Infer.Nulls) { 1 }.type() shouldBe TypeOf.ANY
 
-            expr<_, Int?>(infer = Infer.Type) { 1 }.type() shouldBe typeOf<Int>()
-            expr<_, Int>(infer = Infer.Type) { 1 }.type() shouldBe typeOf<Int>()
-            expr<_, Any?>(infer = Infer.Type) { 1 }.type() shouldBe typeOf<Int>()
+            expr<_, Int?>(infer = Infer.Type) { 1 }.type() shouldBe TypeOf.INT
+            expr<_, Int>(infer = Infer.Type) { 1 }.type() shouldBe TypeOf.INT
+            expr<_, Any?>(infer = Infer.Type) { 1 }.type() shouldBe TypeOf.INT
 
             none()
         }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.io.readJsonStr
 import org.jetbrains.kotlinx.dataframe.kind
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class GatherTests {
@@ -152,7 +152,7 @@ class GatherTests {
             .gather { a and b }
             .into("key", "value")
 
-        gathered["value"].type() shouldBe typeOf<Int>()
+        gathered["value"].type() shouldBe TypeOf.INT
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/inferType.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/inferType.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import kotlin.reflect.typeOf
 
@@ -12,7 +13,7 @@ class InferTypeTests {
         col.type() shouldBe typeOf<Comparable<*>>()
         val filtered = col.filter { it is String }
         filtered.type() shouldBe typeOf<Comparable<*>>()
-        filtered.inferType().type() shouldBe typeOf<String>()
+        filtered.inferType().type() shouldBe TypeOf.STRING
     }
 
     open class A<T>(val value: T)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -1,16 +1,15 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.time.LocalTime
 import java.time.Month
 import java.util.Locale
-import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -27,7 +26,7 @@ class ParseTests {
 
             val parsed = date.parse(ParserOptions(dateTimePattern = pattern)).cast<LocalDate>()
 
-            parsed.type() shouldBe typeOf<LocalDate>()
+            parsed.type() shouldBe TypeOf.LOCAL_DATE
             with(parsed[0]) {
                 month shouldBe Month.JANUARY
                 dayOfMonth shouldBe 1
@@ -62,7 +61,7 @@ class ParseTests {
 
             val parsed = dateTime.parse(ParserOptions(dateTimePattern = pattern, locale = locale)).cast<LocalDateTime>()
 
-            parsed.type() shouldBe typeOf<LocalDateTime>()
+            parsed.type() shouldBe TypeOf.LOCAL_DATE_TIME
             with(parsed[0]) {
                 month shouldBe Month.JUNE
                 dayOfMonth shouldBe 3
@@ -96,7 +95,7 @@ class ParseTests {
 
         val parsed = time.parse(ParserOptions(dateTimePattern = pattern)).cast<LocalTime>()
 
-        parsed.type() shouldBe typeOf<LocalTime>()
+        parsed.type() shouldBe TypeOf.LOCAL_TIME
         with(parsed[0]) {
             hour shouldBe 13
             minute shouldBe 5
@@ -121,7 +120,7 @@ class ParseTests {
         val time by columnOf(" 2020-01-06", "2020-01-07 ")
         val df = dataFrameOf(time)
         val casted = df.convert(time).toLocalDate()
-        casted[time].type() shouldBe typeOf<LocalDate>()
+        casted[time].type() shouldBe TypeOf.LOCAL_DATE
     }
 
     @Test
@@ -136,10 +135,10 @@ class ParseTests {
 
     @Test
     fun `parse instant`() {
-        columnOf("2022-01-23T04:29:40Z").parse().type shouldBe typeOf<Instant>()
-        columnOf("2022-01-23T04:29:40+01:00").parse().type shouldBe typeOf<Instant>()
+        columnOf("2022-01-23T04:29:40Z").parse().type shouldBe TypeOf.INSTANT
+        columnOf("2022-01-23T04:29:40+01:00").parse().type shouldBe TypeOf.INSTANT
 
-        columnOf("2022-01-23T04:29:40").parse().type shouldBe typeOf<LocalDateTime>()
+        columnOf("2022-01-23T04:29:40").parse().type shouldBe TypeOf.LOCAL_DATE_TIME
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -3,12 +3,12 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import java.time.LocalTime
-import java.time.Month
 import java.util.Locale
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
@@ -2,8 +2,8 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.impl.commonType
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class PivotTests {
@@ -46,7 +46,7 @@ class PivotTests {
         val cols = pivoted.getColumns { allExcept(a).colsAtAnyDepth { !it.isColumnGroup() } }
         cols.size shouldBe 4
         cols.forEach {
-            it.type() shouldBe typeOf<Char>()
+            it.type() shouldBe TypeOf.CHAR
         }
         pivoted["w"]["first"][0] shouldBe '-'
         pivoted["w"]["last"][0] shouldBe '?'
@@ -184,6 +184,6 @@ class PivotTests {
             .groupBy("name")
             .default(0)
             .min()
-        pivoted["city"]["London"]["isHappy"].type() shouldBe listOf(typeOf<Int>(), typeOf<Boolean>()).commonType()
+        pivoted["city"]["London"]["isHappy"].type() shouldBe listOf(TypeOf.INT, TypeOf.BOOLEAN).commonType()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class ReplaceTests {
 
@@ -11,6 +11,6 @@ class ReplaceTests {
         val df = dataFrameOf("a")(1)
         val conv = df.replace { "a"<Int>() named "b" }.with { it.convertToDouble() }
         conv.columnNames() shouldBe listOf("b")
-        conv.columnTypes() shouldBe listOf(typeOf<Double>())
+        conv.columnTypes() shouldBe listOf(TypeOf.DOUBLE)
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -6,8 +6,8 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.hasNulls
 import org.jetbrains.kotlinx.dataframe.impl.DataRowImpl
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class SplitTests {
@@ -47,7 +47,7 @@ class SplitTests {
             .parse()
         split.schema().print()
         split["title"].hasNulls shouldBe false
-        split["year"].type shouldBe typeOf<Int>()
+        split["year"].type shouldBe TypeOf.INT
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.kind
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Ignore
 import org.junit.Test
 import java.io.File
@@ -39,7 +40,7 @@ class CreateDataFrameTests {
         val df = listOf(Data()).toDataFrame()
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 1
-        df.columnTypes() shouldBe listOf(typeOf<IllegalStateException>(), typeOf<Int>())
+        df.columnTypes() shouldBe listOf(typeOf<IllegalStateException>(), TypeOf.INT)
         (df["a"][0] is IllegalStateException) shouldBe true
         df["b"][0] shouldBe 1
     }
@@ -55,11 +56,11 @@ class CreateDataFrameTests {
             "e" from { if (true) it else null }
         }
         res["a"].kind shouldBe ColumnKind.Value
-        res["a"].type() shouldBe typeOf<Int>()
+        res["a"].type() shouldBe TypeOf.INT
         res["b"].kind shouldBe ColumnKind.Frame
         res["c"].kind shouldBe ColumnKind.Group
-        res["d"].type() shouldBe typeOf<Int?>()
-        res["e"].type() shouldBe typeOf<Int>()
+        res["d"].type() shouldBe TypeOf.NULLABLE_INT
+        res["e"].type() shouldBe TypeOf.INT
     }
 
     @Test
@@ -70,10 +71,10 @@ class CreateDataFrameTests {
             expr(infer = Infer.Type) { it } into "d"
         }
 
-        res["e"].type() shouldBe typeOf<Int>()
+        res["e"].type() shouldBe TypeOf.INT
         res["e"].kind() shouldBe ColumnKind.Value
 
-        res["d"].type() shouldBe typeOf<Int>()
+        res["d"].type() shouldBe TypeOf.INT
         res["d"].kind() shouldBe ColumnKind.Value
     }
 
@@ -217,8 +218,8 @@ class CreateDataFrameTests {
         val df = functions.toDataFrame(maxDepth = 2)
 
         val col = df.getColumnGroup(DeserializedContainerSource::incompatibility)
-        col[IncompatibleVersionErrorData<*>::actual].type() shouldBe typeOf<Any>()
-        col[IncompatibleVersionErrorData<*>::expected].type() shouldBe typeOf<Any>()
+        col[IncompatibleVersionErrorData<*>::actual].type() shouldBe TypeOf.ANY
+        col[IncompatibleVersionErrorData<*>::expected].type() shouldBe TypeOf.ANY
     }
 
     interface Named {
@@ -388,10 +389,10 @@ class CreateDataFrameTests {
         // cannot read java constructor parameter names with reflection, so sort lexicographically
         listOf(JavaPojo(2.0, null, "bb", 1)).toDataFrame() shouldBe
             dataFrameOf(
-                DataColumn.createValueColumn("a", listOf(1), typeOf<Int>()),
-                DataColumn.createValueColumn("b", listOf("bb"), typeOf<String>()),
-                DataColumn.createValueColumn("c", listOf(null), typeOf<Int?>()),
-                DataColumn.createValueColumn("d", listOf(2.0), typeOf<Number>()),
+                DataColumn.createValueColumn("a", listOf(1), TypeOf.INT),
+                DataColumn.createValueColumn("b", listOf("bb"), TypeOf.STRING),
+                DataColumn.createValueColumn("c", listOf(null), TypeOf.NULLABLE_INT),
+                DataColumn.createValueColumn("d", listOf(2.0), TypeOf.NUMBER),
             )
 
         listOf(KotlinPojo("bb", 1)).toDataFrame { properties(KotlinPojo::getA) } shouldBe

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/CsvTests.kt
@@ -3,7 +3,6 @@ package org.jetbrains.kotlinx.dataframe.io
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.LocalDateTime
 import org.apache.commons.csv.CSVFormat
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ParserOptions
@@ -20,13 +19,12 @@ import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.testCsv
 import org.jetbrains.kotlinx.dataframe.testResource
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.io.File
 import java.io.StringWriter
-import java.net.URL
 import java.util.Locale
 import kotlin.reflect.KClass
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class CsvTests {
@@ -42,9 +40,9 @@ class CsvTests {
         val df = DataFrame.readDelimStr(src)
         df.nrow shouldBe 2
         df.ncol shouldBe 2
-        df["first"].type() shouldBe typeOf<Int>()
+        df["first"].type() shouldBe TypeOf.INT
         df["second"].allNulls() shouldBe true
-        df["second"].type() shouldBe typeOf<String?>()
+        df["second"].type() shouldBe TypeOf.NULLABLE_STRING
     }
 
     @Test
@@ -70,9 +68,9 @@ class CsvTests {
         df.nrow shouldBe 5
         df.columnNames()[5] shouldBe "duplicate1"
         df.columnNames()[6] shouldBe "duplicate11"
-        df["duplicate1"].type() shouldBe typeOf<String?>()
-        df["double"].type() shouldBe typeOf<Double?>()
-        df["time"].type() shouldBe typeOf<LocalDateTime>()
+        df["duplicate1"].type() shouldBe TypeOf.NULLABLE_STRING
+        df["double"].type() shouldBe TypeOf.NULLABLE_DOUBLE
+        df["time"].type() shouldBe TypeOf.LOCAL_DATE_TIME
 
         println(df)
     }
@@ -89,10 +87,10 @@ class CsvTests {
         df.nrow shouldBe 5
         df.columnNames()[5] shouldBe "duplicate1"
         df.columnNames()[6] shouldBe "duplicate11"
-        df["duplicate1"].type() shouldBe typeOf<String?>()
-        df["double"].type() shouldBe typeOf<Double?>()
-        df["number"].type() shouldBe typeOf<Double>()
-        df["time"].type() shouldBe typeOf<LocalDateTime>()
+        df["duplicate1"].type() shouldBe TypeOf.NULLABLE_STRING
+        df["double"].type() shouldBe TypeOf.NULLABLE_DOUBLE
+        df["number"].type() shouldBe TypeOf.DOUBLE
+        df["time"].type() shouldBe TypeOf.LOCAL_DATE_TIME
 
         println(df)
     }
@@ -140,7 +138,7 @@ class CsvTests {
         val header = ('A'..'K').map { it.toString() }
         val df = DataFrame.readCSV(simpleCsv, header = header, skipLines = 1)
         df.columnNames() shouldBe header
-        df["B"].type() shouldBe typeOf<Int>()
+        df["B"].type() shouldBe TypeOf.INT
 
         val headerShort = ('A'..'E').map { it.toString() }
         val dfShort = DataFrame.readCSV(simpleCsv, header = headerShort, skipLines = 1)
@@ -178,8 +176,8 @@ class CsvTests {
     @Test
     fun `if string starts with a number, it should be parsed as a string anyway`() {
         val df = DataFrame.readCSV(durationCsv)
-        df["duration"].type() shouldBe typeOf<String>()
-        df["floatDuration"].type() shouldBe typeOf<String>()
+        df["duration"].type() shouldBe TypeOf.STRING
+        df["floatDuration"].type() shouldBe TypeOf.STRING
     }
 
     @Test
@@ -261,8 +259,7 @@ class CsvTests {
     fun `check integrity of example data`() {
         val df = DataFrame.readCSV("../data/jetbrains_repositories.csv")
         df.columnNames() shouldBe listOf("full_name", "html_url", "stargazers_count", "topics", "watchers")
-        df.columnTypes() shouldBe
-            listOf(typeOf<String>(), typeOf<URL>(), typeOf<Int>(), typeOf<String>(), typeOf<Int>())
+        df.columnTypes() shouldBe listOf(TypeOf.STRING, TypeOf.URL, TypeOf.INT, TypeOf.STRING, TypeOf.INT)
         df shouldBe DataFrame.readCSV("../data/jetbrains repositories.csv")
     }
 
@@ -301,7 +298,7 @@ class CsvTests {
         emptyCsvFileManualHeader.apply {
             isEmpty() shouldBe true
             columnNames() shouldBe listOf("a", "b", "c")
-            columnTypes() shouldBe listOf(typeOf<String>(), typeOf<String>(), typeOf<String>())
+            columnTypes() shouldBe listOf(TypeOf.STRING, TypeOf.STRING, TypeOf.STRING)
         }
 
         val emptyCsvFileWithHeader = DataFrame.readCSV(
@@ -310,7 +307,7 @@ class CsvTests {
         emptyCsvFileWithHeader.apply {
             isEmpty() shouldBe true
             columnNames() shouldBe listOf("a", "b", "c")
-            columnTypes() shouldBe listOf(typeOf<String>(), typeOf<String>(), typeOf<String>())
+            columnTypes() shouldBe listOf(TypeOf.STRING, TypeOf.STRING, TypeOf.STRING)
         }
 
         val emptyTsvStr = DataFrame.readTSV(File.createTempFile("empty", "tsv"))

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.io
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -24,7 +25,6 @@ import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.math.BigDecimal
-import java.time.LocalTime
 import java.util.Locale
 
 class ParserTests {
@@ -106,9 +106,9 @@ class ParserTests {
         )
         longCol.convertToLocalTime(TimeZone.UTC).shouldBe(
             columnOf(
-                LocalTime.of(0, 0, 1),
-                LocalTime.of(0, 1, 0),
-                LocalTime.of(1, 0, 0),
+                LocalTime(0, 0, 1),
+                LocalTime(0, 1, 0),
+                LocalTime(1, 0, 0),
             ),
         )
 
@@ -121,9 +121,9 @@ class ParserTests {
         )
         datetimeCol.convertToLocalTime().shouldBe(
             columnOf(
-                LocalTime.of(0, 0, 1),
-                LocalTime.of(0, 1, 0),
-                LocalTime.of(1, 0, 0),
+                LocalTime(0, 0, 1),
+                LocalTime(0, 1, 0),
+                LocalTime(1, 0, 0),
             ),
         )
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
@@ -21,21 +21,21 @@ import org.jetbrains.kotlinx.dataframe.api.plus
 import org.jetbrains.kotlinx.dataframe.api.times
 import org.jetbrains.kotlinx.dataframe.api.tryParse
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.math.BigDecimal
 import java.time.LocalTime
 import java.util.Locale
-import kotlin.reflect.typeOf
 
 class ParserTests {
 
     @Test
     fun `parse datetime with custom format`() {
         val col by columnOf("04.02.2021 -- 19:44:32")
-        col.tryParse().type() shouldBe typeOf<String>()
+        col.tryParse().type() shouldBe TypeOf.STRING
         DataFrame.parser.addDateTimePattern("dd.MM.uuuu -- HH:mm:ss")
         val parsed = col.parse()
-        parsed.type() shouldBe typeOf<LocalDateTime>()
+        parsed.type() shouldBe TypeOf.LOCAL_DATE_TIME
         parsed.cast<LocalDateTime>()[0].year shouldBe 2021
         DataFrame.parser.resetToDefault()
     }
@@ -62,7 +62,7 @@ class ParserTests {
     fun `convert mixed column`() {
         val col by columnOf(1.0, "1")
         val converted = col.convertTo<Int>()
-        converted.type() shouldBe typeOf<Int>()
+        converted.type() shouldBe TypeOf.INT
         converted[0] shouldBe 1
         converted[1] shouldBe 1
     }
@@ -71,7 +71,7 @@ class ParserTests {
     fun `convert BigDecimal column`() {
         val col by columnOf(BigDecimal(1.0), BigDecimal(0.321))
         val converted = col.convertTo<Float>()
-        converted.type() shouldBe typeOf<Float>()
+        converted.type() shouldBe TypeOf.FLOAT
         converted[0] shouldBe 1.0f
         converted[1] shouldBe 0.321f
     }
@@ -80,7 +80,7 @@ class ParserTests {
     fun `convert to Boolean`() {
         val col by columnOf(BigDecimal(1.0), BigDecimal(0.0), 0, 1, 10L, 0.0, 0.1)
         col.convertTo<Boolean>().shouldBe(
-            DataColumn.createValueColumn("col", listOf(true, false, false, true, true, false, true), typeOf<Boolean>()),
+            DataColumn.createValueColumn("col", listOf(true, false, false, true, true, false, true), TypeOf.BOOLEAN),
         )
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/PlaylistJsonTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/PlaylistJsonTest.kt
@@ -19,8 +19,8 @@ import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.dataTypes.IMG
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class PlaylistJsonTest {
 
@@ -118,20 +118,20 @@ class PlaylistJsonTest {
     @Test
     fun `deep update`() {
         val updated = item.convert { snippet.thumbnails.default.url }.with { IMG(it) }
-        updated.snippet.thumbnails.default.url.type() shouldBe typeOf<IMG>()
+        updated.snippet.thumbnails.default.url.type() shouldBe TypeOf.IMG
     }
 
     @Test
     fun `deep update group`() {
         val updated = item.convert { snippet.thumbnails.default }.with { it.url }
-        updated.snippet.thumbnails["default"].type() shouldBe typeOf<String>()
+        updated.snippet.thumbnails["default"].type() shouldBe TypeOf.STRING
     }
 
     @Test
     fun `deep batch update`() {
         val updated = item.convert { snippet.thumbnails.default.url and snippet.thumbnails.high.url }.with { IMG(it) }
-        updated.snippet.thumbnails.default.url.type() shouldBe typeOf<IMG>()
-        updated.snippet.thumbnails.high.url.type() shouldBe typeOf<IMG>()
+        updated.snippet.thumbnails.default.url.type() shouldBe TypeOf.IMG
+        updated.snippet.thumbnails.high.url.type() shouldBe TypeOf.IMG
     }
 
     @Test
@@ -139,11 +139,11 @@ class PlaylistJsonTest {
         val updated = item
             .convert { colsAtAnyDepth { it.name() == "url" } }
             .with { (it as? String)?.let { IMG(it) } }
-        updated.snippet.thumbnails.default.url.type() shouldBe typeOf<IMG>()
-        updated.snippet.thumbnails.maxres.url.type() shouldBe typeOf<IMG?>()
-        updated.snippet.thumbnails.standard.url.type() shouldBe typeOf<IMG?>()
-        updated.snippet.thumbnails.medium.url.type() shouldBe typeOf<IMG>()
-        updated.snippet.thumbnails.high.url.type() shouldBe typeOf<IMG>()
+        updated.snippet.thumbnails.default.url.type() shouldBe TypeOf.IMG
+        updated.snippet.thumbnails.maxres.url.type() shouldBe TypeOf.NULLABLE_IMG
+        updated.snippet.thumbnails.standard.url.type() shouldBe TypeOf.NULLABLE_IMG
+        updated.snippet.thumbnails.medium.url.type() shouldBe TypeOf.IMG
+        updated.snippet.thumbnails.high.url.type() shouldBe TypeOf.IMG
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ReadTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ReadTests.kt
@@ -14,8 +14,8 @@ import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class ReadTests {
 
@@ -105,6 +105,6 @@ class ReadTests {
         df.rowsCount() shouldBe 2
         df.columnsCount() shouldBe 3
         df.columnNames() shouldBe header
-        df.columnTypes() shouldBe List(3) { typeOf<Int>() }
+        df.columnTypes() shouldBe List(3) { TypeOf.INT }
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -35,7 +35,6 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
-import org.jetbrains.kotlinx.dataframe.get
 import org.jetbrains.kotlinx.dataframe.impl.io.SERIALIZATION_VERSION
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.COLUMNS
 import org.jetbrains.kotlinx.dataframe.impl.io.SerializationKeys.DATA
@@ -52,6 +51,7 @@ import org.jetbrains.kotlinx.dataframe.io.JSON.TypeClashTactic.ARRAY_AND_VALUE_C
 import org.jetbrains.kotlinx.dataframe.parseJsonStr
 import org.jetbrains.kotlinx.dataframe.testJson
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.jetbrains.kotlinx.dataframe.values
 import org.junit.Test
 import kotlin.reflect.typeOf
@@ -77,8 +77,8 @@ class JsonTests {
 
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 5
-        df["numbers"].type() shouldBe typeOf<Int>()
-        df["letters"].type() shouldBe typeOf<String>()
+        df["numbers"].type() shouldBe TypeOf.INT
+        df["letters"].type() shouldBe TypeOf.STRING
         df["numbers"].values() shouldBe listOf(1, 2, 3, 4, 5)
         df["letters"].values() shouldBe listOf("a", "b", "c", "d", "e")
     }
@@ -101,8 +101,8 @@ class JsonTests {
 
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 5
-        df["numbers"].type() shouldBe typeOf<Int>()
-        df["letters"].type() shouldBe typeOf<String>()
+        df["numbers"].type() shouldBe TypeOf.INT
+        df["letters"].type() shouldBe TypeOf.STRING
         df["numbers"].values() shouldBe listOf(1, 2, 3, 4, 5)
         df["letters"].values() shouldBe listOf("a", "b", "c", "d", "e")
     }
@@ -120,9 +120,9 @@ class JsonTests {
         val df = DataFrame.readJsonStr(json).alsoDebug()
         df.columnsCount() shouldBe 3
         df.rowsCount() shouldBe 2
-        df["a"].type() shouldBe typeOf<Int>()
+        df["a"].type() shouldBe TypeOf.INT
         df["b"].type() shouldBe typeOf<Comparable<*>>()
-        df["c"].type() shouldBe typeOf<Double?>()
+        df["c"].type() shouldBe TypeOf.NULLABLE_DOUBLE
     }
 
     @Test
@@ -138,9 +138,9 @@ class JsonTests {
         val df = DataFrame.readJsonStr(json, typeClashTactic = ANY_COLUMNS).alsoDebug()
         df.columnsCount() shouldBe 3
         df.rowsCount() shouldBe 2
-        df["a"].type() shouldBe typeOf<Int>()
+        df["a"].type() shouldBe TypeOf.INT
         df["b"].type() shouldBe typeOf<Comparable<*>>()
-        df["c"].type() shouldBe typeOf<Double?>()
+        df["c"].type() shouldBe TypeOf.NULLABLE_DOUBLE
     }
 
     @Test
@@ -159,8 +159,8 @@ class JsonTests {
         df.rowsCount() shouldBe 3
         val group = df["a"] as ColumnGroup<*>
         group.columnsCount() shouldBe 3
-        group["b"].type() shouldBe typeOf<Int?>()
-        group["value"].type() shouldBe typeOf<String?>()
+        group["b"].type() shouldBe TypeOf.NULLABLE_INT
+        group["value"].type() shouldBe TypeOf.NULLABLE_STRING
         group["array"].type() shouldBe typeOf<List<Int>>()
     }
 
@@ -179,7 +179,7 @@ class JsonTests {
         df.columnsCount() shouldBe 1
         df.rowsCount() shouldBe 3
         val a = df["a"] as ValueColumn<*>
-        a.type() shouldBe typeOf<Any>()
+        a.type() shouldBe TypeOf.ANY
         a[0] shouldBe "text"
         (a[1] as DataRow<*>)["b"] shouldBe 2
         a[2] shouldBe listOf(6, 7, 8)
@@ -238,9 +238,9 @@ class JsonTests {
         group[0].alsoDebug().let {
             it.columnsCount() shouldBe 3
             it.rowsCount() shouldBe 2
-            it["b"].type() shouldBe typeOf<Int?>()
-            it["c"].type() shouldBe typeOf<Int?>()
-            it["d"].type() shouldBe typeOf<Int?>()
+            it["b"].type() shouldBe TypeOf.NULLABLE_INT
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
+            it["d"].type() shouldBe TypeOf.NULLABLE_INT
             it["b"].values.toList() shouldBe listOf(2, null)
             it["c"].values.toList() shouldBe listOf(null, 3)
             it["d"].values.toList() shouldBe listOf(null, null)
@@ -249,9 +249,9 @@ class JsonTests {
         group[1].alsoDebug().let {
             it.columnsCount() shouldBe 3
             it.rowsCount() shouldBe 2
-            it["b"].type() shouldBe typeOf<Int?>()
-            it["c"].type() shouldBe typeOf<Int?>()
-            it["d"].type() shouldBe typeOf<Int?>()
+            it["b"].type() shouldBe TypeOf.NULLABLE_INT
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
+            it["d"].type() shouldBe TypeOf.NULLABLE_INT
             it["b"].values.toList() shouldBe listOf(4, null)
             it["c"].values.toList() shouldBe listOf(null, null)
             it["d"].values.toList() shouldBe listOf(null, 5)
@@ -275,9 +275,9 @@ class JsonTests {
         group[0].alsoDebug().let {
             it.columnsCount() shouldBe 3
             it.rowsCount() shouldBe 2
-            it["b"].type() shouldBe typeOf<Int?>()
-            it["c"].type() shouldBe typeOf<Int?>()
-            it["d"].type() shouldBe typeOf<Int?>()
+            it["b"].type() shouldBe TypeOf.NULLABLE_INT
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
+            it["d"].type() shouldBe TypeOf.NULLABLE_INT
             it["b"].values.toList() shouldBe listOf(2, null)
             it["c"].values.toList() shouldBe listOf(null, 3)
             it["d"].values.toList() shouldBe listOf(null, null)
@@ -286,9 +286,9 @@ class JsonTests {
         group[1].alsoDebug().let {
             it.columnsCount() shouldBe 3
             it.rowsCount() shouldBe 2
-            it["b"].type() shouldBe typeOf<Int?>()
-            it["c"].type() shouldBe typeOf<Int?>()
-            it["d"].type() shouldBe typeOf<Int?>()
+            it["b"].type() shouldBe TypeOf.NULLABLE_INT
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
+            it["d"].type() shouldBe TypeOf.NULLABLE_INT
             it["b"].values.toList() shouldBe listOf(4, null)
             it["c"].values.toList() shouldBe listOf(null, null)
             it["d"].values.toList() shouldBe listOf(null, 5)
@@ -312,17 +312,17 @@ class JsonTests {
         df.rowsCount() shouldBe 4
         val group = df["a"] as ColumnGroup<*>
         group.columnsCount() shouldBe 3
-        group["b"].type() shouldBe typeOf<Int?>()
-        group["value"].type() shouldBe typeOf<String?>()
-        group["array"].type() shouldBe typeOf<DataFrame<*>>()
+        group["b"].type() shouldBe TypeOf.NULLABLE_INT
+        group["value"].type() shouldBe TypeOf.NULLABLE_STRING
+        group["array"].type() shouldBe TypeOf.ANY_FRAME
         val nestedDf = group.getFrameColumn("array")[2]
-        nestedDf["a"].type() shouldBe typeOf<String?>()
-        nestedDf["value"].type() shouldBe typeOf<Int?>()
-        nestedDf["array"].type() shouldBe typeOf<DataFrame<*>>()
+        nestedDf["a"].type() shouldBe TypeOf.NULLABLE_STRING
+        nestedDf["value"].type() shouldBe TypeOf.NULLABLE_INT
+        nestedDf["array"].type() shouldBe TypeOf.ANY_FRAME
         group.getFrameColumn("array")[3].alsoDebug().let {
             it.columnsCount() shouldBe 3
             it.rowsCount() shouldBe 3
-            it["a"].type() shouldBe typeOf<String>()
+            it["a"].type() shouldBe TypeOf.STRING
             it["a"].values.toList() shouldBe listOf("b", "c", "d")
         }
     }
@@ -343,7 +343,7 @@ class JsonTests {
         df.columnsCount() shouldBe 1
         df.rowsCount() shouldBe 4
         val a = df["a"] as ValueColumn<*>
-        a.type() shouldBe typeOf<Any>()
+        a.type() shouldBe TypeOf.ANY
         a[0] shouldBe "text"
         (a[1] as DataRow<*>).let {
             it.columnsCount() shouldBe 1
@@ -369,7 +369,7 @@ class JsonTests {
             .let {
                 it.columnsCount() shouldBe 1
                 it.rowsCount() shouldBe 3
-                it["a"].type() shouldBe typeOf<String>()
+                it["a"].type() shouldBe TypeOf.STRING
                 it["a"].values.toList() shouldBe listOf("b", "c", "d")
             }
     }
@@ -402,21 +402,21 @@ class JsonTests {
     @Test
     fun `NaN double serialization`() {
         val df = dataFrameOf("v")(1.1, Double.NaN)
-        df["v"].type() shouldBe typeOf<Double>()
+        df["v"].type() shouldBe TypeOf.DOUBLE
         DataFrame.readJsonStr(df.toJson()) shouldBe df
     }
 
     @Test
     fun `NaN double serialization Any`() {
         val df = dataFrameOf("v")(1.1, Double.NaN)
-        df["v"].type() shouldBe typeOf<Double>()
+        df["v"].type() shouldBe TypeOf.DOUBLE
         DataFrame.readJsonStr(df.toJson(), typeClashTactic = ANY_COLUMNS) shouldBe df
     }
 
     @Test
     fun `NaN float serialization`() {
         val df = dataFrameOf("v")(1.1f, Float.NaN)
-        df["v"].type() shouldBe typeOf<Float>()
+        df["v"].type() shouldBe TypeOf.FLOAT
         val actual = DataFrame.readJsonStr(df.toJson()).convert("v").toFloat()
         actual shouldBe df
     }
@@ -424,7 +424,7 @@ class JsonTests {
     @Test
     fun `NaN float serialization Any`() {
         val df = dataFrameOf("v")(1.1f, Float.NaN)
-        df["v"].type() shouldBe typeOf<Float>()
+        df["v"].type() shouldBe TypeOf.FLOAT
         val actual = DataFrame.readJsonStr(df.toJson(), typeClashTactic = ANY_COLUMNS).convert("v").toFloat()
         actual shouldBe df
     }
@@ -432,14 +432,14 @@ class JsonTests {
     @Test
     fun `NaN string serialization`() {
         val df = dataFrameOf("v")("NaM", "NaN")
-        df["v"].type() shouldBe typeOf<String>()
+        df["v"].type() shouldBe TypeOf.STRING
         DataFrame.readJsonStr(df.toJson()) shouldBe df
     }
 
     @Test
     fun `NaN string serialization Any`() {
         val df = dataFrameOf("v")("NaM", "NaN")
-        df["v"].type() shouldBe typeOf<String>()
+        df["v"].type() shouldBe TypeOf.STRING
         DataFrame.readJsonStr(df.toJson(), typeClashTactic = ANY_COLUMNS) shouldBe df
     }
 
@@ -560,8 +560,8 @@ class JsonTests {
         val df = DataFrame.readJsonStr(json).alsoDebug()
         val group = df.getColumnGroup("a")
         group["array"].type() shouldBe typeOf<List<Int>>()
-        group["value"].type() shouldBe typeOf<String?>()
-        group["b"].type() shouldBe typeOf<Int?>()
+        group["value"].type() shouldBe TypeOf.NULLABLE_STRING
+        group["b"].type() shouldBe TypeOf.NULLABLE_INT
     }
 
     @Test
@@ -579,19 +579,19 @@ class JsonTests {
         val df = DataFrame.readJsonStr(json).alsoDebug()
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 4
-        df["c"].type() shouldBe typeOf<Int?>()
+        df["c"].type() shouldBe TypeOf.NULLABLE_INT
         val group = df["a"] as ColumnGroup<*>
         group.columnsCount() shouldBe 6
-        group["b"].type() shouldBe typeOf<Int?>()
-        group["value"].type() shouldBe typeOf<Double?>()
-        group["value1"].type() shouldBe typeOf<String?>()
+        group["b"].type() shouldBe TypeOf.NULLABLE_INT
+        group["value"].type() shouldBe TypeOf.NULLABLE_DOUBLE
+        group["value1"].type() shouldBe TypeOf.NULLABLE_STRING
         group["array"].type() shouldBe nothingType(nullable = true)
 
         val schema = df.schema().toString()
         schema shouldContain "Nothing?"
         schema shouldNotContain "Void?"
 
-        group["array1"].type() shouldBe typeOf<Int?>()
+        group["array1"].type() shouldBe TypeOf.NULLABLE_INT
         group["array2"].type() shouldBe typeOf<List<Int>>()
     }
 
@@ -611,11 +611,11 @@ class JsonTests {
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 4
         val c = df["c"] as ValueColumn<*>
-        c.type() shouldBe typeOf<Int?>()
+        c.type() shouldBe TypeOf.NULLABLE_INT
         c[0] shouldBe 1
         c[1..3].allNulls() shouldBe true
         val a = df["a"] as ValueColumn<*>
-        a.type() shouldBe typeOf<Any?>()
+        a.type() shouldBe TypeOf.NULLABLE_ANY
         a[0] shouldBe "text"
         (a[1] as DataRow<*>).let {
             it.columnsCount() shouldBe 4
@@ -649,7 +649,7 @@ class JsonTests {
         val a = df["a"] as ColumnGroup<*>
         a.columnsCount() shouldBe 1
         a["b"].let {
-            it.type() shouldBe typeOf<Int?>()
+            it.type() shouldBe TypeOf.NULLABLE_INT
             it[0] shouldBe 1
             it[1] shouldBe 2
             it[2..6].allNulls() shouldBe true
@@ -704,7 +704,7 @@ class JsonTests {
             it.columnsCount() shouldBe 1
             it.rowsCount() shouldBe 2
             it["b"].let {
-                it.type() shouldBe typeOf<Int?>()
+                it.type() shouldBe TypeOf.NULLABLE_INT
                 it[0] shouldBe null
                 it[1] shouldBe null
             }
@@ -713,7 +713,7 @@ class JsonTests {
             it.columnsCount() shouldBe 1
             it.rowsCount() shouldBe 2
             it["b"].let {
-                it.type() shouldBe typeOf<Int>()
+                it.type() shouldBe TypeOf.INT
                 it[0] shouldBe 1
                 it[1] shouldBe 2
             }
@@ -796,9 +796,9 @@ class JsonTests {
             it as ColumnGroup<*>
 
             it["b"].type() shouldBe typeOf<DataRow<*>>()
-            it["b"]["value"].type() shouldBe typeOf<Int?>()
+            it["b"]["value"].type() shouldBe TypeOf.NULLABLE_INT
             it["b"]["array"].type() shouldBe typeOf<List<Int>>()
-            it["c"].type() shouldBe typeOf<Int?>()
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
             it["d"].type() shouldBe nothingType(nullable = true)
 
             it[0].let {
@@ -853,11 +853,11 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 1
                 it["key"].let {
-                    it.type() shouldBe typeOf<String>()
+                    it.type() shouldBe TypeOf.STRING
                     it[0] shouldBe "b"
                 }
                 it["value"].let {
-                    it.type() shouldBe typeOf<Int>() // tightened by values, but Int? is also valid of course
+                    it.type() shouldBe TypeOf.INT // tightened by values, but Int? is also valid of course
                     it[0] shouldBe 1
                 }
             }
@@ -865,12 +865,12 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 3
                 it["key"].let {
-                    it.type() shouldBe typeOf<String>()
+                    it.type() shouldBe TypeOf.STRING
                     it[0] shouldBe "c"
                     it[1] shouldBe "d"
                 }
                 it["value"].let {
-                    it.type() shouldBe typeOf<Any?>()
+                    it.type() shouldBe TypeOf.NULLABLE_ANY
                     it[0] shouldBe 2
                     it[1] shouldBe null
                 }
@@ -879,8 +879,8 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 0
 
-                it["key"].type() shouldBe typeOf<String>()
-                it["value"].type() shouldBeIn listOf(typeOf<Any?>(), typeOf<Any>()) // no data, so Any(?) ValueColumn
+                it["key"].type() shouldBe TypeOf.STRING
+                it["value"].type() shouldBeIn listOf(TypeOf.NULLABLE_ANY, TypeOf.ANY) // no data, so Any(?) ValueColumn
             }
         }
     }
@@ -920,9 +920,9 @@ class JsonTests {
             it shouldBe instanceOf<ColumnGroup<*>>()
             it as ColumnGroup<*>
 
-            it["b"].type() shouldBe typeOf<Any?>()
-            it["c"].type() shouldBe typeOf<Int?>()
-            it["d"].type() shouldBe typeOf<Any?>()
+            it["b"].type() shouldBe TypeOf.NULLABLE_ANY
+            it["c"].type() shouldBe TypeOf.NULLABLE_INT
+            it["d"].type() shouldBe TypeOf.NULLABLE_ANY
 
             it[0].toMap() shouldBe mapOf("b" to 1, "c" to null, "d" to null)
             it[1].toMap() shouldBe mapOf("b" to listOf(1, 2, 3), "c" to 2, "d" to null)
@@ -965,11 +965,11 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 1
                 it["key"].let {
-                    it.type() shouldBe typeOf<String>()
+                    it.type() shouldBe TypeOf.STRING
                     it[0] shouldBe "b"
                 }
                 it["value"].let {
-                    it.type() shouldBe typeOf<Int>() // tightened by values, but Int? is also valid of course
+                    it.type() shouldBe TypeOf.INT // tightened by values, but Int? is also valid of course
                     it[0] shouldBe 1
                 }
             }
@@ -977,12 +977,12 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 3
                 it["key"].let {
-                    it.type() shouldBe typeOf<String>()
+                    it.type() shouldBe TypeOf.STRING
                     it[0] shouldBe "c"
                     it[1] shouldBe "d"
                 }
                 it["value"].let {
-                    it.type() shouldBe typeOf<Any?>()
+                    it.type() shouldBe TypeOf.NULLABLE_ANY
                     it[0] shouldBe 2
                     it[1] shouldBe null
                     it[2] shouldBe listOf(1, 2, 3)
@@ -992,8 +992,8 @@ class JsonTests {
                 it.columnsCount() shouldBe 2
                 it.rowsCount() shouldBe 0
 
-                it["key"].type() shouldBe typeOf<String>()
-                it["value"].type() shouldBeIn listOf(typeOf<Any?>(), typeOf<Any>()) // no data, so Any(?) ValueColumn
+                it["key"].type() shouldBe TypeOf.STRING
+                it["value"].type() shouldBeIn listOf(TypeOf.NULLABLE_ANY, TypeOf.ANY) // no data, so Any(?) ValueColumn
             }
         }
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/puzzles/BasicTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/puzzles/BasicTests.kt
@@ -22,9 +22,9 @@ import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.where
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.get
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.text.DecimalFormatSymbols
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class BasicTests {
@@ -189,8 +189,8 @@ class BasicTests {
         val convertedDfAcc = df.convert { priority }.with { it == "yes" }
         val convertedDfStr = df.convert { "priority"<String>() }.with { it == "yes" }
 
-        convertedDfAcc[priority].type() shouldBe typeOf<Boolean>()
-        convertedDfAcc["priority"].type() shouldBe typeOf<Boolean>()
+        convertedDfAcc[priority].type() shouldBe TypeOf.BOOLEAN
+        convertedDfAcc["priority"].type() shouldBe TypeOf.BOOLEAN
 
         convertedDfStr[priority][5] shouldBe false
         convertedDfStr["priority"][5] shouldBe false

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderingTests.kt
@@ -32,11 +32,10 @@ import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
 import org.jetbrains.kotlinx.dataframe.samples.api.secondName
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.jsoup.Jsoup
 import org.junit.Test
-import java.net.URL
 import java.text.DecimalFormatSymbols
-import kotlin.reflect.typeOf
 
 class RenderingTests : TestBase() {
 
@@ -58,7 +57,7 @@ class RenderingTests : TestBase() {
     @Test
     fun `parse url`() {
         val df = dataFrameOf("url")("http://www.google.com").parse()
-        df["url"].type() shouldBe typeOf<URL>()
+        df["url"].type() shouldBe TypeOf.URL
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
 import org.jetbrains.kotlinx.dataframe.kind
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.io.File
 import kotlin.reflect.typeOf
@@ -346,8 +347,8 @@ class Create : TestBase() {
         // SampleEnd
         df.columnNames() shouldBe listOf("name", "age")
         df.rowsCount() shouldBe 3
-        df["name"].type() shouldBe typeOf<String>()
-        df["age"].type() shouldBe typeOf<Int>()
+        df["name"].type() shouldBe TypeOf.STRING
+        df["age"].type() shouldBe TypeOf.INT
     }
 
     @Test
@@ -373,8 +374,8 @@ class Create : TestBase() {
         // SampleEnd
         df.columnsCount() shouldBe 2
         df.rowsCount() shouldBe 3
-        df["name"].type() shouldBe typeOf<String>()
-        df["age"].type() shouldBe typeOf<Int>()
+        df["name"].type() shouldBe TypeOf.STRING
+        df["age"].type() shouldBe TypeOf.INT
     }
 
     @Test
@@ -397,7 +398,7 @@ class Create : TestBase() {
         df.columnsCount() shouldBe 3
         df.rowsCount() shouldBe 2
         df["name"].kind shouldBe ColumnKind.Group
-        df["name"]["firstName"].type() shouldBe typeOf<String>()
+        df["name"]["firstName"].type() shouldBe TypeOf.STRING
         df["scores"].kind shouldBe ColumnKind.Frame
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/std.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlinx.dataframe.api.std
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.math.std
 import org.jetbrains.kotlinx.dataframe.type
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class StdTests {
 
@@ -21,11 +21,11 @@ class StdTests {
         val expected = 1.0
 
         value.values().std() shouldBe expected
-        value.values().std(typeOf<Int>()) shouldBe expected
+        value.values().std(TypeOf.INT) shouldBe expected
         value.std() shouldBe expected
         df[value].std() shouldBe expected
         df.std { value } shouldBe expected
-        df.std().columnTypes().single() shouldBe typeOf<Double>()
+        df.std().columnTypes().single() shouldBe TypeOf.DOUBLE
     }
 
     @Test
@@ -35,7 +35,7 @@ class StdTests {
         val expected = 1.0
 
         value.values().std() shouldBe expected
-        value.values().std(typeOf<Double>()) shouldBe expected
+        value.values().std(TypeOf.DOUBLE) shouldBe expected
         value.std() shouldBe expected
         df[value].std() shouldBe expected
         df.std { value } shouldBe expected

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/animals/AnimalsTests.kt
@@ -10,8 +10,8 @@ import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.value
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.api.withNull
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class AnimalsTests {
 
@@ -33,7 +33,7 @@ class AnimalsTests {
         mean.columnsCount() shouldBe 2
         mean.rowsCount() shouldBe 2
         mean.name.values() shouldBe listOf("age", "visits")
-        mean.value.type() shouldBe typeOf<Double>()
+        mean.value.type() shouldBe TypeOf.DOUBLE
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -122,7 +122,6 @@ import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.api.replace
 import org.jetbrains.kotlinx.dataframe.api.rows
-import org.jetbrains.kotlinx.dataframe.api.schema
 import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.api.single
 import org.jetbrains.kotlinx.dataframe.api.sortBy
@@ -188,8 +187,8 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.size
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
-import java.lang.reflect.Type
 import java.math.BigDecimal
 import java.time.LocalDate
 import kotlin.reflect.jvm.jvmErasure
@@ -275,8 +274,8 @@ class DataFrameTests : BaseTest() {
         df.ncol shouldBe 2
         df.nrow shouldBe 2
         df.columnNames() shouldBe listOf("name", "age")
-        df["name"].type() shouldBe typeOf<String>()
-        df["age"].type() shouldBe typeOf<Int?>()
+        df["name"].type() shouldBe TypeOf.STRING
+        df["age"].type() shouldBe TypeOf.NULLABLE_INT
     }
 
     @Test
@@ -947,7 +946,7 @@ class DataFrameTests : BaseTest() {
         val df = typed.add {
             expr(infer = Infer.Type) { f } into "f"
         }
-        df["f"].type() shouldBe typeOf<Int>()
+        df["f"].type() shouldBe TypeOf.INT
     }
 
     @Test
@@ -1033,11 +1032,11 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `union dataframes with different type of the same column`() {
         val df2 = dataFrameOf("age")(32.6, 56.3, null)
-        df2["age"].type() shouldBe typeOf<Double?>()
+        df2["age"].type() shouldBe TypeOf.NULLABLE_DOUBLE
         val merged = df.concat(df2)
-        merged["age"].type() shouldBe typeOf<Number?>()
+        merged["age"].type() shouldBe TypeOf.NULLABLE_NUMBER
         val updated = merged.convert("age") { "age"<Number?>()?.toDouble() }
-        updated["age"].type() shouldBe typeOf<Double?>()
+        updated["age"].type() shouldBe TypeOf.NULLABLE_DOUBLE
     }
 
     @Test
@@ -1064,10 +1063,10 @@ class DataFrameTests : BaseTest() {
     fun `addRow`() {
         val res = typed.append("Bob", null, "Paris", null)
         res.nrow shouldBe typed.nrow + 1
-        res.name.type() shouldBe typeOf<String>()
-        res.age.type() shouldBe typeOf<Int?>()
-        res.city.type() shouldBe typeOf<String?>()
-        res.weight.type() shouldBe typeOf<Int?>()
+        res.name.type() shouldBe TypeOf.STRING
+        res.age.type() shouldBe TypeOf.NULLABLE_INT
+        res.city.type() shouldBe TypeOf.NULLABLE_STRING
+        res.weight.type() shouldBe TypeOf.NULLABLE_INT
 
         val row = res.last()
         row.name shouldBe "Bob"
@@ -1563,7 +1562,7 @@ class DataFrameTests : BaseTest() {
         mean.ncol shouldBe 2
         mean.columnNames() shouldBe listOf("age", "weight")
         mean.columns().forEach {
-            it.type() shouldBe typeOf<Double>()
+            it.type() shouldBe TypeOf.DOUBLE
         }
     }
 
@@ -1572,8 +1571,8 @@ class DataFrameTests : BaseTest() {
         val d = typed.groupBy { name }.mean()
         d.columnNames() shouldBe listOf("name", "age", "weight")
         d.nrow shouldBe typed.name.countDistinct()
-        d["age"].type() shouldBe typeOf<Double>()
-        d["weight"].type() shouldBe typeOf<Double>()
+        d["age"].type() shouldBe TypeOf.DOUBLE
+        d["weight"].type() shouldBe TypeOf.DOUBLE
     }
 
     @Test
@@ -1888,7 +1887,7 @@ class DataFrameTests : BaseTest() {
         val df = dataFrameOf('a'..'f').randomInt(3)
         df.nrow shouldBe 3
         df.ncol shouldBe ('a'..'f').count()
-        df.columns().forEach { it.type() shouldBe typeOf<Int>() }
+        df.columns().forEach { it.type() shouldBe TypeOf.INT }
     }
 
     @Test
@@ -1921,7 +1920,7 @@ class DataFrameTests : BaseTest() {
         val df = dataFrameOf(names).nulls<Double>(10)
         df.nrow shouldBe 10
         df.ncol shouldBe 2
-        df.columns().forEach { col -> (col.type() == typeOf<Double?>() && col.allNulls()) shouldBe true }
+        df.columns().forEach { col -> (col.type() == TypeOf.NULLABLE_DOUBLE && col.allNulls()) shouldBe true }
     }
 
     @Test
@@ -1931,7 +1930,7 @@ class DataFrameTests : BaseTest() {
         val df = dataFrameOf(first, second).fill(5) { true }
         df.nrow shouldBe 5
         df.ncol shouldBe 2
-        df.columns().forEach { col -> (col.type() == typeOf<Boolean>() && col.all { it == true }) shouldBe true }
+        df.columns().forEach { col -> (col.type() == TypeOf.BOOLEAN && col.all { it == true }) shouldBe true }
     }
 
     @Test
@@ -2095,7 +2094,7 @@ class DataFrameTests : BaseTest() {
             val group = it.asColumnGroup()
             group.columnNames() shouldBe listOf("age", "weight")
             group.columns().forEach {
-                it.type() shouldBe typeOf<Double?>()
+                it.type() shouldBe TypeOf.NULLABLE_DOUBLE
             }
         }
     }
@@ -2376,8 +2375,8 @@ class DataFrameTests : BaseTest() {
         val updated = typed
             .convert { weight }.toDouble()
             .update { colsOf<Number?>() }.where { name == "Charlie" }.withZero()
-        updated.age.type shouldBe typeOf<Int>()
-        updated["weight"].type shouldBe typeOf<Double>()
+        updated.age.type shouldBe TypeOf.INT
+        updated["weight"].type shouldBe TypeOf.DOUBLE
         val filtered = updated.filter { name == "Charlie" }
         filtered.nrow shouldBe 3
         filtered.age.forEach {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/PivotTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/PivotTests.kt
@@ -60,6 +60,7 @@ import org.jetbrains.kotlinx.dataframe.impl.asList
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.util.AbstractSet
 import kotlin.reflect.KClass
@@ -135,9 +136,9 @@ class PivotTests {
             }.toSet()
 
         actual shouldBe expected
-        res["age"].type() shouldBe typeOf<Boolean>()
-        res["city"].type() shouldBe typeOf<Boolean>()
-        res["weight"].type() shouldBe typeOf<Boolean>()
+        res["age"].type() shouldBe TypeOf.BOOLEAN
+        res["city"].type() shouldBe TypeOf.BOOLEAN
+        res["weight"].type() shouldBe TypeOf.BOOLEAN
     }
 
     @Test
@@ -150,7 +151,7 @@ class PivotTests {
         val data = res.getColumnGroup("key")
 
         data["age"].type() shouldBe typeOf<List<Int>>()
-        data["city"].type() shouldBe typeOf<String>()
+        data["city"].type() shouldBe TypeOf.STRING
         data["weight"].type() shouldBe typeOf<Comparable<*>>() // Comparable<String + Int> -> Comparable<Nothing | *>
 
         res.renderToString(columnTypes = true, title = true) shouldBe

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
@@ -10,15 +10,20 @@ import org.jetbrains.kotlinx.dataframe.impl.createType
 import org.jetbrains.kotlinx.dataframe.impl.guessValueType
 import org.jetbrains.kotlinx.dataframe.impl.isArray
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveArray
-import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.impl.replaceGenericTypeParametersWithUpperbound
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.io.Serializable
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
+@Suppress("ktlint:standard:property-naming", "PrivatePropertyName")
 class UtilTests {
+
+    private val `List(Int)` = typeOf<List<Int>>()
+    private val `List(Int)?` = typeOf<List<Int>?>()
+    private val `List(Int?)` = typeOf<List<Int?>>()
 
     @OptIn(ExperimentalUnsignedTypes::class)
     @Test
@@ -97,23 +102,23 @@ class UtilTests {
 
     @Test
     fun `createType test`() {
-        emptyList<KClass<*>>().createType(nullable = false) shouldBe nothingType(nullable = false)
-        emptyList<KClass<*>>().createType(nullable = true) shouldBe nothingType(nullable = true)
+        emptyList<KClass<*>>().createType(nullable = false) shouldBe TypeOf.NOTHING
+        emptyList<KClass<*>>().createType(nullable = true) shouldBe TypeOf.NULLABLE_NOTHING
 
-        listOf(Nothing::class).createType(nullable = false) shouldBe nothingType(nullable = false)
-        listOf(Nothing::class).createType(nullable = true) shouldBe nothingType(nullable = true)
+        listOf(Nothing::class).createType(nullable = false) shouldBe TypeOf.NOTHING
+        listOf(Nothing::class).createType(nullable = true) shouldBe TypeOf.NULLABLE_NOTHING
     }
 
     @Test
     fun `commonType classes test`() {
-        emptyList<KClass<*>>().commonType(false, typeOf<List<Int>>()) shouldBe typeOf<List<Int>>()
-        emptyList<KClass<*>>().commonType(true, typeOf<List<Int>>()) shouldBe typeOf<List<Int>?>()
+        emptyList<KClass<*>>().commonType(false, `List(Int)`) shouldBe `List(Int)`
+        emptyList<KClass<*>>().commonType(true, `List(Int)`) shouldBe `List(Int)?`
 
-        listOf(Nothing::class).commonType(false) shouldBe nothingType(nullable = false)
-        listOf(Nothing::class).commonType(true) shouldBe nothingType(nullable = true)
+        listOf(Nothing::class).commonType(false) shouldBe TypeOf.NOTHING
+        listOf(Nothing::class).commonType(true) shouldBe TypeOf.NULLABLE_NOTHING
 
-        emptyList<KClass<*>>().commonType(false, null) shouldBe nothingType(nullable = false)
-        emptyList<KClass<*>>().commonType(true, null) shouldBe nothingType(nullable = true)
+        emptyList<KClass<*>>().commonType(false, null) shouldBe TypeOf.NOTHING
+        emptyList<KClass<*>>().commonType(true, null) shouldBe TypeOf.NULLABLE_NOTHING
     }
 
     val a = listOf(1, 2.0, "a")
@@ -123,54 +128,54 @@ class UtilTests {
 
     @Test
     fun `guessValueType no listification`() {
-        guessValueType(sequenceOf(1, 2)) shouldBe typeOf<Int>()
-        guessValueType(sequenceOf(1, 2, null)) shouldBe typeOf<Int?>()
+        guessValueType(sequenceOf(1, 2)) shouldBe TypeOf.INT
+        guessValueType(sequenceOf(1, 2, null)) shouldBe TypeOf.NULLABLE_INT
 
-        guessValueType(sequenceOf(1, 2.0)) shouldBe typeOf<Number>()
-        guessValueType(sequenceOf(1, 2.0, null)) shouldBe typeOf<Number?>()
+        guessValueType(sequenceOf(1, 2.0)) shouldBe TypeOf.NUMBER
+        guessValueType(sequenceOf(1, 2.0, null)) shouldBe TypeOf.NULLABLE_NUMBER
 
         guessValueType(sequenceOf(1, 2.0, "a")) shouldBe typeOf<Comparable<*>>()
         guessValueType(sequenceOf(1, 2.0, "a", null)) shouldBe typeOf<Comparable<*>?>()
 
-        guessValueType(sequenceOf(1, 2.0, "a", listOf(1, 2))) shouldBe typeOf<Any>()
-        guessValueType(sequenceOf(1, 2.0, "a", null, listOf(1, 2))) shouldBe typeOf<Any?>()
+        guessValueType(sequenceOf(1, 2.0, "a", listOf(1, 2))) shouldBe TypeOf.ANY
+        guessValueType(sequenceOf(1, 2.0, "a", null, listOf(1, 2))) shouldBe TypeOf.NULLABLE_ANY
 
-        guessValueType(sequenceOf(null, null)) shouldBe nothingType(nullable = true)
-        guessValueType(emptySequence()) shouldBe nothingType(nullable = false)
+        guessValueType(sequenceOf(null, null)) shouldBe TypeOf.NULLABLE_NOTHING
+        guessValueType(emptySequence()) shouldBe TypeOf.NOTHING
 
         guessValueType(sequenceOf(listOf<Int?>(null))) shouldBe typeOf<List<Nothing?>>()
         guessValueType(sequenceOf(emptyList<Int>())) shouldBe typeOf<List<Nothing>>()
         guessValueType(sequenceOf(listOf<Int?>(null), emptyList<Int>())) shouldBe typeOf<List<Nothing?>>()
         guessValueType(sequenceOf(emptyList<Int>(), null)) shouldBe typeOf<List<Nothing>?>()
 
-        guessValueType(sequenceOf(listOf(1), emptyList())) shouldBe typeOf<List<Int>>()
-        guessValueType(sequenceOf(listOf(1, null), emptyList())) shouldBe typeOf<List<Int?>>()
-        guessValueType(sequenceOf(listOf(1), listOf(null))) shouldBe typeOf<List<Int?>>()
+        guessValueType(sequenceOf(listOf(1), emptyList())) shouldBe `List(Int)`
+        guessValueType(sequenceOf(listOf(1, null), emptyList())) shouldBe `List(Int?)`
+        guessValueType(sequenceOf(listOf(1), listOf(null))) shouldBe `List(Int?)`
 
-        guessValueType(sequenceOf(1, emptyList<Any?>())) shouldBe typeOf<Any>()
+        guessValueType(sequenceOf(1, emptyList<Any?>())) shouldBe TypeOf.ANY
 
-        guessValueType(sequenceOf(1, 2, listOf(1), emptySet<Any>())) shouldBe typeOf<Any>()
+        guessValueType(sequenceOf(1, 2, listOf(1), emptySet<Any>())) shouldBe TypeOf.ANY
         guessValueType(sequenceOf(listOf(1), setOf(1.0, 2.0))) shouldBe typeOf<Collection<Number>>()
     }
 
     @Test
     fun `guessValueType with listification`() {
-        guessValueType(sequenceOf(1, 2), listifyValues = true) shouldBe typeOf<Int>()
-        guessValueType(sequenceOf(1, 2, null), listifyValues = true) shouldBe typeOf<Int?>()
+        guessValueType(sequenceOf(1, 2), listifyValues = true) shouldBe TypeOf.INT
+        guessValueType(sequenceOf(1, 2, null), listifyValues = true) shouldBe TypeOf.NULLABLE_INT
 
-        guessValueType(sequenceOf(1, 2.0), listifyValues = true) shouldBe typeOf<Number>()
-        guessValueType(sequenceOf(1, 2.0, null), listifyValues = true) shouldBe typeOf<Number?>()
+        guessValueType(sequenceOf(1, 2.0), listifyValues = true) shouldBe TypeOf.NUMBER
+        guessValueType(sequenceOf(1, 2.0, null), listifyValues = true) shouldBe TypeOf.NULLABLE_NUMBER
 
         guessValueType(sequenceOf(1, 2.0, "a"), listifyValues = true) shouldBe typeOf<Comparable<*>>()
         guessValueType(sequenceOf(1, 2.0, "a", null), listifyValues = true) shouldBe typeOf<Comparable<*>?>()
 
-        guessValueType(sequenceOf(1, 2, listOf(1)), listifyValues = true) shouldBe typeOf<List<Int>>()
-        guessValueType(sequenceOf(1, 2, listOf(1), null), listifyValues = true) shouldBe typeOf<List<Int>>()
-        guessValueType(sequenceOf(1, 2, listOf(1, null)), listifyValues = true) shouldBe typeOf<List<Int?>>()
-        guessValueType(sequenceOf(1, 2, listOf(1, null), null), listifyValues = true) shouldBe typeOf<List<Int?>>()
+        guessValueType(sequenceOf(1, 2, listOf(1)), listifyValues = true) shouldBe `List(Int)`
+        guessValueType(sequenceOf(1, 2, listOf(1), null), listifyValues = true) shouldBe `List(Int)`
+        guessValueType(sequenceOf(1, 2, listOf(1, null)), listifyValues = true) shouldBe `List(Int?)`
+        guessValueType(sequenceOf(1, 2, listOf(1, null), null), listifyValues = true) shouldBe `List(Int?)`
 
-        guessValueType(sequenceOf(1, 2, listOf(null)), listifyValues = true) shouldBe typeOf<List<Int?>>()
-        guessValueType(sequenceOf(1, 2, listOf(null), null), listifyValues = true) shouldBe typeOf<List<Int?>>()
+        guessValueType(sequenceOf(1, 2, listOf(null)), listifyValues = true) shouldBe `List(Int?)`
+        guessValueType(sequenceOf(1, 2, listOf(null), null), listifyValues = true) shouldBe `List(Int?)`
 
         guessValueType(sequenceOf(emptyList<Int>()), listifyValues = true) shouldBe typeOf<List<Nothing>>()
         guessValueType(sequenceOf(emptyList<Int>(), null), listifyValues = true) shouldBe typeOf<List<Nothing>>()
@@ -180,28 +185,28 @@ class UtilTests {
         guessValueType(
             values = sequenceOf(1, 2, listOf(1), emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any>()
+        ) shouldBe TypeOf.ANY
         guessValueType(
             values = sequenceOf(1, 2, listOf(1), null, emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any?>()
+        ) shouldBe TypeOf.NULLABLE_ANY
         guessValueType(
             values = sequenceOf(1, 2, listOf(1, null), emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any>()
+        ) shouldBe TypeOf.ANY
         guessValueType(
             values = sequenceOf(1, 2, listOf(1, null), null, emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any?>()
+        ) shouldBe TypeOf.NULLABLE_ANY
 
         guessValueType(
             values = sequenceOf(1, 2, listOf(null), emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any>()
+        ) shouldBe TypeOf.ANY
         guessValueType(
             values = sequenceOf(1, 2, listOf(null), null, emptySet<Any>()),
             listifyValues = true,
-        ) shouldBe typeOf<Any?>()
+        ) shouldBe TypeOf.NULLABLE_ANY
 
         guessValueType(
             values = sequenceOf(emptyList(), emptySet<Any>()),
@@ -250,28 +255,28 @@ class UtilTests {
     @Test
     fun `commonType KTypes test`() {
         // TODO issue #471: Type inference incorrect w.r.t. variance
-        listOf(null).commonType(false) shouldBe typeOf<Any?>()
+        listOf(null).commonType(false) shouldBe TypeOf.NULLABLE_ANY
 //        listOf(null).commonType(true) shouldBe null
-        listOf(typeOf<Int>(), typeOf<Any>()).commonType() shouldBe typeOf<Any>()
-        listOf(typeOf<Int>(), typeOf<List<Any>>()).commonType() shouldBe typeOf<Any>()
-        listOf(typeOf<Int>(), typeOf<List<Any>?>()).commonType() shouldBe typeOf<Any?>()
-        listOf(typeOf<Int>(), typeOf<Int>()).commonType() shouldBe typeOf<Int>()
-        listOf(typeOf<Int>(), typeOf<Int?>()).commonType() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(true)).commonType() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(false)).commonType() shouldBe typeOf<Int>()
+        listOf(TypeOf.INT, TypeOf.ANY).commonType() shouldBe TypeOf.ANY
+        listOf(TypeOf.INT, typeOf<List<Any>>()).commonType() shouldBe TypeOf.ANY
+        listOf(TypeOf.INT, typeOf<List<Any>?>()).commonType() shouldBe TypeOf.NULLABLE_ANY
+        listOf(TypeOf.INT, TypeOf.INT).commonType() shouldBe TypeOf.INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_INT).commonType() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_NOTHING).commonType() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NOTHING).commonType() shouldBe TypeOf.INT
         listOf(typeOf<Comparable<Int>>(), typeOf<Comparable<Int>>()).commonType() shouldBe typeOf<Comparable<Int>>()
 //        listOf(typeOf<Comparable<Int>>(), typeOf<Comparable<String>>()).commonType() shouldBe typeOf<Comparable<*>>()
-//        listOf(typeOf<List<Int>>(), typeOf<List<String>>()).commonType(false) shouldBe typeOf<List<Comparable<Nothing>>>()
-//        listOf(typeOf<List<Int>>(), typeOf<List<String>>()).commonType() shouldBe typeOf<List<Comparable<*>>>()
-//        listOf(typeOf<List<Int>>(), typeOf<Set<String>>()).commonType(false) shouldBe typeOf<Collection<Comparable<Nothing>>>()
-//        listOf(typeOf<List<Int>>(), typeOf<Set<String>>()).commonType() shouldBe typeOf<Collection<Comparable<*>>>()
-//        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>>>()).commonType() shouldBe typeOf<List<Any>>()
-//        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>?>>()).commonType(false) shouldBe typeOf<List<Any?>>()
-//        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>?>>()).commonType() shouldBe typeOf<List<*>>()
+//        listOf(INT_LIST, typeOf<List<String>>()).commonType(false) shouldBe typeOf<List<Comparable<Nothing>>>()
+//        listOf(INT_LIST, typeOf<List<String>>()).commonType() shouldBe typeOf<List<Comparable<*>>>()
+//        listOf(INT_LIST, typeOf<Set<String>>()).commonType(false) shouldBe typeOf<Collection<Comparable<Nothing>>>()
+//        listOf(INT_LIST, typeOf<Set<String>>()).commonType() shouldBe typeOf<Collection<Comparable<*>>>()
+//        listOf(INT_LIST, typeOf<List<List<Any>>>()).commonType() shouldBe typeOf<List<Any>>()
+//        listOf(INT_LIST, typeOf<List<List<Any>?>>()).commonType(false) shouldBe typeOf<List<Any?>>()
+//        listOf(INT_LIST, typeOf<List<List<Any>?>>()).commonType() shouldBe typeOf<List<*>>()
 //        listOf(typeOf<List<Nothing>>(), typeOf<Set<Nothing>>()).commonType() shouldBe typeOf<Collection<Nothing>>()
-        listOf(nothingType(false)).commonType() shouldBe nothingType(false)
-        listOf(nothingType(true)).commonType() shouldBe nothingType(true)
-//        emptyList<KType>().commonType() shouldBe nothingType(false)
+        listOf(TypeOf.NOTHING).commonType() shouldBe TypeOf.NOTHING
+        listOf(TypeOf.NULLABLE_NOTHING).commonType() shouldBe TypeOf.NULLABLE_NOTHING
+//        emptyList<KType>().commonType() shouldBe NOTHING
         listOf(
             typeOf<AbstractType<Int>>(),
             typeOf<AbstractType<Int>>(),
@@ -294,65 +299,69 @@ class UtilTests {
 //            typeOf<AbstractType<Any>>()
 //        ).commonType() shouldBe typeOf<AbstractType<in Int>>()
 
-        listOf(typeOf<Int>(), typeOf<List<Any>>()).commonType() shouldBe typeOf<Any>()
-        listOf(typeOf<Int>(), typeOf<List<Any>?>()).commonType() shouldBe typeOf<Any?>()
-        listOf(typeOf<Int>(), typeOf<Int>()).commonType() shouldBe typeOf<Int>()
-        listOf(typeOf<Int>(), typeOf<Int?>()).commonType() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(true)).commonType() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(false)).commonType() shouldBe typeOf<Int>()
+        listOf(TypeOf.INT, typeOf<List<Any>>()).commonType() shouldBe TypeOf.ANY
+        listOf(TypeOf.INT, typeOf<List<Any>?>()).commonType() shouldBe TypeOf.NULLABLE_ANY
+        listOf(TypeOf.INT, TypeOf.INT).commonType() shouldBe TypeOf.INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_INT).commonType() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_NOTHING).commonType() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NOTHING).commonType() shouldBe TypeOf.INT
         listOf(
-            typeOf<List<Int>>(),
+            `List(Int)`,
             typeOf<List<String>>(),
         ).commonType(false) shouldBe typeOf<List<out Comparable<Nothing>>>()
-        listOf(typeOf<List<Int>>(), typeOf<List<String>>()).commonType() shouldBe typeOf<List<out Comparable<*>>>()
+        listOf(`List(Int)`, typeOf<List<String>>()).commonType() shouldBe typeOf<List<out Comparable<*>>>()
         listOf(
-            typeOf<List<Int>>(),
+            `List(Int)`,
             typeOf<Set<String>>(),
         ).commonType(false) shouldBe typeOf<Collection<out Comparable<Nothing>>>()
-        listOf(typeOf<List<Int>>(), typeOf<Set<String>>()).commonType() shouldBe typeOf<Collection<out Comparable<*>>>()
-        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>>>()).commonType() shouldBe typeOf<List<out Any>>()
-        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>?>>()).commonType(false) shouldBe typeOf<List<out Any?>>()
-        listOf(typeOf<List<Int>>(), typeOf<List<List<Any>?>>()).commonType() shouldBe typeOf<List<*>>()
+        listOf(`List(Int)`, typeOf<Set<String>>()).commonType() shouldBe typeOf<Collection<out Comparable<*>>>()
+        listOf(`List(Int)`, typeOf<List<List<Any>>>()).commonType() shouldBe typeOf<List<out Any>>()
+        listOf(`List(Int)`, typeOf<List<List<Any>?>>()).commonType(false) shouldBe typeOf<List<out Any?>>()
+        listOf(`List(Int)`, typeOf<List<List<Any>?>>()).commonType() shouldBe typeOf<List<*>>()
         listOf(typeOf<List<Nothing>>(), typeOf<Set<Nothing>>()).commonType() shouldBe typeOf<Collection<out Nothing>>()
-        listOf(nothingType(false)).commonType() shouldBe nothingType(false)
-        listOf(nothingType(true)).commonType() shouldBe nothingType(true)
-        listOf<KType>().commonType() shouldBe typeOf<Any>()
+        listOf(TypeOf.NOTHING).commonType() shouldBe TypeOf.NOTHING
+        listOf(TypeOf.NULLABLE_NOTHING).commonType() shouldBe TypeOf.NULLABLE_NOTHING
+        listOf<KType>().commonType() shouldBe TypeOf.ANY
     }
 
     @Test
     fun `commonTypeListifyValues test`() {
         // TODO issue #471: Type inference incorrect w.r.t. variance
-        listOf<KType>().commonTypeListifyValues() shouldBe typeOf<Any>()
-        listOf(typeOf<Int>(), typeOf<Int>()).commonTypeListifyValues() shouldBe typeOf<Int>()
-        listOf(typeOf<Int>(), typeOf<Int?>()).commonTypeListifyValues() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(true)).commonTypeListifyValues() shouldBe typeOf<Int?>()
-        listOf(typeOf<Int>(), nothingType(false)).commonTypeListifyValues() shouldBe typeOf<Int>()
-        listOf(typeOf<Int>(), typeOf<Double>(), nothingType(true)).commonTypeListifyValues() shouldBe typeOf<Number?>()
+        listOf<KType>().commonTypeListifyValues() shouldBe TypeOf.ANY
+        listOf(TypeOf.INT, TypeOf.INT).commonTypeListifyValues() shouldBe TypeOf.INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_INT).commonTypeListifyValues() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NULLABLE_NOTHING).commonTypeListifyValues() shouldBe TypeOf.NULLABLE_INT
+        listOf(TypeOf.INT, TypeOf.NOTHING).commonTypeListifyValues() shouldBe TypeOf.INT
         listOf(
-            typeOf<List<Int>>(),
+            TypeOf.INT,
+            TypeOf.DOUBLE,
+            TypeOf.NULLABLE_NOTHING,
+        ).commonTypeListifyValues() shouldBe TypeOf.NULLABLE_NUMBER
+        listOf(
+            `List(Int)`,
             typeOf<List<String>>(),
         ).commonTypeListifyValues() shouldBe typeOf<List<out Comparable<*>>>()
         listOf(
-            typeOf<List<Int>>(),
+            `List(Int)`,
             typeOf<Set<String>>(),
         ).commonTypeListifyValues() shouldBe typeOf<Collection<out Comparable<*>>>()
 
         listOf(
-            typeOf<Int>(),
-            typeOf<List<Int>>(),
-        ).commonTypeListifyValues() shouldBe typeOf<List<Int>>()
+            TypeOf.INT,
+            `List(Int)`,
+        ).commonTypeListifyValues() shouldBe `List(Int)`
 
         listOf(
-            typeOf<Int>(),
-            typeOf<List<Int>>(),
-            nothingType(true),
-        ).commonTypeListifyValues() shouldBe typeOf<List<Int>>()
+            TypeOf.INT,
+            `List(Int)`,
+            TypeOf.NULLABLE_NOTHING,
+        ).commonTypeListifyValues() shouldBe `List(Int)`
 
         listOf(
-            typeOf<Int>(),
-            typeOf<List<Int?>>(),
-            nothingType(true),
-        ).commonTypeListifyValues() shouldBe typeOf<List<Int?>>()
+            TypeOf.INT,
+            `List(Int?)`,
+            TypeOf.NULLABLE_NOTHING,
+        ).commonTypeListifyValues() shouldBe `List(Int?)`
 
         listOf(
             typeOf<List<Nothing>>(),
@@ -361,21 +370,21 @@ class UtilTests {
 
         listOf(
             typeOf<List<Nothing>>(),
-            nothingType(true),
+            TypeOf.NULLABLE_NOTHING,
         ).commonTypeListifyValues() shouldBe typeOf<List<Nothing>>()
 
         listOf(
-            typeOf<Int>(),
-            typeOf<List<Int>>(),
+            TypeOf.INT,
+            `List(Int)`,
             typeOf<Set<Any>>(),
-        ).commonTypeListifyValues() shouldBe typeOf<Any>()
+        ).commonTypeListifyValues() shouldBe TypeOf.ANY
 
         listOf(
-            typeOf<Int>(),
-            typeOf<List<Int>>(),
+            TypeOf.INT,
+            `List(Int)`,
             typeOf<Set<Any>>(),
-            nothingType(true),
-        ).commonTypeListifyValues() shouldBe typeOf<Any?>()
+            TypeOf.NULLABLE_NOTHING,
+        ).commonTypeListifyValues() shouldBe TypeOf.NULLABLE_ANY
 
         listOf(
             typeOf<List<Nothing>>(),
@@ -385,7 +394,7 @@ class UtilTests {
         listOf(
             typeOf<List<Nothing>>(),
             typeOf<Set<Nothing>>(),
-            nothingType(true),
+            TypeOf.NULLABLE_NOTHING,
         ).commonTypeListifyValues() shouldBe typeOf<Collection<out Nothing>?>()
 
         listOf(

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
@@ -54,9 +54,9 @@ import org.jetbrains.kotlinx.dataframe.api.map
 import org.jetbrains.kotlinx.dataframe.exceptions.CellConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.name
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.jetbrains.kotlinx.dataframe.values
 import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.typeOf
 
 /**
  * Save [dataFrame] content in Apache Arrow format (can be written to File, ByteArray, OutputStream or raw Channel) with [targetSchema].
@@ -85,7 +85,7 @@ internal class ArrowWriterImpl(
     private fun countTotalBytes(column: AnyCol): Long? {
         val columnType = column.type()
         return when {
-            columnType.isSubtypeOf(typeOf<String?>()) ->
+            columnType.isSubtypeOf(TypeOf.NULLABLE_STRING) ->
                 column.values.fold(0L) { totalBytes, value ->
                     totalBytes + value.toString().length * 4
                 }

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.io
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toJavaLocalTime
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BaseFixedWidthVector
 import org.apache.arrow.vector.BaseVariableWidthVector
@@ -226,8 +227,7 @@ internal class ArrowWriterImpl(
                     }
 
             is DateDayVector ->
-                column
-                    .convertToLocalDate()
+                column.convertToLocalDate()
                     .forEachIndexed { i, value ->
                         value?.also { vector.set(i, value.toJavaLocalDate().toEpochDay().toInt()) }
                             ?: vector.setNull(i)
@@ -243,29 +243,30 @@ internal class ArrowWriterImpl(
             is TimeNanoVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toNanoOfDay()) }
+                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay()) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMicroVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toNanoOfDay() / 1000) }
+                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay() / 1000) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMilliVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, (value.toNanoOfDay() / 1000 / 1000).toInt()) }
+                        value?.also { vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000).toInt()) }
                             ?: vector.setNull(i)
                     }
 
             is TimeSecVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, (value.toNanoOfDay() / 1000 / 1000 / 1000).toInt()) }
-                            ?: vector.setNull(i)
+                        value?.also {
+                            vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000 / 1000).toInt())
+                        } ?: vector.setNull(i)
                     }
 
             else -> {

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
@@ -1,5 +1,11 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.BitVector
@@ -55,13 +61,12 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.SeekableByteChannel
-import java.time.Duration
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlin.reflect.KType
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * same as [Iterable<DataFrame<T>>.concat()] without internal type guessing (all batches should have the same schema)
@@ -108,7 +113,7 @@ private fun Float4Vector.values(range: IntRange): List<Float?> = range.map { get
 
 private fun Float8Vector.values(range: IntRange): List<Double?> = range.map { getObject(it) }
 
-private fun DurationVector.values(range: IntRange): List<Duration?> = range.map { getObject(it) }
+private fun DurationVector.values(range: IntRange): List<Duration?> = range.map { getObject(it).toKotlinDuration() }
 
 private fun DateDayVector.values(range: IntRange): List<LocalDate?> =
     range.map {
@@ -117,17 +122,19 @@ private fun DateDayVector.values(range: IntRange): List<LocalDate?> =
         } else {
             DateUtility.getLocalDateTimeFromEpochMilli(getObject(it).toLong() * DateUtility.daysToStandardMillis)
                 .toLocalDate()
+                .toKotlinLocalDate()
         }
     }
 
-private fun DateMilliVector.values(range: IntRange): List<LocalDateTime?> = range.map { getObject(it) }
+private fun DateMilliVector.values(range: IntRange): List<LocalDateTime?> =
+    range.map { getObject(it)?.toKotlinLocalDateTime() }
 
 private fun TimeNanoVector.values(range: IntRange): List<LocalTime?> =
     range.mapIndexed { i, it ->
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(get(it))
+            JavaLocalTime.ofNanoOfDay(get(it)).toKotlinLocalTime()
         }
     }
 
@@ -136,7 +143,7 @@ private fun TimeMicroVector.values(range: IntRange): List<LocalTime?> =
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(getObject(it) * 1000)
+            JavaLocalTime.ofNanoOfDay(getObject(it) * 1000).toKotlinLocalTime()
         }
     }
 
@@ -145,19 +152,19 @@ private fun TimeMilliVector.values(range: IntRange): List<LocalTime?> =
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(get(it).toLong() * 1000_000)
+            JavaLocalTime.ofNanoOfDay(get(it).toLong() * 1000_000).toKotlinLocalTime()
         }
     }
 
 private fun TimeSecVector.values(range: IntRange): List<LocalTime?> =
-    range.map { getObject(it)?.let { LocalTime.ofSecondOfDay(it.toLong()) } }
+    range.map { getObject(it)?.let { JavaLocalTime.ofSecondOfDay(it.toLong()).toKotlinLocalTime() } }
 
 private fun TimeStampNanoVector.values(range: IntRange): List<LocalDateTime?> =
     range.mapIndexed { i, it ->
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -166,7 +173,7 @@ private fun TimeStampMicroVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -175,7 +182,7 @@ private fun TimeStampMilliVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -184,7 +191,7 @@ private fun TimeStampSecVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
@@ -57,6 +57,7 @@ import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
 import org.jetbrains.kotlinx.dataframe.api.getColumn
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.impl.asList
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.channels.ReadableByteChannel
@@ -241,12 +242,7 @@ private fun LargeVarCharVector.values(range: IntRange): List<String?> =
         }
     }
 
-internal fun nothingType(nullable: Boolean): KType =
-    if (nullable) {
-        typeOf<List<Nothing?>>()
-    } else {
-        typeOf<List<Nothing>>()
-    }.arguments.first().type!!
+internal fun nothingType(nullable: Boolean): KType = if (nullable) TypeOf.NULLABLE_NOTHING else TypeOf.NOTHING
 
 private inline fun <reified T> List<T?>.withTypeNullable(
     expectedNulls: Boolean,

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import org.apache.arrow.vector.types.DateUnit
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.TimeUnit
@@ -9,11 +12,11 @@ import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.typeClass
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * Create Arrow [Field] (note: this is part of [Schema], does not contain data itself) that has the same
@@ -80,23 +83,24 @@ public fun AnyCol.toArrowField(mismatchSubscriber: (ConvertingMismatch) -> Unit 
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalDate?>()) ||
-            columnType.isSubtypeOf(typeOf<kotlinx.datetime.LocalDate?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalDate?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalDate?>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.DAY), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalDateTime?>()) ||
-            columnType.isSubtypeOf(typeOf<kotlinx.datetime.LocalDateTime?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalDateTime?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalDateTime?>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.MILLISECOND), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalTime?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalTime?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalTime>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Time(TimeUnit.NANOSECOND, 64), null),

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.io
 
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.LocalTime
 import org.apache.arrow.vector.types.DateUnit
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.TimeUnit
@@ -12,6 +9,7 @@ import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.typeClass
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
 import java.time.LocalDate as JavaLocalDate
@@ -27,80 +25,80 @@ public fun AnyCol.toArrowField(mismatchSubscriber: (ConvertingMismatch) -> Unit 
     val columnType = column.type()
     val nullable = columnType.isMarkedNullable
     return when {
-        columnType.isSubtypeOf(typeOf<String?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_STRING) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Utf8(), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Boolean?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_BOOLEAN) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Bool(), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Byte?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_BYTE) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Int(8, true), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Short?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_SHORT) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Int(16, true), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Int?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_INT) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Int(32, true), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Long?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_LONG) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Int(64, true), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Float?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_FLOAT) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<Double?>()) ->
+        columnType.isSubtypeOf(TypeOf.NULLABLE_DOUBLE) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<JavaLocalDate?>()) ||
-            columnType.isSubtypeOf(typeOf<LocalDate?>()) ->
+        columnType.isSubtypeOf(typeOfNullableJavaLocalDate) ||
+            columnType.isSubtypeOf(TypeOf.NULLABLE_LOCAL_DATE) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.DAY), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<JavaLocalDateTime?>()) ||
-            columnType.isSubtypeOf(typeOf<LocalDateTime?>()) ->
+        columnType.isSubtypeOf(typeOfNullableJavaLocalDateTime) ||
+            columnType.isSubtypeOf(TypeOf.NULLABLE_LOCAL_DATE_TIME) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.MILLISECOND), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<JavaLocalTime?>()) ||
-            columnType.isSubtypeOf(typeOf<LocalTime>()) ->
+        columnType.isSubtypeOf(typeOfNullableJavaLocalTime) ||
+            columnType.isSubtypeOf(TypeOf.NULLABLE_LOCAL_TIME) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Time(TimeUnit.NANOSECOND, 64), null),
@@ -113,6 +111,10 @@ public fun AnyCol.toArrowField(mismatchSubscriber: (ConvertingMismatch) -> Unit 
         }
     }
 }
+
+private val typeOfNullableJavaLocalDateTime = typeOf<JavaLocalDateTime?>()
+private val typeOfNullableJavaLocalDate = typeOf<JavaLocalDate?>()
+private val typeOfNullableJavaLocalTime = typeOf<JavaLocalTime?>()
 
 /**
  * Create Arrow [Schema] matching [this] actual data.

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
@@ -3,6 +3,11 @@ package org.jetbrains.kotlinx.dataframe.io
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toJavaInstant
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.TimeStampMicroVector
 import org.apache.arrow.vector.TimeStampMilliVector
@@ -46,9 +51,6 @@ import java.io.File
 import java.net.URL
 import java.nio.channels.Channels
 import java.sql.DriverManager
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import java.util.Locale
 import kotlin.reflect.typeOf
 
@@ -499,9 +501,9 @@ internal class ArrowKtTest {
     @Test
     fun testTimeStamp() {
         val dates = listOf(
-            LocalDateTime.of(2023, 11, 23, 9, 30, 25),
-            LocalDateTime.of(2015, 5, 25, 14, 20, 13),
-            LocalDateTime.of(2013, 6, 19, 11, 20, 13),
+            LocalDateTime(2023, 11, 23, 9, 30, 25),
+            LocalDateTime(2015, 5, 25, 14, 20, 13),
+            LocalDateTime(2013, 6, 19, 11, 20, 13),
         )
 
         val dataFrame = dataFrameOf(
@@ -554,7 +556,7 @@ internal class ArrowKtTest {
                 timeStampSecVector.allocateNew(dates.size)
 
                 dates.forEachIndexed { index, localDateTime ->
-                    val instant = localDateTime.toInstant(ZoneOffset.UTC)
+                    val instant = localDateTime.toInstant(UtcOffset.ZERO).toJavaInstant()
                     timeStampNanoVector[index] = instant.toEpochMilli() * 1_000_000L + instant.nano
                     timeStampMicroVector[index] = instant.toEpochMilli() * 1_000L
                     timeStampMilliVector[index] = instant.toEpochMilli()
@@ -580,10 +582,10 @@ internal class ArrowKtTest {
 
     private fun expectedSimpleDataFrame(): AnyFrame {
         val dates = listOf(
-            LocalDateTime.of(2020, 11, 23, 9, 30, 25),
-            LocalDateTime.of(2015, 5, 25, 14, 20, 13),
-            LocalDateTime.of(2013, 6, 19, 11, 20, 13),
-            LocalDateTime.of(2000, 1, 1, 0, 0, 0),
+            LocalDateTime(2020, 11, 23, 9, 30, 25),
+            LocalDateTime(2015, 5, 25, 14, 20, 13),
+            LocalDateTime(2013, 6, 19, 11, 20, 13),
+            LocalDateTime(2000, 1, 1, 0, 0, 0),
         )
 
         return dataFrameOf(

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.toKotlinLocalTime
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.forEachIndexed
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import java.math.BigInteger
 import java.time.ZoneOffset
 import kotlin.math.absoluteValue
@@ -44,19 +45,19 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val asciiStringCol = exampleFrame["asciiString"] as DataColumn<String?>
-    asciiStringCol.type() shouldBe typeOf<String>().withNullability(expectedNullable)
+    asciiStringCol.type() shouldBe TypeOf.STRING.withNullability(expectedNullable)
     asciiStringCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, "Test Example ${iBatch(i)}")
     }
 
     val utf8StringCol = exampleFrame["utf8String"] as DataColumn<String?>
-    utf8StringCol.type() shouldBe typeOf<String>().withNullability(expectedNullable)
+    utf8StringCol.type() shouldBe TypeOf.STRING.withNullability(expectedNullable)
     utf8StringCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, "Тестовый пример ${iBatch(i)}")
     }
 
     val largeStringCol = exampleFrame["largeString"] as DataColumn<String?>
-    largeStringCol.type() shouldBe typeOf<String>().withNullability(expectedNullable)
+    largeStringCol.type() shouldBe TypeOf.STRING.withNullability(expectedNullable)
     largeStringCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, "Test Example Should Be Large ${iBatch(i)}")
     }
@@ -68,19 +69,19 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val byteCol = exampleFrame["byte"] as DataColumn<Byte?>
-    byteCol.type() shouldBe typeOf<Byte>().withNullability(expectedNullable)
+    byteCol.type() shouldBe TypeOf.BYTE.withNullability(expectedNullable)
     byteCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, (iBatch(i) * 10).toByte())
     }
 
     val shortCol = exampleFrame["short"] as DataColumn<Short?>
-    shortCol.type() shouldBe typeOf<Short>().withNullability(expectedNullable)
+    shortCol.type() shouldBe TypeOf.SHORT.withNullability(expectedNullable)
     shortCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, (iBatch(i) * 1000).toShort())
     }
 
     val intCol = exampleFrame["int"] as DataColumn<Int?>
-    intCol.type() shouldBe typeOf<Int>().withNullability(expectedNullable)
+    intCol.type() shouldBe TypeOf.INT.withNullability(expectedNullable)
     intCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, iBatch(i) * 100000000)
     }
@@ -92,13 +93,13 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val unsignedByteCol = exampleFrame["unsigned_byte"] as DataColumn<Short?>
-    unsignedByteCol.type() shouldBe typeOf<Short>().withNullability(expectedNullable)
+    unsignedByteCol.type() shouldBe TypeOf.SHORT.withNullability(expectedNullable)
     unsignedByteCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, (iBatch(i) * 10 % (Byte.MIN_VALUE.toShort() * 2).absoluteValue).toShort())
     }
 
     val unsignedShortCol = exampleFrame["unsigned_short"] as DataColumn<Int?>
-    unsignedShortCol.type() shouldBe typeOf<Int>().withNullability(expectedNullable)
+    unsignedShortCol.type() shouldBe TypeOf.INT.withNullability(expectedNullable)
     unsignedShortCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, iBatch(i) * 1000 % (Short.MIN_VALUE.toInt() * 2).absoluteValue)
     }
@@ -125,13 +126,13 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val floatCol = exampleFrame["float"] as DataColumn<Float?>
-    floatCol.type() shouldBe typeOf<Float>().withNullability(expectedNullable)
+    floatCol.type() shouldBe TypeOf.FLOAT.withNullability(expectedNullable)
     floatCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, 2.0f.pow(iBatch(i).toFloat()))
     }
 
     val doubleCol = exampleFrame["double"] as DataColumn<Double?>
-    doubleCol.type() shouldBe typeOf<Double>().withNullability(expectedNullable)
+    doubleCol.type() shouldBe TypeOf.DOUBLE.withNullability(expectedNullable)
     doubleCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, 2.0.pow(iBatch(i)))
     }
@@ -143,7 +144,7 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val datetimeCol = exampleFrame["date64"] as DataColumn<LocalDateTime?>
-    datetimeCol.type() shouldBe typeOf<LocalDateTime>().withNullability(expectedNullable)
+    datetimeCol.type() shouldBe TypeOf.LOCAL_DATE_TIME.withNullability(expectedNullable)
     datetimeCol.forEachIndexed { i, element ->
         assertValueOrNull(
             rowNumber = iBatch(i),
@@ -155,13 +156,13 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val timeSecCol = exampleFrame["time32_seconds"] as DataColumn<LocalTime?>
-    timeSecCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
+    timeSecCol.type() shouldBe TypeOf.LOCAL_TIME.withNullability(expectedNullable)
     timeSecCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, JavaLocalTime.ofSecondOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }
 
     val timeMilliCol = exampleFrame["time32_milli"] as DataColumn<LocalTime?>
-    timeMilliCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
+    timeMilliCol.type() shouldBe TypeOf.LOCAL_TIME.withNullability(expectedNullable)
     timeMilliCol.forEachIndexed { i, element ->
         assertValueOrNull(
             rowNumber = iBatch(i),
@@ -171,13 +172,13 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     }
 
     val timeMicroCol = exampleFrame["time64_micro"] as DataColumn<LocalTime?>
-    timeMicroCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
+    timeMicroCol.type() shouldBe TypeOf.LOCAL_TIME.withNullability(expectedNullable)
     timeMicroCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000).toKotlinLocalTime())
     }
 
     val timeNanoCol = exampleFrame["time64_nano"] as DataColumn<LocalTime?>
-    timeNanoCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
+    timeNanoCol.type() shouldBe TypeOf.LOCAL_TIME.withNullability(expectedNullable)
     timeNanoCol.forEachIndexed { i, element ->
         assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
@@ -1,18 +1,24 @@
 package org.jetbrains.kotlinx.dataframe.io
 
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.forEachIndexed
 import java.math.BigInteger
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.ZoneOffset
 import kotlin.math.absoluteValue
 import kotlin.math.pow
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * Assert that we have got the same data that was originally saved on example creation.
@@ -133,7 +139,7 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     val dateCol = exampleFrame["date32"] as DataColumn<LocalDate?>
     dateCol.type() shouldBe typeOf<LocalDate>().withNullability(expectedNullable)
     dateCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalDate.ofEpochDay(iBatch(i).toLong() * 30))
+        assertValueOrNull(iBatch(i), element, JavaLocalDate.ofEpochDay(iBatch(i).toLong() * 30).toKotlinLocalDate())
     }
 
     val datetimeCol = exampleFrame["date64"] as DataColumn<LocalDateTime?>
@@ -142,32 +148,38 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
         assertValueOrNull(
             rowNumber = iBatch(i),
             actual = element,
-            expected = LocalDateTime.ofEpochSecond(iBatch(i).toLong() * 60 * 60 * 24 * 30, 0, ZoneOffset.UTC),
+            expected = JavaLocalDateTime
+                .ofEpochSecond(iBatch(i).toLong() * 60 * 60 * 24 * 30, 0, ZoneOffset.UTC)
+                .toKotlinLocalDateTime(),
         )
     }
 
     val timeSecCol = exampleFrame["time32_seconds"] as DataColumn<LocalTime?>
     timeSecCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeSecCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofSecondOfDay(iBatch(i).toLong()))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofSecondOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }
 
     val timeMilliCol = exampleFrame["time32_milli"] as DataColumn<LocalTime?>
     timeMilliCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeMilliCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000_000))
+        assertValueOrNull(
+            rowNumber = iBatch(i),
+            actual = element,
+            expected = JavaLocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000_000).toKotlinLocalTime(),
+        )
     }
 
     val timeMicroCol = exampleFrame["time64_micro"] as DataColumn<LocalTime?>
     timeMicroCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeMicroCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000).toKotlinLocalTime())
     }
 
     val timeNanoCol = exampleFrame["time64_nano"] as DataColumn<LocalTime?>
     timeNanoCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeNanoCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong()))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }
 
     exampleFrame.getColumnOrNull("nulls")?.let { nullCol ->

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import java.net.URL
-import java.time.LocalDate
 
 /**
  * DataFrame to be saved in Apache Arrow
@@ -67,12 +67,12 @@ val citiesExampleFrame = dataFrameOf(
     DataColumn.createValueColumn(
         "settled",
         listOf(
-            LocalDate.of(1237, 1, 1),
-            LocalDate.of(1189, 5, 7),
-            LocalDate.of(1624, 1, 1),
-            LocalDate.of(1790, 7, 16),
-            LocalDate.of(1703, 5, 27),
-            LocalDate.of(1929, 2, 11),
+            LocalDate(1237, 1, 1),
+            LocalDate(1189, 5, 7),
+            LocalDate(1624, 1, 1),
+            LocalDate(1790, 7, 16),
+            LocalDate(1703, 5, 27),
+            LocalDate(1929, 2, 11),
         ),
     ),
     DataColumn.createValueColumn(

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -37,10 +39,10 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.URL
 import java.nio.file.Files
-import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.Calendar
-import java.util.Date
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.util.Date as JavaDate
 
 public class Excel : SupportedDataFrameFormat {
     override fun readDataFrame(stream: InputStream, header: List<String>): AnyFrame = DataFrame.readExcel(stream)
@@ -474,15 +476,15 @@ public fun <T> DataFrame<T>.writeExcel(
                 cell.setCellValueByGuessedType(any)
 
                 when (any) {
-                    is LocalDate, is kotlinx.datetime.LocalDate -> {
+                    is JavaLocalDate, is LocalDate -> {
                         cell.cellStyle = cellStyleDate
                     }
 
-                    is Calendar, is Date -> {
+                    is Calendar, is JavaDate -> {
                         cell.cellStyle = cellStyleDateTime
                     }
 
-                    is LocalDateTime -> {
+                    is JavaLocalDateTime -> {
                         if (any.year < 1900) {
                             cell.cellStyle = cellStyleTime
                         } else {
@@ -490,7 +492,7 @@ public fun <T> DataFrame<T>.writeExcel(
                         }
                     }
 
-                    is kotlinx.datetime.LocalDateTime -> {
+                    is LocalDateTime -> {
                         if (any.year < 1900) {
                             cell.cellStyle = cellStyleTime
                         } else {
@@ -515,23 +517,23 @@ private fun Cell.setCellValueByGuessedType(any: Any) =
 
         is Number -> this.setCellValue(any.toDouble())
 
-        is LocalDate -> this.setCellValue(any)
+        is JavaLocalDate -> this.setCellValue(any)
 
-        is LocalDateTime -> this.setTime(any)
+        is JavaLocalDateTime -> this.setTime(any)
 
         is Boolean -> this.setCellValue(any)
 
         is Calendar -> this.setDate(any.time)
 
-        is Date -> this.setDate(any)
+        is JavaDate -> this.setDate(any)
 
         is RichTextString -> this.setCellValue(any)
 
         is String -> this.setCellValue(any)
 
-        is kotlinx.datetime.LocalDate -> this.setCellValue(any.toJavaLocalDate())
+        is LocalDate -> this.setCellValue(any.toJavaLocalDate())
 
-        is kotlinx.datetime.LocalDateTime -> this.setTime(any.toJavaLocalDateTime())
+        is LocalDateTime -> this.setTime(any.toJavaLocalDateTime())
 
         // Another option would be to serialize everything else to string,
         // but people can convert columns to string with any serialization framework they want
@@ -545,7 +547,7 @@ private fun Cell.setCellValueByGuessedType(any: Any) =
  * are displayed as 00.01.1900 in Excel and as 30.12.1899 in LibreOffice Calc and also in POI.
  * POI can not set 1899 year directly.
  */
-private fun Cell.setTime(localDateTime: LocalDateTime) {
+private fun Cell.setTime(localDateTime: JavaLocalDateTime) {
     this.setCellValue(DateUtil.getExcelDate(localDateTime.plusDays(1)) - 1.0)
 }
 
@@ -555,7 +557,7 @@ private fun Cell.setTime(localDateTime: LocalDateTime) {
  * are displayed as 00.01.1900 in Excel and as 30.12.1899 in LibreOffice Calc and also in POI.
  * POI can not set 1899 year directly.
  */
-private fun Cell.setDate(date: Date) {
+private fun Cell.setDate(date: JavaDate) {
     val calStart = LocaleUtil.getLocaleCalendar()
     calStart.time = date
     this.setTime(calStart.toInstant().atZone(getUserTimeZone().toZoneId()).toLocalDateTime())

--- a/dataframe-excel/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/XlsxTest.kt
+++ b/dataframe-excel/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/XlsxTest.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlinx.dataframe.io
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.LocalDateTime
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.concat
@@ -11,10 +10,10 @@ import org.jetbrains.kotlinx.dataframe.api.toColumn
 import org.jetbrains.kotlinx.dataframe.exceptions.DuplicateColumnNamesException
 import org.jetbrains.kotlinx.dataframe.impl.DataFrameSize
 import org.jetbrains.kotlinx.dataframe.size
+import org.jetbrains.kotlinx.dataframe.util.TypeOf
 import org.junit.Test
 import java.net.URL
 import java.nio.file.Files
-import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class XlsxTest {
@@ -86,7 +85,7 @@ class XlsxTest {
     @Test
     fun `read date time`() {
         val df = DataFrame.read(testResource("datetime.xlsx"))
-        df["time"].type() shouldBe typeOf<LocalDateTime>()
+        df["time"].type() shouldBe TypeOf.LOCAL_DATE_TIME
     }
 
     @Test
@@ -196,7 +195,7 @@ class XlsxTest {
             testResource("mixed_column.xlsx"),
             stringColumns = StringColumns("A"),
         )
-        df["col1"].type() shouldBe typeOf<String>()
+        df["col1"].type() shouldBe TypeOf.STRING
         df shouldBe dataFrameOf("col1")("100", "A100", "B100", "C100")
     }
 }


### PR DESCRIPTION
As described in [this YT issue](https://youtrack.jetbrains.com/issue/KT-53508), `typeOf<>()` is a very heavy operation. A single call to it creates a completely fresh reflection environment and can result in hundreds of function calls.

![image](https://github.com/user-attachments/assets/a8a5c224-a253-4e9f-b294-e1df354129ba)

I found a couple calls (like `typeOf<String>()`) which are called 30+ times across the library!

This PR tries to minimize these calls by collecting the most-used KTypes into a single place. They are lazily evaluated when needed, so they shouldn't take up much memory when unused. I expect runtime performance improvements across the library and especially in the tests, as lots of type-checks are done there.

I've converted core/src and core/test already but I'll need to look into the other modules to replace some of the typeOf calls there too.


While working on the PR I found some inconsistencies with kotlinx datetime and java datetime classes. I've addressed those in a separate commit, make sure to check that too :).