### PR TITLE
allow applying ksp to custom configs

### DIFF
--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -58,7 +58,10 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                         }
                     }
                 }
-                val overriddenConfigs = target.findProperty(PROP_KSP_CONFIGS)?.let { (it as String) }?.split(",")
+                val overriddenConfigs = target.findProperty(PROP_KSP_CONFIGS)
+                    ?.let { (it as String) }
+                    ?.split(",")
+                    ?.map { it.trim() }
                 val configs = when {
                     overriddenConfigs != null -> overriddenConfigs
                     isMultiplatform -> listOf("kspJvm", "kspJvmTest")

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -47,8 +47,19 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                         }
                     }
                 }
-                val overriddenConfigs =
-                    target.properties.get("kotlin.dataframe.ksp.configs")?.let { (it as String)}?.split(",")
+                val customConfigsProp = "kotlin.dataframe.ksp.configs"
+                var overriddenConfigs =
+                    target.properties.get(customConfigsProp)?.let { (it as String)}?.split(",")
+                if (overriddenConfigs != null) {
+                    overriddenConfigs =
+                        target.extraProperties.get(customConfigsProp)?.let { (it as String)}?.split(",")
+                } else {
+                    if (customConfigsProp in target.extraProperties.properties) {
+                        target.logger.warn(
+                            "`$customConfigsProp` set as both a regular and an extra property. Only the regular property value is used.",
+                        )
+                    }
+                }
                 val configs = when {
                     overriddenConfigs != null -> overriddenConfigs
                     isMultiplatform -> listOf("kspJvm","kspJvmTest")


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/841 

As described in the issue, I needed to modify the ConvenienceSchemeGeneratorPlugin again (this is sort of part 2 after https://github.com/Kotlin/dataframe/pull/647). This PR is basically what I've been using for myself all of this time so I could correctly use dataframes in my custom source set. 

I think my solution is hacky and I am not sure this PR should be accepted, but it does get the job done for me.

I allow setting custom configs as either a gradle property or an extra property. The reason why is because while in my own code I set the extra property programatically based on some custom build logic that detects if a module has both android and jvm source sets, the extra property can only be set programatically wheras the regular property can be set in a `gradle.properties` file. I only use the extra property, but I expect if this PR is merged that others might want to do it via `gradle.properties`. `gradle.properties` would not work for me, however, because I need to set it programatically which is only supported by extra properties. Therefore, unforunately, the best I could think of was allow both. 

