### PR TITLE
Enforcing kotlinx datetime bias

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.kotlinx.dataframe.AnyBaseCol
@@ -38,7 +39,6 @@ import org.jetbrains.kotlinx.dataframe.io.toDataFrame
 import org.jetbrains.kotlinx.dataframe.path
 import java.math.BigDecimal
 import java.net.URL
-import java.time.LocalTime
 import java.util.Locale
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.impl.api
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.atTime
@@ -10,6 +11,7 @@ import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toJavaLocalTime
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -38,7 +40,6 @@ import org.jetbrains.kotlinx.dataframe.path
 import org.jetbrains.kotlinx.dataframe.type
 import java.math.BigDecimal
 import java.net.URL
-import java.time.LocalTime
 import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -49,6 +50,10 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
+import java.time.Instant as JavaInstant
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 @PublishedApi
 internal fun <T, C, R> Convert<T, C>.withRowCellImpl(
@@ -299,13 +304,19 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 LocalDate::class -> convert<Int> { it.toLong().toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<Long> {
-                    it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
+                LocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<Int> { Instant.fromEpochMilliseconds(it.toLong()) }
+
+                JavaLocalDateTime::class -> convert<Int> {
+                    it.toLong().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Int> { it.toLong().toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                LocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Int> { it.toLong().toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Int> { JavaInstant.ofEpochMilli(it.toLong()) }
 
                 else -> null
             }
@@ -341,13 +352,15 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 Instant::class -> convert<Long> { Instant.fromEpochMilliseconds(it) }
 
-                java.time.LocalDateTime::class -> convert<Long> {
+                JavaLocalDateTime::class -> convert<Long> {
                     it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                LocalTime::class -> convert<Long> { it.toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Long> { it.toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Long> { JavaInstant.ofEpochMilli(it) }
 
                 else -> null
             }
@@ -359,39 +372,45 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 LocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<Instant> {
+                LocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone) }
+
+                JavaLocalDateTime::class -> convert<Instant> {
                     it.toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
+                JavaLocalDate::class -> convert<Instant> { it.toLocalDate(defaultTimeZone).toJavaLocalDate() }
 
-                java.time.Instant::class -> convert<Instant> { it.toJavaInstant() }
+                JavaInstant::class -> convert<Instant> { it.toJavaInstant() }
 
-                LocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<Instant> { it.toLocalTime(defaultTimeZone).toJavaLocalTime() }
 
                 else -> null
             }
 
-            java.time.Instant::class -> when (toClass) {
-                Long::class -> convert<java.time.Instant> { it.toEpochMilli() }
+            JavaInstant::class -> when (toClass) {
+                Long::class -> convert<JavaInstant> { it.toEpochMilli() }
 
-                LocalDateTime::class -> convert<java.time.Instant> {
+                LocalDateTime::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDateTime(defaultTimeZone)
                 }
 
-                LocalDate::class -> convert<java.time.Instant> { it.toKotlinInstant().toLocalDate(defaultTimeZone) }
+                LocalDate::class -> convert<JavaInstant> { it.toKotlinInstant().toLocalDate(defaultTimeZone) }
 
-                java.time.LocalDateTime::class -> convert<java.time.Instant> {
+                LocalTime::class -> convert<JavaInstant> { it.toKotlinInstant().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<JavaInstant> { it.toKotlinInstant() }
+
+                JavaLocalDateTime::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
                 }
 
-                java.time.LocalDate::class -> convert<java.time.Instant> {
+                JavaLocalDate::class -> convert<JavaInstant> {
                     it.toKotlinInstant().toLocalDate(defaultTimeZone).toJavaLocalDate()
                 }
 
-                Instant::class -> convert<java.time.Instant> { it.toKotlinInstant() }
-
-                LocalTime::class -> convert<java.time.Instant> { it.toKotlinInstant().toLocalTime(defaultTimeZone) }
+                JavaLocalTime::class -> convert<JavaInstant> {
+                    it.toKotlinInstant().toLocalTime(defaultTimeZone).toJavaLocalTime()
+                }
 
                 else -> null
             }
@@ -417,30 +436,38 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
             LocalDateTime::class -> when (toClass) {
                 LocalDate::class -> convert<LocalDateTime> { it.date }
+                LocalTime::class -> convert<LocalDateTime> { it.time }
                 Instant::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone) }
                 Long::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone).toEpochMilliseconds() }
-                java.time.LocalDateTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime() }
-                java.time.LocalDate::class -> convert<LocalDateTime> { it.date.toJavaLocalDate() }
-                java.time.LocalTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime().toLocalTime() }
+                JavaLocalDateTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime() }
+                JavaLocalDate::class -> convert<LocalDateTime> { it.date.toJavaLocalDate() }
+                JavaLocalTime::class -> convert<LocalDateTime> { it.toJavaLocalDateTime().toLocalTime() }
+                JavaInstant::class -> convert<LocalDateTime> { it.toInstant(defaultTimeZone).toJavaInstant() }
                 else -> null
             }
 
-            java.time.LocalDateTime::class -> when (toClass) {
-                LocalDate::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime().date }
+            JavaLocalDateTime::class -> when (toClass) {
+                LocalDate::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime().date }
 
-                LocalDateTime::class -> convert<java.time.LocalDateTime> { it.toKotlinLocalDateTime() }
+                LocalTime::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime().time }
 
-                Instant::class -> convert<java.time.LocalDateTime> {
+                LocalDateTime::class -> convert<JavaLocalDateTime> { it.toKotlinLocalDateTime() }
+
+                Instant::class -> convert<JavaLocalDateTime> {
                     it.toKotlinLocalDateTime().toInstant(defaultTimeZone)
                 }
 
-                Long::class -> convert<java.time.LocalDateTime> {
+                Long::class -> convert<JavaLocalDateTime> {
                     it.toKotlinLocalDateTime().toInstant(defaultTimeZone).toEpochMilliseconds()
                 }
 
-                java.time.LocalDate::class -> convert<java.time.LocalDateTime> { it.toLocalDate() }
+                JavaLocalDate::class -> convert<JavaLocalDateTime> { it.toLocalDate() }
 
-                java.time.LocalTime::class -> convert<java.time.LocalDateTime> { it.toLocalTime() }
+                JavaLocalTime::class -> convert<JavaLocalDateTime> { it.toLocalTime() }
+
+                JavaInstant::class -> convert<JavaLocalDateTime> {
+                    it.toKotlinLocalDateTime().toInstant(defaultTimeZone).toJavaInstant()
+                }
 
                 else -> null
             }
@@ -449,25 +476,30 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 LocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0) }
                 Instant::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone) }
                 Long::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone).toEpochMilliseconds() }
-                java.time.LocalDate::class -> convert<LocalDate> { it.toJavaLocalDate() }
-                java.time.LocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0).toJavaLocalDateTime() }
+                JavaLocalDate::class -> convert<LocalDate> { it.toJavaLocalDate() }
+                JavaLocalDateTime::class -> convert<LocalDate> { it.atTime(0, 0).toJavaLocalDateTime() }
+                JavaInstant::class -> convert<LocalDate> { it.atStartOfDayIn(defaultTimeZone).toJavaInstant() }
                 else -> null
             }
 
-            java.time.LocalDate::class -> when (toClass) {
-                LocalDate::class -> convert<java.time.LocalDate> { it.toKotlinLocalDate() }
+            JavaLocalDate::class -> when (toClass) {
+                LocalDate::class -> convert<JavaLocalDate> { it.toKotlinLocalDate() }
 
-                LocalDateTime::class -> convert<java.time.LocalDate> { it.atTime(0, 0).toKotlinLocalDateTime() }
+                LocalDateTime::class -> convert<JavaLocalDate> { it.atTime(0, 0).toKotlinLocalDateTime() }
 
-                Instant::class -> convert<java.time.LocalDate> {
+                Instant::class -> convert<JavaLocalDate> {
                     it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone)
                 }
 
-                Long::class -> convert<java.time.LocalDate> {
+                Long::class -> convert<JavaLocalDate> {
                     it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone).toEpochMilliseconds()
                 }
 
-                java.time.LocalDateTime::class -> convert<java.time.LocalDate> { it.atStartOfDay() }
+                JavaLocalDateTime::class -> convert<JavaLocalDate> { it.atStartOfDay() }
+
+                JavaInstant::class -> convert<JavaLocalDate> {
+                    it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone).toJavaInstant()
+                }
 
                 else -> null
             }
@@ -488,12 +520,10 @@ internal fun Long.toLocalDateTime(zone: TimeZone = defaultTimeZone) =
 
 internal fun Long.toLocalDate(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).date
 
-internal fun Long.toLocalTime(zone: TimeZone = defaultTimeZone) =
-    toLocalDateTime(zone).toJavaLocalDateTime().toLocalTime()
+internal fun Long.toLocalTime(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).time
 
 internal fun Instant.toLocalDate(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).date
 
-internal fun Instant.toLocalTime(zone: TimeZone = defaultTimeZone) =
-    toLocalDateTime(zone).toJavaLocalDateTime().toLocalTime()
+internal fun Instant.toLocalTime(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).time
 
 internal val defaultTimeZone = TimeZone.currentSystemDefault()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -1,8 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.impl.api
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -31,9 +35,6 @@ import org.jetbrains.kotlinx.dataframe.typeClass
 import java.net.URL
 import java.text.NumberFormat
 import java.text.ParsePosition
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.util.Locale
@@ -43,6 +44,11 @@ import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import kotlin.time.Duration
+import java.time.Duration as JavaDuration
+import java.time.Instant as JavaInstant
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 internal interface StringParser<T> {
     fun toConverter(options: ParserOptions?): TypeConverter
@@ -132,17 +138,20 @@ internal object Parsers : GlobalParserOptions {
         resetToDefault()
     }
 
-    private fun String.toLocalDateTimeOrNull(formatter: DateTimeFormatter?): LocalDateTime? {
+    private fun String.toJavaLocalDateTimeOrNull(formatter: DateTimeFormatter?): JavaLocalDateTime? {
         if (formatter != null) {
-            return catchSilent { java.time.LocalDateTime.parse(this, formatter) }
+            return catchSilent { JavaLocalDateTime.parse(this, formatter) }
         } else {
-            catchSilent { LocalDateTime.parse(this) }?.let { return it }
+            catchSilent { JavaLocalDateTime.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { java.time.LocalDateTime.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalDateTime.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
+
+    private fun String.toLocalDateTimeOrNull(formatter: DateTimeFormatter?): LocalDateTime? =
+        toJavaLocalDateTimeOrNull(formatter)?.toKotlinLocalDateTime()
 
     private fun String.toUrlOrNull(): URL? = if (isURL(this)) catchSilent { URL(this) } else null
 
@@ -157,29 +166,35 @@ internal object Parsers : GlobalParserOptions {
             else -> null
         }
 
-    private fun String.toLocalDateOrNull(formatter: DateTimeFormatter?): LocalDate? {
+    private fun String.toJavaLocalDateOrNull(formatter: DateTimeFormatter?): JavaLocalDate? {
         if (formatter != null) {
-            return catchSilent { java.time.LocalDate.parse(this, formatter) }
+            return catchSilent { JavaLocalDate.parse(this, formatter) }
         } else {
-            catchSilent { LocalDate.parse(this) }?.let { return it }
+            catchSilent { JavaLocalDate.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { java.time.LocalDate.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalDate.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
 
-    private fun String.toLocalTimeOrNull(formatter: DateTimeFormatter?): LocalTime? {
+    private fun String.toLocalDateOrNull(formatter: DateTimeFormatter?): LocalDate? =
+        toJavaLocalDateOrNull(formatter)?.toKotlinLocalDate()
+
+    private fun String.toJavaLocalTimeOrNull(formatter: DateTimeFormatter?): JavaLocalTime? {
         if (formatter != null) {
-            return catchSilent { LocalTime.parse(this, formatter) }
+            return catchSilent { JavaLocalTime.parse(this, formatter) }
         } else {
-            catchSilent { LocalTime.parse(this) }?.let { return it }
+            catchSilent { JavaLocalTime.parse(this) }?.let { return it }
             for (format in formatters) {
-                catchSilent { LocalTime.parse(this, format) }?.let { return it }
+                catchSilent { JavaLocalTime.parse(this, format) }?.let { return it }
             }
         }
         return null
     }
+
+    private fun String.toLocalTimeOrNull(formatter: DateTimeFormatter?): LocalTime? =
+        toJavaLocalTimeOrNull(formatter)?.toKotlinLocalTime()
 
     private fun String.parseDouble(format: NumberFormat) =
         when (uppercase(Locale.getDefault())) {
@@ -234,39 +249,45 @@ internal object Parsers : GlobalParserOptions {
         // kotlinx.datetime.Instant
         stringParser { catchSilent { Instant.parse(it) } },
         // java.time.Instant
-        stringParser { catchSilent { java.time.Instant.parse(it) } },
+        stringParser { catchSilent { JavaInstant.parse(it) } },
         // kotlinx.datetime.LocalDateTime
-        stringParserWithOptions { options ->
-            val formatter = options?.getDateTimeFormatter()
-            val parser = { it: String -> it.toLocalDateTimeOrNull(formatter)?.toKotlinLocalDateTime() }
-            parser
-        },
-        // java.time.LocalDateTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalDateTimeOrNull(formatter) }
             parser
         },
-        // kotlinx.datetime.LocalDate
+        // java.time.LocalDateTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
-            val parser = { it: String -> it.toLocalDateOrNull(formatter)?.toKotlinLocalDate() }
+            val parser = { it: String -> it.toJavaLocalDateTimeOrNull(formatter) }
             parser
         },
-        // java.time.LocalDate
+        // kotlinx.datetime.LocalDate
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalDateOrNull(formatter) }
             parser
         },
+        // java.time.LocalDate
+        stringParserWithOptions { options ->
+            val formatter = options?.getDateTimeFormatter()
+            val parser = { it: String -> it.toJavaLocalDateOrNull(formatter) }
+            parser
+        },
         // kotlin.time.Duration
         stringParser { catchSilent { Duration.parse(it) } },
         // java.time.Duration
-        stringParser { catchSilent { java.time.Duration.parse(it) } },
-        // java.time.LocalTime
+        stringParser { catchSilent { JavaDuration.parse(it) } },
+        // kotlinx.datetime.LocalTime
         stringParserWithOptions { options ->
             val formatter = options?.getDateTimeFormatter()
             val parser = { it: String -> it.toLocalTimeOrNull(formatter) }
+            parser
+        },
+        // java.time.LocalTime
+        stringParserWithOptions { options ->
+            val formatter = options?.getDateTimeFormatter()
+            val parser = { it: String -> it.toJavaLocalTimeOrNull(formatter) }
             parser
         },
         // java.net.URL

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVRecord
 import org.apache.commons.io.input.BOMInputStream
@@ -34,9 +37,6 @@ import java.io.StringWriter
 import java.math.BigDecimal
 import java.net.URL
 import java.nio.charset.Charset
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.util.zip.GZIPInputStream
 import kotlin.reflect.KClass
 import kotlin.reflect.full.withNullability

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalTime
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
@@ -13,7 +14,6 @@ import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.hasNulls
 import org.junit.Test
-import java.time.LocalTime
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.hours
 
@@ -24,7 +24,7 @@ class ConvertTests {
         val time by columnOf("11?22?33", null)
         val converted = time.toDataFrame().convert { time }.toLocalTime("HH?mm?ss")[time]
         converted.hasNulls shouldBe true
-        converted[0] shouldBe LocalTime.of(11, 22, 33)
+        converted[0] shouldBe LocalTime(11, 22, 33)
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -4,11 +4,11 @@ import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.type
 import org.junit.Test
-import java.time.LocalTime
-import java.time.Month
 import java.util.Locale
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.days

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ParserTests.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.io
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -23,7 +24,6 @@ import org.jetbrains.kotlinx.dataframe.api.tryParse
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.junit.Test
 import java.math.BigDecimal
-import java.time.LocalTime
 import java.util.Locale
 import kotlin.reflect.typeOf
 
@@ -106,9 +106,9 @@ class ParserTests {
         )
         longCol.convertToLocalTime(TimeZone.UTC).shouldBe(
             columnOf(
-                LocalTime.of(0, 0, 1),
-                LocalTime.of(0, 1, 0),
-                LocalTime.of(1, 0, 0),
+                LocalTime(0, 0, 1),
+                LocalTime(0, 1, 0),
+                LocalTime(1, 0, 0),
             ),
         )
 
@@ -121,9 +121,9 @@ class ParserTests {
         )
         datetimeCol.convertToLocalTime().shouldBe(
             columnOf(
-                LocalTime.of(0, 0, 1),
-                LocalTime.of(0, 1, 0),
-                LocalTime.of(1, 0, 0),
+                LocalTime(0, 0, 1),
+                LocalTime(0, 1, 0),
+                LocalTime(1, 0, 0),
             ),
         )
     }

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.io
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toJavaLocalTime
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BaseFixedWidthVector
 import org.apache.arrow.vector.BaseVariableWidthVector
@@ -226,8 +227,7 @@ internal class ArrowWriterImpl(
                     }
 
             is DateDayVector ->
-                column
-                    .convertToLocalDate()
+                column.convertToLocalDate()
                     .forEachIndexed { i, value ->
                         value?.also { vector.set(i, value.toJavaLocalDate().toEpochDay().toInt()) }
                             ?: vector.setNull(i)
@@ -243,29 +243,30 @@ internal class ArrowWriterImpl(
             is TimeNanoVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toNanoOfDay()) }
+                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay()) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMicroVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toNanoOfDay() / 1000) }
+                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay() / 1000) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMilliVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, (value.toNanoOfDay() / 1000 / 1000).toInt()) }
+                        value?.also { vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000).toInt()) }
                             ?: vector.setNull(i)
                     }
 
             is TimeSecVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, (value.toNanoOfDay() / 1000 / 1000 / 1000).toInt()) }
-                            ?: vector.setNull(i)
+                        value?.also {
+                            vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000 / 1000).toInt())
+                        } ?: vector.setNull(i)
                     }
 
             else -> {

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowWriterImpl.kt
@@ -2,8 +2,6 @@ package org.jetbrains.kotlinx.dataframe.io
 
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toJavaLocalDate
-import kotlinx.datetime.toJavaLocalTime
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BaseFixedWidthVector
 import org.apache.arrow.vector.BaseVariableWidthVector
@@ -229,7 +227,7 @@ internal class ArrowWriterImpl(
             is DateDayVector ->
                 column.convertToLocalDate()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toJavaLocalDate().toEpochDay().toInt()) }
+                        value?.also { vector.set(i, value.toEpochDays()) }
                             ?: vector.setNull(i)
                     }
 
@@ -243,21 +241,21 @@ internal class ArrowWriterImpl(
             is TimeNanoVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay()) }
+                        value?.also { vector.set(i, value.toNanosecondOfDay()) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMicroVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, value.toJavaLocalTime().toNanoOfDay() / 1000) }
+                        value?.also { vector.set(i, value.toNanosecondOfDay() / 1000) }
                             ?: vector.setNull(i)
                     }
 
             is TimeMilliVector ->
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
-                        value?.also { vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000).toInt()) }
+                        value?.also { vector.set(i, (value.toNanosecondOfDay() / 1000 / 1000).toInt()) }
                             ?: vector.setNull(i)
                     }
 
@@ -265,7 +263,7 @@ internal class ArrowWriterImpl(
                 column.convertToLocalTime()
                     .forEachIndexed { i, value ->
                         value?.also {
-                            vector.set(i, (value.toJavaLocalTime().toNanoOfDay() / 1000 / 1000 / 1000).toInt())
+                            vector.set(i, (value.toNanosecondOfDay() / 1000 / 1000 / 1000).toInt())
                         } ?: vector.setNull(i)
                     }
 

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
@@ -1,5 +1,11 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.BitVector
@@ -55,13 +61,12 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.SeekableByteChannel
-import java.time.Duration
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlin.reflect.KType
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * same as [Iterable<DataFrame<T>>.concat()] without internal type guessing (all batches should have the same schema)
@@ -108,7 +113,7 @@ private fun Float4Vector.values(range: IntRange): List<Float?> = range.map { get
 
 private fun Float8Vector.values(range: IntRange): List<Double?> = range.map { getObject(it) }
 
-private fun DurationVector.values(range: IntRange): List<Duration?> = range.map { getObject(it) }
+private fun DurationVector.values(range: IntRange): List<Duration?> = range.map { getObject(it).toKotlinDuration() }
 
 private fun DateDayVector.values(range: IntRange): List<LocalDate?> =
     range.map {
@@ -117,17 +122,19 @@ private fun DateDayVector.values(range: IntRange): List<LocalDate?> =
         } else {
             DateUtility.getLocalDateTimeFromEpochMilli(getObject(it).toLong() * DateUtility.daysToStandardMillis)
                 .toLocalDate()
+                .toKotlinLocalDate()
         }
     }
 
-private fun DateMilliVector.values(range: IntRange): List<LocalDateTime?> = range.map { getObject(it) }
+private fun DateMilliVector.values(range: IntRange): List<LocalDateTime?> =
+    range.map { getObject(it)?.toKotlinLocalDateTime() }
 
 private fun TimeNanoVector.values(range: IntRange): List<LocalTime?> =
     range.mapIndexed { i, it ->
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(get(it))
+            JavaLocalTime.ofNanoOfDay(get(it)).toKotlinLocalTime()
         }
     }
 
@@ -136,7 +143,7 @@ private fun TimeMicroVector.values(range: IntRange): List<LocalTime?> =
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(getObject(it) * 1000)
+            JavaLocalTime.ofNanoOfDay(getObject(it) * 1000).toKotlinLocalTime()
         }
     }
 
@@ -145,19 +152,19 @@ private fun TimeMilliVector.values(range: IntRange): List<LocalTime?> =
         if (isNull(i)) {
             null
         } else {
-            LocalTime.ofNanoOfDay(get(it).toLong() * 1000_000)
+            JavaLocalTime.ofNanoOfDay(get(it).toLong() * 1000_000).toKotlinLocalTime()
         }
     }
 
 private fun TimeSecVector.values(range: IntRange): List<LocalTime?> =
-    range.map { getObject(it)?.let { LocalTime.ofSecondOfDay(it.toLong()) } }
+    range.map { getObject(it)?.let { JavaLocalTime.ofSecondOfDay(it.toLong()).toKotlinLocalTime() } }
 
 private fun TimeStampNanoVector.values(range: IntRange): List<LocalDateTime?> =
     range.mapIndexed { i, it ->
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -166,7 +173,7 @@ private fun TimeStampMicroVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -175,7 +182,7 @@ private fun TimeStampMilliVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 
@@ -184,7 +191,7 @@ private fun TimeStampSecVector.values(range: IntRange): List<LocalDateTime?> =
         if (isNull(i)) {
             null
         } else {
-            getObject(it)
+            getObject(it).toKotlinLocalDateTime()
         }
     }
 

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowTypesMatching.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import org.apache.arrow.vector.types.DateUnit
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.TimeUnit
@@ -9,11 +12,11 @@ import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.typeClass
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * Create Arrow [Field] (note: this is part of [Schema], does not contain data itself) that has the same
@@ -80,23 +83,24 @@ public fun AnyCol.toArrowField(mismatchSubscriber: (ConvertingMismatch) -> Unit 
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalDate?>()) ||
-            columnType.isSubtypeOf(typeOf<kotlinx.datetime.LocalDate?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalDate?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalDate?>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.DAY), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalDateTime?>()) ||
-            columnType.isSubtypeOf(typeOf<kotlinx.datetime.LocalDateTime?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalDateTime?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalDateTime?>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Date(DateUnit.MILLISECOND), null),
                 emptyList(),
             )
 
-        columnType.isSubtypeOf(typeOf<LocalTime?>()) ->
+        columnType.isSubtypeOf(typeOf<JavaLocalTime?>()) ||
+            columnType.isSubtypeOf(typeOf<LocalTime>()) ->
             Field(
                 column.name(),
                 FieldType(nullable, ArrowType.Time(TimeUnit.NANOSECOND, 64), null),

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
@@ -3,6 +3,11 @@ package org.jetbrains.kotlinx.dataframe.io
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toJavaInstant
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.TimeStampMicroVector
 import org.apache.arrow.vector.TimeStampMilliVector
@@ -46,9 +51,6 @@ import java.io.File
 import java.net.URL
 import java.nio.channels.Channels
 import java.sql.DriverManager
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import java.util.Locale
 import kotlin.reflect.typeOf
 
@@ -499,9 +501,9 @@ internal class ArrowKtTest {
     @Test
     fun testTimeStamp() {
         val dates = listOf(
-            LocalDateTime.of(2023, 11, 23, 9, 30, 25),
-            LocalDateTime.of(2015, 5, 25, 14, 20, 13),
-            LocalDateTime.of(2013, 6, 19, 11, 20, 13),
+            LocalDateTime(2023, 11, 23, 9, 30, 25),
+            LocalDateTime(2015, 5, 25, 14, 20, 13),
+            LocalDateTime(2013, 6, 19, 11, 20, 13),
         )
 
         val dataFrame = dataFrameOf(
@@ -554,7 +556,7 @@ internal class ArrowKtTest {
                 timeStampSecVector.allocateNew(dates.size)
 
                 dates.forEachIndexed { index, localDateTime ->
-                    val instant = localDateTime.toInstant(ZoneOffset.UTC)
+                    val instant = localDateTime.toInstant(UtcOffset.ZERO).toJavaInstant()
                     timeStampNanoVector[index] = instant.toEpochMilli() * 1_000_000L + instant.nano
                     timeStampMicroVector[index] = instant.toEpochMilli() * 1_000L
                     timeStampMilliVector[index] = instant.toEpochMilli()
@@ -580,10 +582,10 @@ internal class ArrowKtTest {
 
     private fun expectedSimpleDataFrame(): AnyFrame {
         val dates = listOf(
-            LocalDateTime.of(2020, 11, 23, 9, 30, 25),
-            LocalDateTime.of(2015, 5, 25, 14, 20, 13),
-            LocalDateTime.of(2013, 6, 19, 11, 20, 13),
-            LocalDateTime.of(2000, 1, 1, 0, 0, 0),
+            LocalDateTime(2020, 11, 23, 9, 30, 25),
+            LocalDateTime(2015, 5, 25, 14, 20, 13),
+            LocalDateTime(2013, 6, 19, 11, 20, 13),
+            LocalDateTime(2000, 1, 1, 0, 0, 0),
         )
 
         return dataFrameOf(

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/exampleEstimatesAssertions.kt
@@ -1,18 +1,24 @@
 package org.jetbrains.kotlinx.dataframe.io
 
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.forEachIndexed
 import java.math.BigInteger
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.ZoneOffset
 import kotlin.math.absoluteValue
 import kotlin.math.pow
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.time.LocalTime as JavaLocalTime
 
 /**
  * Assert that we have got the same data that was originally saved on example creation.
@@ -133,7 +139,7 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
     val dateCol = exampleFrame["date32"] as DataColumn<LocalDate?>
     dateCol.type() shouldBe typeOf<LocalDate>().withNullability(expectedNullable)
     dateCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalDate.ofEpochDay(iBatch(i).toLong() * 30))
+        assertValueOrNull(iBatch(i), element, JavaLocalDate.ofEpochDay(iBatch(i).toLong() * 30).toKotlinLocalDate())
     }
 
     val datetimeCol = exampleFrame["date64"] as DataColumn<LocalDateTime?>
@@ -142,32 +148,38 @@ internal fun assertEstimations(exampleFrame: AnyFrame, expectedNullable: Boolean
         assertValueOrNull(
             rowNumber = iBatch(i),
             actual = element,
-            expected = LocalDateTime.ofEpochSecond(iBatch(i).toLong() * 60 * 60 * 24 * 30, 0, ZoneOffset.UTC),
+            expected = JavaLocalDateTime
+                .ofEpochSecond(iBatch(i).toLong() * 60 * 60 * 24 * 30, 0, ZoneOffset.UTC)
+                .toKotlinLocalDateTime(),
         )
     }
 
     val timeSecCol = exampleFrame["time32_seconds"] as DataColumn<LocalTime?>
     timeSecCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeSecCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofSecondOfDay(iBatch(i).toLong()))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofSecondOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }
 
     val timeMilliCol = exampleFrame["time32_milli"] as DataColumn<LocalTime?>
     timeMilliCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeMilliCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000_000))
+        assertValueOrNull(
+            rowNumber = iBatch(i),
+            actual = element,
+            expected = JavaLocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000_000).toKotlinLocalTime(),
+        )
     }
 
     val timeMicroCol = exampleFrame["time64_micro"] as DataColumn<LocalTime?>
     timeMicroCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeMicroCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong() * 1000).toKotlinLocalTime())
     }
 
     val timeNanoCol = exampleFrame["time64_nano"] as DataColumn<LocalTime?>
     timeNanoCol.type() shouldBe typeOf<LocalTime>().withNullability(expectedNullable)
     timeNanoCol.forEachIndexed { i, element ->
-        assertValueOrNull(iBatch(i), element, LocalTime.ofNanoOfDay(iBatch(i).toLong()))
+        assertValueOrNull(iBatch(i), element, JavaLocalTime.ofNanoOfDay(iBatch(i).toLong()).toKotlinLocalTime())
     }
 
     exampleFrame.getColumnOrNull("nulls")?.let { nullCol ->

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import java.net.URL
-import java.time.LocalDate
 
 /**
  * DataFrame to be saved in Apache Arrow
@@ -67,12 +67,12 @@ val citiesExampleFrame = dataFrameOf(
     DataColumn.createValueColumn(
         "settled",
         listOf(
-            LocalDate.of(1237, 1, 1),
-            LocalDate.of(1189, 5, 7),
-            LocalDate.of(1624, 1, 1),
-            LocalDate.of(1790, 7, 16),
-            LocalDate.of(1703, 5, 27),
-            LocalDate.of(1929, 2, 11),
+            LocalDate(1237, 1, 1),
+            LocalDate(1189, 5, 7),
+            LocalDate(1624, 1, 1),
+            LocalDate(1790, 7, 16),
+            LocalDate(1703, 5, 27),
+            LocalDate(1929, 2, 11),
         ),
     ),
     DataColumn.createValueColumn(

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.io
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
@@ -37,10 +39,10 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.URL
 import java.nio.file.Files
-import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.Calendar
-import java.util.Date
+import java.time.LocalDate as JavaLocalDate
+import java.time.LocalDateTime as JavaLocalDateTime
+import java.util.Date as JavaDate
 
 public class Excel : SupportedDataFrameFormat {
     override fun readDataFrame(stream: InputStream, header: List<String>): AnyFrame = DataFrame.readExcel(stream)
@@ -474,15 +476,15 @@ public fun <T> DataFrame<T>.writeExcel(
                 cell.setCellValueByGuessedType(any)
 
                 when (any) {
-                    is LocalDate, is kotlinx.datetime.LocalDate -> {
+                    is JavaLocalDate, is LocalDate -> {
                         cell.cellStyle = cellStyleDate
                     }
 
-                    is Calendar, is Date -> {
+                    is Calendar, is JavaDate -> {
                         cell.cellStyle = cellStyleDateTime
                     }
 
-                    is LocalDateTime -> {
+                    is JavaLocalDateTime -> {
                         if (any.year < 1900) {
                             cell.cellStyle = cellStyleTime
                         } else {
@@ -490,7 +492,7 @@ public fun <T> DataFrame<T>.writeExcel(
                         }
                     }
 
-                    is kotlinx.datetime.LocalDateTime -> {
+                    is LocalDateTime -> {
                         if (any.year < 1900) {
                             cell.cellStyle = cellStyleTime
                         } else {
@@ -515,23 +517,23 @@ private fun Cell.setCellValueByGuessedType(any: Any) =
 
         is Number -> this.setCellValue(any.toDouble())
 
-        is LocalDate -> this.setCellValue(any)
+        is JavaLocalDate -> this.setCellValue(any)
 
-        is LocalDateTime -> this.setTime(any)
+        is JavaLocalDateTime -> this.setTime(any)
 
         is Boolean -> this.setCellValue(any)
 
         is Calendar -> this.setDate(any.time)
 
-        is Date -> this.setDate(any)
+        is JavaDate -> this.setDate(any)
 
         is RichTextString -> this.setCellValue(any)
 
         is String -> this.setCellValue(any)
 
-        is kotlinx.datetime.LocalDate -> this.setCellValue(any.toJavaLocalDate())
+        is LocalDate -> this.setCellValue(any.toJavaLocalDate())
 
-        is kotlinx.datetime.LocalDateTime -> this.setTime(any.toJavaLocalDateTime())
+        is LocalDateTime -> this.setTime(any.toJavaLocalDateTime())
 
         // Another option would be to serialize everything else to string,
         // but people can convert columns to string with any serialization framework they want
@@ -545,7 +547,7 @@ private fun Cell.setCellValueByGuessedType(any: Any) =
  * are displayed as 00.01.1900 in Excel and as 30.12.1899 in LibreOffice Calc and also in POI.
  * POI can not set 1899 year directly.
  */
-private fun Cell.setTime(localDateTime: LocalDateTime) {
+private fun Cell.setTime(localDateTime: JavaLocalDateTime) {
     this.setCellValue(DateUtil.getExcelDate(localDateTime.plusDays(1)) - 1.0)
 }
 
@@ -555,7 +557,7 @@ private fun Cell.setTime(localDateTime: LocalDateTime) {
  * are displayed as 00.01.1900 in Excel and as 30.12.1899 in LibreOffice Calc and also in POI.
  * POI can not set 1899 year directly.
  */
-private fun Cell.setDate(date: Date) {
+private fun Cell.setDate(date: JavaDate) {
     val calStart = LocaleUtil.getLocaleCalendar()
     calStart.time = date
     this.setTime(calStart.toInstant().atZone(getUserTimeZone().toZoneId()).toLocalDateTime())


### PR DESCRIPTION
Different parts of the library had different biases towards using Java's datetime libraries or Kotlin's.

Since DF is a Kotlin library, we should prefer Kotlin's.

This PR addresses that, while also filling in some missing conversions/parsers.
