### PR TITLE
Avoid 'expected: range(0, 32768)' exception when saving mixed data to Arrow

### DIFF
--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
@@ -503,10 +503,12 @@ internal class ArrowKtTest {
         val dataFrame = dataFrameOf(bigMixedColumn)
         val warnings = ArrayList<ConvertingMismatch>()
         val writer = dataFrame.arrowWriter(
-            targetSchema = Schema(listOf(
-                Field("bigMixedColumn", FieldType.nullable(ArrowType.Int(64, true)), emptyList())
-            )),
-            mode = ArrowWriter.Mode.LOYAL
+            targetSchema = Schema(
+                listOf(
+                    Field("bigMixedColumn", FieldType.nullable(ArrowType.Int(64, true)), emptyList()),
+                ),
+            ),
+            mode = ArrowWriter.Mode.LOYAL,
         ) {
             warnings.add(it)
         }
@@ -517,7 +519,7 @@ internal class ArrowKtTest {
         assert(warnings.filterIsInstance<ConvertingMismatch.TypeConversionFail.ConversionFailIgnored>().size == 1)
         assert(warnings.filterIsInstance<ConvertingMismatch.SavedAsString>().size == 1)
 
-        DataFrame.readArrowFeather(data)["bigMixedColumn"] shouldBe dataFrame[bigMixedColumn].map { it.toString()}
+        DataFrame.readArrowFeather(data)["bigMixedColumn"] shouldBe dataFrame[bigMixedColumn].map { it.toString() }
     }
 
     @Test

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
@@ -192,3 +192,15 @@ val bigStringColumn = run {
     }
     DataColumn.createValueColumn("bigStringColumn", list)
 }
+
+val bigMixedColumn = run {
+    val list = ArrayList<Any>()
+    for (i in 0 .. 32768) {
+        list.add(i * i)
+    }
+    list.add("Dirty data")
+    for (i in 32768 downTo 0) {
+        list.add(i * i)
+    }
+    DataColumn.createValueColumn("bigMixedColumn", list)
+}

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/examplesToWrite.kt
@@ -195,7 +195,7 @@ val bigStringColumn = run {
 
 val bigMixedColumn = run {
     val list = ArrayList<Any>()
-    for (i in 0 .. 32768) {
+    for (i in 0..32768) {
         list.add(i * i)
     }
     list.add("Dirty data")


### PR DESCRIPTION
Although we have fixed https://github.com/Kotlin/dataframe/pull/350 for saving large string columns, the same error still appears when saving mixed (such as `<Comparable>`) column as string vector but with number or date in target schema with non-strict validation. Now we should always allocate enough memory for string vectors.