### PR TITLE
Compiler plugin bugfixes

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -251,11 +251,9 @@ internal fun convertToDataFrame(
         val kClass = returnType.classifier as KClass<*>
         val fieldKind = returnType.getFieldKind()
 
-        val shouldCreateValueCol = (
-            maxDepth <= 0 &&
-                !fieldKind.shouldBeConvertedToFrameColumn &&
-                !fieldKind.shouldBeConvertedToColumnGroup
-        ) ||
+        val keepSubtree =
+            maxDepth <= 0 && !fieldKind.shouldBeConvertedToFrameColumn && !fieldKind.shouldBeConvertedToColumnGroup
+        val shouldCreateValueCol = keepSubtree ||
             kClass == Any::class ||
             kClass in preserveClasses ||
             property in preserveProperties ||

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -325,13 +325,13 @@ fun KotlinTypeFacade.pluginDataFrameSchema(schemaTypeArg: ConeTypeProjection): P
 fun KotlinTypeFacade.pluginDataFrameSchema(coneClassLikeType: ConeClassLikeType): PluginDataFrameSchema {
     val symbol = coneClassLikeType.toSymbol(session) as? FirRegularClassSymbol ?: return PluginDataFrameSchema(emptyList())
     val declarationSymbols = if (symbol.isLocal && symbol.resolvedSuperTypes.firstOrNull() != session.builtinTypes.anyType.type) {
-        val rootSchemaSymbol = symbol.resolvedSuperTypes.first().toSymbol(session) as FirRegularClassSymbol
-        rootSchemaSymbol.declaredMemberScope(session, FirResolvePhase.DECLARATIONS)
+        val rootSchemaSymbol = symbol.resolvedSuperTypes.first().toSymbol(session) as? FirRegularClassSymbol
+        rootSchemaSymbol?.declaredMemberScope(session, FirResolvePhase.DECLARATIONS)
     } else {
         symbol.declaredMemberScope(session, FirResolvePhase.DECLARATIONS)
     }.let { scope ->
-        val names = scope.getCallableNames()
-        names.flatMap { scope.getProperties(it) }
+        val names = scope?.getCallableNames() ?: emptySet()
+        names.flatMap { scope?.getProperties(it) ?: emptyList() }
     }
 
     val mapping = symbol.typeParameterSymbols

--- a/plugins/kotlin-dataframe/testData/box/explode.kt
+++ b/plugins/kotlin-dataframe/testData/box/explode.kt
@@ -3,20 +3,23 @@ import org.jetbrains.kotlinx.dataframe.annotations.*
 import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.io.*
 
-@DataSchema
-interface ExplodeSchema {
-    val timestamps: List<Int>
-}
-
-fun explode(df: DataFrame<ExplodeSchema>) {
-    val res = df.explode { timestamps }
-    val col: DataColumn<Int> = res.timestamps
-}
-
 fun box(): String {
-    val df = dataFrameOf("timestamps")(listOf(100, 113, 140), listOf(400, 410, 453)).cast<ExplodeSchema>()
+    val df = dataFrameOf("timestamps")(listOf(100, 113, 140), listOf(400, 410, 453))
     val df1 = df.explode { timestamps }
     val timestamps: DataColumn<Int> = df1.timestamps
     timestamps.print()
+
+
+    val df2 = dataFrameOf("a", "b")(listOf(100, 113, 140), listOf(400, 410))
+    val df3 = df2.explode { a and b }
+    // exploding multiple columns will introduce nulls
+    df3.print()
+    // compiler needs to play safe and make both selected columns nullable
+    df3.compileTimeSchema().columns.let {
+        assert(it["a"]!!.nullable)
+        assert(it["b"]!!.nullable)
+    }
+    // compile time schema is still compatible with runtime
+    df3.compareSchemas()
     return "OK"
 }

--- a/plugins/kotlin-dataframe/testData/box/toDataFrame_dataSchema.kt
+++ b/plugins/kotlin-dataframe/testData/box/toDataFrame_dataSchema.kt
@@ -1,0 +1,31 @@
+@file:Suppress("UnusedImport")
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class Person(val firstName: String, val lastName: String, val age: Int, val city: String?)
+
+@DataSchema
+data class Group(val id: String, val participants: List<Person>)
+
+fun box(): String {
+    val df = listOf(
+        Group("1", listOf(
+            Person("Alice", "Cooper", 15, "London"),
+            Person("Bob", "Dylan", 45, "Dubai")
+        )),
+        Group("2", listOf(
+            Person("Charlie", "Daniels", 20, "Moscow"),
+            Person("Charlie", "Chaplin", 40, "Milan"),
+        )),
+    ).toDataFrame(maxDepth = 0)
+
+    val groups = df.add("groupSize") {
+        // interestingly, this is still a DataFrame. Because @DataSchema Person
+        participants.rowsCount()
+    }
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -389,6 +389,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("toDataFrame_dataSchema.kt")
+  public void testToDataFrame_dataSchema() {
+    runTest("testData/box/toDataFrame_dataSchema.kt");
+  }
+
+  @Test
   @TestMetadata("toDataFrame_dsl.kt")
   public void testToDataFrame_dsl() {
     runTest("testData/box/toDataFrame_dsl.kt");


### PR DESCRIPTION
toDataFrame and explode produced invalid schemas and now fixed, making sure using generated extension properties won't lead to exceptions at runtime
Second commit is about ClassCast exception at compilation, or rather in IDE at analysis. All plugin code should not throw exceptions because they all appear in IDE 