### PR TITLE
Add Language annotations for better IDE experience

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -111,7 +112,9 @@ internal fun <T, C, R> Split<T, C>.by(
 
 // region match
 
-public fun <T, C : String?> Split<T, C>.match(regex: String): SplitWithTransform<T, C, String?> = match(regex.toRegex())
+public fun <T, C : String?> Split<T, C>.match(
+    @Language("RegExp") regex: String,
+): SplitWithTransform<T, C, String?> = match(regex.toRegex())
 
 public fun <T, C : String?> Split<T, C>.match(regex: Regex): SplitWithTransform<T, C, String?> =
     by {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/json.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromStream
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -254,7 +255,7 @@ public fun DataRow.Companion.readJson(
 @Refine
 @Interpretable("ReadJsonStr")
 public fun DataFrame.Companion.readJsonStr(
-    text: String,
+    @Language("json") text: String,
     header: List<String> = emptyList(),
     keyValuePaths: List<JsonPath> = emptyList(),
     typeClashTactic: TypeClashTactic = ARRAY_AND_VALUE_COLUMNS,
@@ -269,7 +270,7 @@ public fun DataFrame.Companion.readJsonStr(
  * @return [DataRow] from the given [text].
  */
 public fun DataRow.Companion.readJsonStr(
-    text: String,
+    @Language("json") text: String,
     header: List<String> = emptyList(),
     keyValuePaths: List<JsonPath> = emptyList(),
     typeClashTactic: TypeClashTactic = ARRAY_AND_VALUE_COLUMNS,


### PR DESCRIPTION
For `readJsonStr`, with JSON It will look like this:
![image](https://github.com/user-attachments/assets/61c3b1ff-b375-41d6-ba0c-6ac4b5aa2cf7)
Plus ability to open it in an editor
![image](https://github.com/user-attachments/assets/91a341db-b3a5-4db5-946b-06a7cdf89ff6)

Here's also regex argument in `split.match()`. There will be an action to check this regexp and to edit it as well
![image](https://github.com/user-attachments/assets/d6d810e6-b694-4554-ab2b-fc09c9e20ac7)

![image](https://github.com/user-attachments/assets/7e6abb72-01d9-41b0-9d07-48a94e3b96ff)



