### PR TITLE
Added special check for function types in debug mode

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnImpl.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlinx.dataframe.kind
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.typeOf
 
 internal abstract class DataColumnImpl<T>(
     protected val values: List<T>,
@@ -21,6 +23,9 @@ internal abstract class DataColumnImpl<T>(
     private infix fun <T> T?.matches(type: KType) =
         when {
             this == null -> type.isMarkedNullable
+
+            // special case since functions are often stored as a $$Lambda$... class, the subClassOf check would fail
+            this is Function<*> && type.isSubtypeOf(typeOf<Function<*>?>()) -> true
 
             this.isPrimitiveArray ->
                 type.isPrimitiveArray &&


### PR DESCRIPTION
Fixes failing test in [debug mode](https://github.com/Kotlin/dataframe/issues/713):
```
org.jetbrains.kotlinx.dataframe.testSets.person.DataFrameTests.guess column type for type without classifier
java.lang.IllegalArgumentException: Values of ValueColumn 'a' have types '[DataFrameTests$$Lambda$4183/0x000000010140ac40]' which are not compatible given with column type 'kotlin.Function<*>'
  at org.jetbrains.kotlinx.dataframe.impl.columns.DataColumnImpl.<init>(DataColumnImpl.kt:39)
```
It was caused by recognizing `kotlin.Function<*>` types explicitly in https://github.com/Kotlin/dataframe/commit/10935d2e80d1e233f2891a71decba2c7af3276a1. 

I simply added an additional check in the debug mode for functional types, as the check should not fail for this case.