### PR TITLE
Revert "Generate fields in REPL for data schemas"

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -82,7 +82,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
         val result = generator.generate(
             schema = schema,
             name = name,
-            fields = true,
+            fields = false,
             extensionProperties = true,
             isOpen = isOpen,
             visibility = MarkerVisibility.IMPLICIT_PUBLIC,

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -107,12 +107,7 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $typeName { }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -138,12 +133,7 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $typeName { }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -163,10 +153,7 @@ class CodeGenerationTests : BaseTest() {
         val declaration1 =
             """
             @DataSchema(isOpen = false)
-            interface $type1 {
-                val city: String?
-                val name: String
-            }
+            interface $type1 { }
             
             val $dfName<$type1>.city: $dataCol<$stringName?> @JvmName("${type1}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$type1>.city: $stringName? @JvmName("${type1}_city") get() = this["city"] as $stringName?
@@ -178,11 +165,7 @@ class CodeGenerationTests : BaseTest() {
         val declaration2 =
             """
             @DataSchema
-            interface $type2 {
-                val age: Int
-                val nameAndCity: _DataFrameType1
-                val weight: Int?
-            }
+            interface $type2 { }
             
             val $dfName<$type2>.age: $dataCol<$intName> @JvmName("${type2}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$type2>.age: $intName @JvmName("${type2}_age") get() = this["age"] as $intName

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -81,12 +81,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected =
             """
             @DataSchema
-            interface $marker {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $marker { }
             
             val $dfName<$marker>.age: $dataCol<$intName> @JvmName("${marker}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$marker>.age: $intName @JvmName("${marker}_age") get() = this["age"] as $intName
@@ -108,9 +103,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected3 =
             """
             @DataSchema
-            interface $marker3 : $markerFull {
-                override val city: String
-            }
+            interface $marker3 : $markerFull { }
             
             val $dfName<$marker3>.city: $dataCol<$stringName> @JvmName("${marker3}_city") get() = this["city"] as $dataCol<$stringName>
             val $dfRowName<$marker3>.city: $stringName @JvmName("${marker3}_city") get() = this["city"] as $stringName
@@ -127,9 +120,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected5 =
             """
             @DataSchema
-            interface $marker5 : $markerFull {
-                override val weight: Int
-            }
+            interface $marker5 : $markerFull { }
             
             val $dfName<$marker5>.weight: $dataCol<$intName> @JvmName("${marker5}_weight") get() = this["weight"] as $dataCol<$intName>
             val $dfRowName<$marker5>.weight: $intName @JvmName("${marker5}_weight") get() = this["weight"] as $intName
@@ -172,10 +163,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected =
             """
             @DataSchema
-            interface $marker : ${Test2._DataFrameType::class.qualifiedName} {
-                val city: String?
-                val weight: Int?
-            }
+            interface $marker : ${Test2._DataFrameType::class.qualifiedName} { }
             
             val $dfName<$marker>.city: $dataCol<$stringName?> @JvmName("${marker}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$marker>.city: $stringName? @JvmName("${marker}_city") get() = this["city"] as $stringName?

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -82,7 +82,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
         val result = generator.generate(
             schema = schema,
             name = name,
-            fields = true,
+            fields = false,
             extensionProperties = true,
             isOpen = isOpen,
             visibility = MarkerVisibility.IMPLICIT_PUBLIC,

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -107,12 +107,7 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $typeName { }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -138,12 +133,7 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $typeName { }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -163,10 +153,7 @@ class CodeGenerationTests : BaseTest() {
         val declaration1 =
             """
             @DataSchema(isOpen = false)
-            interface $type1 {
-                val city: String?
-                val name: String
-            }
+            interface $type1 { }
             
             val $dfName<$type1>.city: $dataCol<$stringName?> @JvmName("${type1}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$type1>.city: $stringName? @JvmName("${type1}_city") get() = this["city"] as $stringName?
@@ -178,11 +165,7 @@ class CodeGenerationTests : BaseTest() {
         val declaration2 =
             """
             @DataSchema
-            interface $type2 {
-                val age: Int
-                val nameAndCity: _DataFrameType1
-                val weight: Int?
-            }
+            interface $type2 { }
             
             val $dfName<$type2>.age: $dataCol<$intName> @JvmName("${type2}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$type2>.age: $intName @JvmName("${type2}_age") get() = this["age"] as $intName

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -81,12 +81,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected =
             """
             @DataSchema
-            interface $marker {
-                val age: Int
-                val city: String?
-                val name: String
-                val weight: Int?
-            }
+            interface $marker { }
             
             val $dfName<$marker>.age: $dataCol<$intName> @JvmName("${marker}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$marker>.age: $intName @JvmName("${marker}_age") get() = this["age"] as $intName
@@ -108,9 +103,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected3 =
             """
             @DataSchema
-            interface $marker3 : $markerFull {
-                override val city: String
-            }
+            interface $marker3 : $markerFull { }
             
             val $dfName<$marker3>.city: $dataCol<$stringName> @JvmName("${marker3}_city") get() = this["city"] as $dataCol<$stringName>
             val $dfRowName<$marker3>.city: $stringName @JvmName("${marker3}_city") get() = this["city"] as $stringName
@@ -127,9 +120,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected5 =
             """
             @DataSchema
-            interface $marker5 : $markerFull {
-                override val weight: Int
-            }
+            interface $marker5 : $markerFull { }
             
             val $dfName<$marker5>.weight: $dataCol<$intName> @JvmName("${marker5}_weight") get() = this["weight"] as $dataCol<$intName>
             val $dfRowName<$marker5>.weight: $intName @JvmName("${marker5}_weight") get() = this["weight"] as $intName
@@ -172,10 +163,7 @@ class ReplCodeGenTests : BaseTest() {
         val expected =
             """
             @DataSchema
-            interface $marker : ${Test2._DataFrameType::class.qualifiedName} {
-                val city: String?
-                val weight: Int?
-            }
+            interface $marker : ${Test2._DataFrameType::class.qualifiedName} { }
             
             val $dfName<$marker>.city: $dataCol<$stringName?> @JvmName("${marker}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$marker>.city: $stringName? @JvmName("${marker}_city") get() = this["city"] as $stringName?


### PR DESCRIPTION
This reverts commit 54fcd475e663be88e727141d9a843c491bc7962d from https://github.com/Kotlin/dataframe/pull/693 temporarily for the 0.14.0 release.

As discussed, this change breaks some schema generation in notebooks:
![image](https://github.com/user-attachments/assets/d6cb0f66-2644-489d-a617-a63c9603f85b)
![image](https://github.com/user-attachments/assets/f4eb6f84-42e1-4381-93bc-0a6302f8300c)

This change should be properly fixed for the next release. See https://github.com/Kotlin/dataframe/issues/867 for more information.