### PR TITLE
Fix duplicated jvm signature

### DIFF
--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -148,7 +148,7 @@ fun <T> KotlinTypeFacade.interpret(
                         val interpreter = expression.loadInterpreter()
                         if (interpreter == null) {
                             // if the plugin already transformed call, its original form is the last expression of .let { }
-                            val argument = expression.arguments[0]
+                            val argument = expression.arguments.getOrNull(0)
                             val last = (argument as? FirAnonymousFunctionExpression)?.anonymousFunction?.body?.statements?.lastOrNull()
                             val call = (last as? FirReturnExpression)?.result as? FirFunctionCall
                             call?.loadInterpreter()?.let {

--- a/plugins/kotlin-dataframe/testData/box/duplicatedSignature1.kt
+++ b/plugins/kotlin-dataframe/testData/box/duplicatedSignature1.kt
@@ -1,0 +1,47 @@
+package dataframe
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.columns.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class MyRecordModifiedStep2(
+    val group: Group,
+    val str: kotlin.String
+) {
+    @DataSchema
+    data class Group(
+        val a: kotlin.String,
+        val length: kotlin.Int
+    )
+}
+
+@DataSchema
+data class MyRecordModified(
+    val group: Group
+) {
+    @DataSchema
+    data class Group(
+        val a: kotlin.String,
+        val length: kotlin.Int
+    )
+}
+
+@DataSchema
+data class Group1(
+    val a: kotlin.String,
+)
+
+@DataSchema
+data class Group2(
+    val a: kotlin.String,
+)
+
+fun box(): String {
+    val df = dataFrameOf(MyRecordModified(MyRecordModified.Group("a", 123)))
+    // need to trigger JVM classloading so duplicated signature error can appear
+    df.group.a
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -125,6 +125,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("duplicatedSignature1.kt")
+  public void testDuplicatedSignature1() {
+    runTest("testData/box/duplicatedSignature1.kt");
+  }
+
+  @Test
   @TestMetadata("explode.kt")
   public void testExplode() {
     runTest("testData/box/explode.kt");


### PR DESCRIPTION
Problem appears when multiple nested DataSchema declarations have property with the same name. Using parent declarations in JvmName argument solves it. I decided to not use package names there

computeNestedName is slightly modified computeFqName from compiler