### PR TITLE
Making `GroupBy` extensible

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.GroupByImpl
+import org.jetbrains.kotlinx.dataframe.impl.GroupByInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.PivotImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.getPivotColumnPaths
 import org.jetbrains.kotlinx.dataframe.impl.api.groupByImpl
@@ -101,7 +101,7 @@ public fun <T, G> GroupBy<T, G>.toDataFrame(groupedColumnName: String? = null): 
         internal().df.rename(groups).into(groupedColumnName)
     }
 
-internal fun <T, G> GroupBy<T, G>.internal(): GroupByImpl<T, G> = this as GroupByImpl<T, G>
+internal fun <T, G> GroupBy<T, G>.internal(): GroupByInternal<T, G> = this as GroupByInternal<T, G>
 
 public interface Grouped<out T> : Aggregatable<T>
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.GroupByInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.PivotImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.getPivotColumnPaths
 import org.jetbrains.kotlinx.dataframe.impl.api.groupByImpl
@@ -85,23 +84,16 @@ public interface GroupBy<out T, out G> : Grouped<G> {
 
     public fun filter(predicate: GroupedRowFilter<T, G>): GroupBy<T, G>
 
+    @Refine
+    @Interpretable("GroupByToDataFrame")
+    public fun toDataFrame(groupedColumnName: String? = null): DataFrame<T>
+
     public data class Entry<T, G>(val key: DataRow<T>, val group: DataFrame<G>)
 
     public companion object {
         internal val groupedColumnAccessor = column<AnyFrame>("group")
     }
 }
-
-@Refine
-@Interpretable("GroupByToDataFrame")
-public fun <T, G> GroupBy<T, G>.toDataFrame(groupedColumnName: String? = null): DataFrame<T> =
-    if (groupedColumnName == null || groupedColumnName == groups.name()) {
-        internal().df
-    } else {
-        internal().df.rename(groups).into(groupedColumnName)
-    }
-
-internal fun <T, G> GroupBy<T, G>.internal(): GroupByInternal<T, G> = this as GroupByInternal<T, G>
 
 public interface Grouped<out T> : Aggregatable<T>
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
 import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.minus
 import org.jetbrains.kotlinx.dataframe.api.pathOf
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.AggregatableInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.GroupByReceiverImpl
@@ -30,13 +31,25 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.values
 
 /**
+ * Internal implementation interface for [GroupBy].
+ *
+ * While [df] should be hidden in the [GroupBy] DSL, it must be accessible when running
+ * [GroupBy.toDataFrame].
+ *
+ * This interface is public to allow Kandy to implement it.
+ */
+public interface GroupByInternal<T, G> : GroupBy<T, G> {
+    public val df: DataFrame<T>
+}
+
+/**
  * @property df DataFrame containing [groups] column and key columns. Represents GroupBy.
  */
 internal class GroupByImpl<T, G>(
-    val df: DataFrame<T>,
+    override val df: DataFrame<T>,
     override val groups: FrameColumn<G>,
     internal val keyColumnsInGroups: ColumnsSelector<G, *>,
-) : GroupBy<T, G>,
+) : GroupByInternal<T, G>,
     AggregatableInternal<G> {
 
     override val keys by lazy { df - groups }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -13,10 +13,11 @@ import org.jetbrains.kotlinx.dataframe.api.concat
 import org.jetbrains.kotlinx.dataframe.api.convert
 import org.jetbrains.kotlinx.dataframe.api.getColumn
 import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
+import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.minus
 import org.jetbrains.kotlinx.dataframe.api.pathOf
-import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.AggregatableInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.GroupByReceiverImpl
@@ -31,25 +32,13 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.values
 
 /**
- * Internal implementation interface for [GroupBy].
- *
- * While [df] should be hidden in the [GroupBy] DSL, it must be accessible when running
- * [GroupBy.toDataFrame].
- *
- * This interface is public to allow Kandy to implement it.
- */
-public interface GroupByInternal<T, G> : GroupBy<T, G> {
-    public val df: DataFrame<T>
-}
-
-/**
  * @property df DataFrame containing [groups] column and key columns. Represents GroupBy.
  */
 internal class GroupByImpl<T, G>(
-    override val df: DataFrame<T>,
+    val df: DataFrame<T>,
     override val groups: FrameColumn<G>,
     internal val keyColumnsInGroups: ColumnsSelector<G, *>,
-) : GroupByInternal<T, G>,
+) : GroupBy<T, G>,
     AggregatableInternal<G> {
 
     override val keys by lazy { df - groups }
@@ -69,6 +58,13 @@ internal class GroupByImpl<T, G>(
         }
         return df[indices].asGroupBy(groups)
     }
+
+    override fun toDataFrame(groupedColumnName: String?): DataFrame<T> =
+        if (groupedColumnName == null || groupedColumnName == groups.name()) {
+            df
+        } else {
+            df.rename(groups).into(groupedColumnName)
+        }
 }
 
 internal fun <T, G, R> aggregateGroupBy(


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/871

Creating a way to allow Kandy to create a custom GroupBy class by the `GroupByInternal` interface