### PR TITLE
Update GeneratedField.kt

### DIFF
--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/GeneratedField.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/GeneratedField.kt
@@ -54,48 +54,30 @@ public fun FieldType.toNullable(): FieldType =
  * Returns a new fieldType with the same type but with nullability disabled in the column type.
  * NOTE: for [FieldType.FrameFieldType], the `nullable` property indicates the nullability of the frame itself, not the type of the column.
  */
-public fun FieldType.toNotNullable(): FieldType =
-    if (isNullable()) {
+public fun FieldType.toNotNullable(): FieldType {
+    fun String.toNotNullableName() = if (this == "*") "Any" else removeSuffix("?")
+
+    return if (isNullable()) {
         when (this) {
-            is FieldType.FrameFieldType ->
-                FieldType.FrameFieldType(
-                    markerName = markerName.let {
-                        if (it == "*") {
-                            "Any"
-                        } else {
-                            it.removeSuffix("?")
-                        }
-                    },
-                    nullable = nullable,
-                    renderAsList = renderAsList,
-                )
+            is FieldType.FrameFieldType -> FieldType.FrameFieldType(
+                markerName = markerName.toNotNullableName(),
+                nullable = nullable,
+                renderAsList = renderAsList
+            )
 
-            is FieldType.GroupFieldType ->
-                FieldType.GroupFieldType(
-                    markerName = markerName.let {
-                        if (it == "*") {
-                            "Any"
-                        } else {
-                            it.removeSuffix("?")
-                        }
-                    },
-                    renderAsObject = renderAsObject,
-                )
+            is FieldType.GroupFieldType -> FieldType.GroupFieldType(
+                markerName = markerName.toNotNullableName(),
+                renderAsObject = renderAsObject
+            )
 
-            is FieldType.ValueFieldType ->
-                FieldType.ValueFieldType(
-                    typeFqName = typeFqName.let {
-                        if (it == "*") {
-                            "Any"
-                        } else {
-                            it.removeSuffix("?")
-                        }
-                    },
-                )
+            is FieldType.ValueFieldType -> FieldType.ValueFieldType(
+                typeFqName = typeFqName.toNotNullableName()
+            )
         }
     } else {
         this
     }
+}
 
 public val FieldType.name: String
     get() = when (this) {


### PR DESCRIPTION
**Helper Function:** The `toNotNullableName()` extension function encapsulates the logic for determining how to transform a `markerName` or `typeFqName`. This reduces code duplication across the different field types.

**Readability:** By using a helper function, we make it clear what transformation is being applied to the names, improving overall readability.

**Maintainability:** If the logic for determining how to handle names changes in the future, you only need to update it in one place.