### PR TITLE
Find KSP Configurations that are Added Later

### DIFF
--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/ConvenienceSchemaGeneratorPlugin.kt
@@ -3,7 +3,6 @@ package org.jetbrains.dataframe.gradle
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.kotlin.dsl.getByType
 import java.util.Properties
 
@@ -74,13 +73,17 @@ class ConvenienceSchemaGeneratorPlugin : Plugin<Project> {
                     target.configurations.named { it == cfg }.configureEach {
                         cfgsToAdd.remove(cfg)
                         dependencies.add(
-                            target.dependencies.create("org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion")
+                            target.dependencies.create(
+                                "org.jetbrains.kotlinx.dataframe:symbol-processor-all:$preprocessorVersion",
+                            ),
                         )
                     }
                 }
                 target.gradle.projectsEvaluated {
                     cfgsToAdd.forEach { cfg ->
-                        target.logger.warn("Configuration '$cfg' was never found. Please make sure the KSP plugin is applied.")
+                        target.logger.warn(
+                            "Configuration '$cfg' was never found. Please make sure the KSP plugin is applied.",
+                        )
                     }
                 }
 


### PR DESCRIPTION
This is a continuation of the changes in https://github.com/Kotlin/dataframe/pull/647 and https://github.com/Kotlin/dataframe/pull/842. Here I address the issue of configurations being added later.

First, to recap my scenario. In my project that I use dataframes in, I need to use the custom configuration `kspCommonJvmAndroidMainMetadata` because I have modules that have custom intermediate common source set that compiles to both jvm desktop and to android. 

The previous PRs above begin to address this issue. However, there seems to be one more (hopefully last) issue. And that is that in my build logic, for some reason, the configuration `kspCommonJvmAndroidMainMetadata` is not initialized by Gradle until after the dataframes gradle plugin is applied. I am guessing that this is because I am using a custom configuration, so it is initialized at some point later after the kotlin plugin has already been applied and default configurations have been added. This is unfortunate because build logic can get unmanageable for large projects if we have to worry about the ordering of when different plugins and configurations are applied in gradle buildscripts. Ideally, gradle configuration should not care about order.

This PR fixes that issue by looking for the gradle configurations using the live `Project.configurations` list. It still retains the ability to warn the user when a configuration is not found by leveraging `Gradle.projectsEvaluated`. 

I personally dislike using `Gradle.projectsEvaluated` and only resort to it when there is no other option. If anyone knows an alternative way to accomplish this I'd be curious, but I'm unsure if there is any currently. Essentially the problem is that we need to observe the live `Project.configurations` list and apply KSP when the target configuration is initialized, but still must warn the user if the configuration is never found. Technically I don't know any other way to do this other than to warn the user in`Gradle.projectsEvaluated`, because at that point we know that the `Project.configurations` list should be done adding elements (I think).

It works for me.