### PR TITLE
Partially inline AnyFrame typealias in return type position

### DIFF
--- a/plugins/expressions-converter/testData/box/df.txt
+++ b/plugins/expressions-converter/testData/box/df.txt
@@ -45,7 +45,7 @@ package org {
 
                     public final class Wrapper {
                         public constructor Wrapper()
-                        public final val df: org.jetbrains.kotlinx.dataframe.AnyFrame /* = org.jetbrains.kotlinx.dataframe.DataFrame<*> */
+                        public final val df: org.jetbrains.kotlinx.dataframe.DataFrame<*>
                         public final val typed: org.jetbrains.kotlinx.dataframe.DataFrame<org.jetbrains.kotlinx.dataframe.explainer.Person>
                         public open override /*1*/ /*fake_override*/ fun equals(/*0*/ other: kotlin.Any?): kotlin.Boolean
                         @org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions public final fun ff(): kotlin.Unit


### PR DESCRIPTION
I noticed that completion pop-up still shows that AnyFrame = DataFrame<*> and it makes it look cluttered
It makes me want to remove all such type aliases :c But, we can start from dataFrameOf

Before:
![image](https://github.com/user-attachments/assets/6560f675-0861-481d-a9f1-ac3f8f467602)

Looks even worse on a narrow screen:
![image](https://github.com/user-attachments/assets/608d6233-9403-4267-9238-9369cf73a872)

After:
![image](https://github.com/user-attachments/assets/5645f7f2-5bd4-4dde-acb9-bc72c2dc1576)

![image](https://github.com/user-attachments/assets/19abd670-f4f3-4412-a8c0-dcbdc6e3dccc)


