### PR TITLE
Deprecating `DataFrame.read("", delimiter =)`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -22,6 +22,8 @@ import org.jetbrains.kotlinx.dataframe.codeGen.DefaultReadDfMethod
 import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
 import org.jetbrains.kotlinx.dataframe.impl.api.Parsers
 import org.jetbrains.kotlinx.dataframe.impl.api.parse
+import org.jetbrains.kotlinx.dataframe.util.DF_READ_NO_CSV
+import org.jetbrains.kotlinx.dataframe.util.DF_READ_NO_CSV_REPLACE
 import org.jetbrains.kotlinx.dataframe.values
 import java.io.BufferedInputStream
 import java.io.BufferedReader
@@ -100,6 +102,11 @@ public fun DataFrame.Companion.readDelimStr(
         readDelim(it, format, colTypes, skipLines, readLines)
     }
 
+@Deprecated(
+    message = DF_READ_NO_CSV,
+    replaceWith = ReplaceWith(DF_READ_NO_CSV_REPLACE),
+    level = DeprecationLevel.WARNING,
+)
 public fun DataFrame.Companion.read(
     fileOrUrl: String,
     delimiter: Char,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -7,15 +7,13 @@ package org.jetbrains.kotlinx.dataframe.util
  * Level.ERROR -> Remove
  */
 
-// region WARNING in 0.14, ERROR in 0.15
-
-private const val MESSAGE_0_15 = "Will be removed in 0.15."
-
-// endregion
-
 // region WARNING in 0.15, ERROR in 0.16
 
 private const val MESSAGE_0_16 = "Will be removed in 0.16."
+
+internal const val DF_READ_NO_CSV = "This function is deprecated and should be replaced with `readCSV`. $MESSAGE_0_16"
+internal const val DF_READ_NO_CSV_REPLACE =
+    "this.readCSV(fileOrUrl, delimiter, header, colTypes, skipLines, readLines, duplicate, charset)"
 
 // endregion
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/OtherSamples.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.take
 import org.jetbrains.kotlinx.dataframe.explainer.WritersideFooter
 import org.jetbrains.kotlinx.dataframe.explainer.WritersideStyle
-import org.jetbrains.kotlinx.dataframe.io.read
+import org.jetbrains.kotlinx.dataframe.io.readCSV
 import org.jetbrains.kotlinx.dataframe.io.toStandaloneHTML
 import org.junit.Test
 import java.io.File
@@ -16,7 +16,7 @@ class OtherSamples {
 
     @Test
     fun example() {
-        val df = DataFrame.read("../data/titanic.csv", delimiter = ';').take(5)
+        val df = DataFrame.readCSV("../data/titanic.csv", delimiter = ';').take(5)
         // writeTable(df, "exampleName")
     }
 

--- a/docs/StardustDocs/topics/overview.md
+++ b/docs/StardustDocs/topics/overview.md
@@ -50,7 +50,7 @@ Thus,
 **Basics:**
 
 ```kotlin
-val df = DataFrame.read("titanic.csv", delimiter = ';')
+val df = DataFrame.readCSV("titanic.csv", delimiter = ';')
 ```
 
 ```kotlin


### PR DESCRIPTION
First tiny piece of https://github.com/Kotlin/dataframe/issues/827.

All our `DataFrame.read()` overloads exist in guess.kt and go over all available formats based on the file or url given to the function.

`DataFrame.read(..., delimiter =)` can be replaced by the already existing `DataFrame.readCSV(..., delimiter =)` function family. This deprecates the old function with a WARNING in favor of `readCSV`.