### PR TITLE
[Compiler plugin] Support dataFrameOf(Pair<String, List<T>)

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -279,6 +279,8 @@ public inline fun <reified C> dataFrameOf(vararg header: String, fill: (String) 
 
 public fun dataFrameOf(header: Iterable<String>): DataFrameBuilder = DataFrameBuilder(header.asList())
 
+@Refine
+@Interpretable("DataFrameOf3")
 public fun dataFrameOf(vararg columns: Pair<String, List<Any?>>): DataFrame<*> =
     columns.map { it.second.toColumn(it.first, Infer.Type) }.toDataFrame()
 

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/dataFrameOf.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/dataFrameOf.kt
@@ -1,9 +1,12 @@
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
 import org.jetbrains.kotlin.fir.expressions.FirVarargArgumentsExpression
 import org.jetbrains.kotlin.fir.types.commonSuperTypeOrNull
 import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.fir.types.type
 import org.jetbrains.kotlin.fir.types.typeContext
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
@@ -34,5 +37,20 @@ class DataFrameBuilderInvoke0 : AbstractSchemaModificationInterpreter() {
             simpleColumnOf(name, type)
         }
         return PluginDataFrameSchema(columns)
+    }
+}
+
+class DataFrameOf3 : AbstractSchemaModificationInterpreter() {
+    val Arguments.columns: List<Interpreter.Success<Pair<*, *>>> by arg()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        val res = columns.map {
+            val it = it.value
+            val name = (it.first as? FirLiteralExpression)?.value as? String
+            val type = (it.second as? FirExpression)?.resolvedType?.typeArguments?.getOrNull(0)?.type
+            if (name == null || type == null) return PluginDataFrameSchema(emptyList())
+            simpleColumnOf(name, type)
+        }
+        return PluginDataFrameSchema(res)
     }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/stdlib.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/stdlib.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Interpreter
+
+class PairConstructor : AbstractInterpreter<Pair<*, *>>() {
+    val Arguments.receiver: Any? by arg(lens = Interpreter.Id)
+    val Arguments.that: Any? by arg(lens = Interpreter.Id)
+    override fun Arguments.interpret(): Pair<*, *> {
+        return receiver to that
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -136,7 +136,11 @@ fun <T> KotlinTypeFacade.interpret(
                                 is FirCallableReferenceAccess -> {
                                     toKPropertyApproximation(it, session)
                                 }
-
+                                is FirFunctionCall -> {
+                                    it.loadInterpreter()?.let { processor ->
+                                        interpret(it, processor, emptyMap(), reporter)
+                                    }
+                                }
                                 else -> null
                             }
 

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlinx.dataframe.plugin.utils
 
+import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -50,6 +51,9 @@ object Names {
     val LOCAL_DATE_CLASS_ID = kotlinx.datetime.LocalDate::class.classId()
     val LOCAL_DATE_TIME_CLASS_ID = kotlinx.datetime.LocalDateTime::class.classId()
     val INSTANT_CLASS_ID = kotlinx.datetime.Instant::class.classId()
+
+    val PAIR = ClassId(FqName("kotlin"), Name.identifier("Pair"))
+    val TO = CallableId(FqName("kotlin"), Name.identifier("to"))
 }
 
 private fun KClass<*>.classId(): ClassId {

--- a/plugins/kotlin-dataframe/testData/box/dataFrameOf_to.kt
+++ b/plugins/kotlin-dataframe/testData/box/dataFrameOf_to.kt
@@ -1,0 +1,14 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf(
+        "a" to listOf(1, 2),
+        "b" to listOf("str1", "str2"),
+    )
+    val i: Int = df.a[0]
+    val str: String = df.b[0]
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -83,6 +83,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("dataFrameOf_to.kt")
+  public void testDataFrameOf_to() {
+    runTest("testData/box/dataFrameOf_to.kt");
+  }
+
+  @Test
   @TestMetadata("dataFrameOf_vararg.kt")
   public void testDataFrameOf_vararg() {
     runTest("testData/box/dataFrameOf_vararg.kt");


### PR DESCRIPTION
Change in `buildLetCall` is needed because this function has a unique `(...) -> DataFrame` shape, while most other have some kind of `Receiver.(...) -> DataFrame`
`df.convert { }.with { }` -> `df.convert { }.let { it.with { } as ... }`

for  `(...) -> DataFrame` it will be
`dataFrameOf(pairs)` -> `run { dataFrameOf(pairs) as ... }`