### PR TITLE
[Compiler plugin] Add a mechanism to handle function calls to stdlib that can appear as df api arguments

### DIFF
--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/stdlib.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/stdlib.kt
@@ -3,11 +3,38 @@ package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Interpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Present
 
-class PairConstructor : AbstractInterpreter<Pair<*, *>>() {
+class PairToConstructor : AbstractInterpreter<Pair<*, *>>() {
     val Arguments.receiver: Any? by arg(lens = Interpreter.Id)
     val Arguments.that: Any? by arg(lens = Interpreter.Id)
     override fun Arguments.interpret(): Pair<*, *> {
         return receiver to that
     }
 }
+
+class PairConstructor : AbstractInterpreter<Pair<*, *>>() {
+    val Arguments.first: Any? by arg(lens = Interpreter.Id)
+    val Arguments.second: Any? by arg(lens = Interpreter.Id)
+    override fun Arguments.interpret(): Pair<*, *> {
+        return first to second
+    }
+}
+
+class TrimMargin : AbstractInterpreter<String>() {
+    val Arguments.receiver: String by arg(lens = Interpreter.Value)
+    val Arguments.marginPrefix: String by arg(lens = Interpreter.Value, defaultValue = Present("|"))
+
+    override fun Arguments.interpret(): String {
+        return receiver.trimMargin(marginPrefix)
+    }
+}
+
+class TrimIndent : AbstractInterpreter<String>() {
+    val Arguments.receiver: String by arg(lens = Interpreter.Value)
+
+    override fun Arguments.interpret(): String {
+        return receiver.trimIndent()
+    }
+}
+

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlinx.dataframe.plugin.utils
 
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -53,7 +54,10 @@ object Names {
     val INSTANT_CLASS_ID = kotlinx.datetime.Instant::class.classId()
 
     val PAIR = ClassId(FqName("kotlin"), Name.identifier("Pair"))
+    val PAIR_CONSTRUCTOR = CallableId(FqName("kotlin"), FqName("Pair"), Name.identifier("Pair"))
     val TO = CallableId(FqName("kotlin"), Name.identifier("to"))
+    val TRIM_MARGIN = CallableId(StandardNames.TEXT_PACKAGE_FQ_NAME, Name.identifier("trimMargin"))
+    val TRIM_INDENT = CallableId(StandardNames.TEXT_PACKAGE_FQ_NAME, Name.identifier("trimIndent"))
 }
 
 private fun KClass<*>.classId(): ClassId {

--- a/plugins/kotlin-dataframe/testData/box/trimIndent.kt
+++ b/plugins/kotlin-dataframe/testData/box/trimIndent.kt
@@ -4,11 +4,9 @@ import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.io.*
 
 fun box(): String {
-    val df = dataFrameOf(
-        Pair("a", listOf(1, 2))
-        "b" to listOf("str1", "str2"),
-    )
-    val i: Int = df.a[0]
-    val str: String = df.b[0]
+    val df = DataFrame.readJsonStr("""
+        {"a": 123}
+        """.trimIndent())
+    df.a
     return "OK"
 }

--- a/plugins/kotlin-dataframe/testData/box/trimMargin.kt
+++ b/plugins/kotlin-dataframe/testData/box/trimMargin.kt
@@ -4,11 +4,9 @@ import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.io.*
 
 fun box(): String {
-    val df = dataFrameOf(
-        Pair("a", listOf(1, 2))
-        "b" to listOf("str1", "str2"),
-    )
-    val i: Int = df.a[0]
-    val str: String = df.b[0]
+    val df = DataFrame.readJsonStr("""
+        |{"a": 123}
+        |""".trimMargin())
+    df.a
     return "OK"
 }

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -443,6 +443,18 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("trimIndent.kt")
+  public void testTrimIndent() {
+    runTest("testData/box/trimIndent.kt");
+  }
+
+  @Test
+  @TestMetadata("trimMargin.kt")
+  public void testTrimMargin() {
+    runTest("testData/box/trimMargin.kt");
+  }
+
+  @Test
   @TestMetadata("ungroup.kt")
   public void testUngroup() {
     runTest("testData/box/ungroup.kt");


### PR DESCRIPTION
This change is needed because argument for readJsonStr is almost always a function call to either trimMargin or trimIndent with a constant String argument. Bonus: easy to add `Pair("a", listOf())`