### PR TITLE
Change default flatten parent-child separator to "_"

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
@@ -9,37 +9,41 @@ import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.flattenImpl
 import kotlin.reflect.KProperty
 
+public const val FLATTEN_DEFAULT_SEPARATOR: String = "_"
+
 // region DataFrame
 
 @Refine
 @Interpretable("FlattenDefault")
-public fun <T> DataFrame<T>.flatten(keepParentNameForColumns: Boolean = false, separator: String = "."): DataFrame<T> =
-    flatten(keepParentNameForColumns, separator) { all() }
+public fun <T> DataFrame<T>.flatten(
+    keepParentNameForColumns: Boolean = false,
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+): DataFrame<T> = flatten(keepParentNameForColumns, separator) { all() }
 
 @Refine
 @Interpretable("Flatten0")
 public fun <T, C> DataFrame<T>.flatten(
     keepParentNameForColumns: Boolean = false,
-    separator: String = ".",
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = flattenImpl(columns, keepParentNameForColumns, separator)
 
 public fun <T> DataFrame<T>.flatten(
     vararg columns: String,
     keepParentNameForColumns: Boolean = false,
-    separator: String = ".",
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 public fun <T, C> DataFrame<T>.flatten(
     vararg columns: ColumnReference<C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = ".",
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 public fun <T, C> DataFrame<T>.flatten(
     vararg columns: KProperty<C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = ".",
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
@@ -9,41 +9,37 @@ import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.flattenImpl
 import kotlin.reflect.KProperty
 
-public const val FLATTEN_DEFAULT_SEPARATOR: String = "_"
-
 // region DataFrame
 
 @Refine
 @Interpretable("FlattenDefault")
-public fun <T> DataFrame<T>.flatten(
-    keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
-): DataFrame<T> = flatten(keepParentNameForColumns, separator) { all() }
+public fun <T> DataFrame<T>.flatten(keepParentNameForColumns: Boolean = false, separator: String = "_"): DataFrame<T> =
+    flatten(keepParentNameForColumns, separator) { all() }
 
 @Refine
 @Interpretable("Flatten0")
 public fun <T, C> DataFrame<T>.flatten(
     keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+    separator: String = "_",
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = flattenImpl(columns, keepParentNameForColumns, separator)
 
 public fun <T> DataFrame<T>.flatten(
     vararg columns: String,
     keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+    separator: String = "_",
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 public fun <T, C> DataFrame<T>.flatten(
     vararg columns: ColumnReference<C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+    separator: String = "_",
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 public fun <T, C> DataFrame<T>.flatten(
     vararg columns: KProperty<C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+    separator: String = "_",
 ): DataFrame<T> = flatten(keepParentNameForColumns, separator) { columns.toColumnSet() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlinx.dataframe.impl.api
 
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.FLATTEN_DEFAULT_SEPARATOR
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
 import org.jetbrains.kotlinx.dataframe.api.into
@@ -16,7 +15,7 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnSet
 internal fun <T, C> DataFrame<T>.flattenImpl(
     columns: ColumnsSelector<T, C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = FLATTEN_DEFAULT_SEPARATOR,
+    separator: String = "_",
 ): DataFrame<T> {
     val rootColumns = getColumnsWithPaths {
         columns.toColumnSet().filter { it.isColumnGroup() }.simplify()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinx.dataframe.impl.api
 
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.FLATTEN_DEFAULT_SEPARATOR
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
 import org.jetbrains.kotlinx.dataframe.api.into
@@ -15,7 +16,7 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.toColumnSet
 internal fun <T, C> DataFrame<T>.flattenImpl(
     columns: ColumnsSelector<T, C>,
     keepParentNameForColumns: Boolean = false,
-    separator: String = ".",
+    separator: String = FLATTEN_DEFAULT_SEPARATOR,
 ): DataFrame<T> {
     val rootColumns = getColumnsWithPaths {
         columns.toColumnSet().filter { it.isColumnGroup() }.simplify()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
@@ -98,7 +98,7 @@ class FlattenTests {
 
         aggregate
             .flatten(keepParentNameForColumns = true)
-            .columnNames() shouldBe listOf("city", "mean.age", "mean.weight", "std.age", "std.weight")
+            .columnNames() shouldBe listOf("city", "mean_age", "mean_weight", "std_age", "std_weight")
 
         aggregate
             .flatten(keepParentNameForColumns = true, separator = "_happy_separator_")


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/911

While the discussion of separators in generated accessors is for later, this PR at least fixes the case for flatten.

Given a DataFrame with `df.group.child1` and `df.group.child2`. Calling `flatten` with `keepParentNameForColumns` will introduce `flatDf.group_child1` and `flatDf.group_child2` by default now.

This makes it a bit easier compared to the previous default with "." which made the flattened column name "group.child1" and the accessor `` flatDf`.`group child1` ``.