### PR TITLE
Fixed local classes being inferred as `Any` by changing visibility check

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -228,15 +228,14 @@ internal fun commonParents(classes: Iterable<KClass<*>>): List<KClass<*>> =
                 .let {
                     when {
                         // if there is only one class - return it
-                        it.size == 1 && it[0].visibility == KVisibility.PUBLIC -> listOf(it[0])
+                        it.size == 1 && it[0].visibility.let { it == null || it == KVisibility.PUBLIC } -> listOf(it[0])
 
                         else ->
                             it.fold(null as (Set<KClass<*>>?)) { set, clazz ->
                                 // collect a set of all common superclasses from original classes
-                                val superclasses =
-                                    (clazz.allSuperclasses + clazz)
-                                        .filter { it.visibility == KVisibility.PUBLIC }
-                                        .toSet()
+                                val superclasses = (clazz.allSuperclasses + clazz)
+                                    .filter { it.visibility == null || it.visibility == KVisibility.PUBLIC }
+                                    .toSet()
                                 set?.intersect(superclasses) ?: superclasses
                             }!!.let {
                                 // leave only 'leaf' classes, that are not super to some other class in a set

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -38,6 +38,7 @@ class ConstructorsTests {
     @Suppress("ktlint:standard:argument-list-wrapping")
     @Test
     fun `dataFrameOf with local class`() {
+        // issue #928
         data class Car(val type: String, val model: String)
 
         val cars: DataFrame<*> = dataFrameOf("owner", "car")(
@@ -50,5 +51,13 @@ class ConstructorsTests {
         val unfolded = cars.unfold("car")
         unfolded["car"]["type"].type shouldBe typeOf<String>()
         unfolded["car"]["model"].type shouldBe typeOf<String>()
+
+        val cars2 = listOf(
+            Car("audi", "a8"),
+            Car("toyota", "corolla"),
+        ).toDataFrame()
+
+        cars2["type"].type shouldBe typeOf<String>()
+        cars2["model"].type shouldBe typeOf<String>()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.type
 import org.junit.Test
+import kotlin.reflect.typeOf
 
 class ConstructorsTests {
 
@@ -31,5 +33,22 @@ class ConstructorsTests {
     fun `dataFrameOf with nothing columns`() {
         dataFrameOf("a" to emptyList())["a"].type shouldBe nothingType(false)
         dataFrameOf("a" to listOf(null))["a"].type shouldBe nothingType(true)
+    }
+
+    @Suppress("ktlint:standard:argument-list-wrapping")
+    @Test
+    fun `dataFrameOf with local class`() {
+        data class Car(val type: String, val model: String)
+
+        val cars: DataFrame<*> = dataFrameOf("owner", "car")(
+            "Max", Car("audi", "a8"),
+            "Tom", Car("toyota", "corolla"),
+        )
+
+        cars["car"].type shouldBe typeOf<Car>()
+
+        val unfolded = cars.unfold("car")
+        unfolded["car"]["type"].type shouldBe typeOf<String>()
+        unfolded["car"]["model"].type shouldBe typeOf<String>()
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/928

We can assume "no visibility" means "public". This fixes local classes not being inferred.