### PR TITLE
Open File in readExcel in read-only mode

### DIFF
--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -131,7 +131,8 @@ public fun DataFrame.Companion.readExcel(
     nameRepairStrategy: NameRepairStrategy = NameRepairStrategy.CHECK_UNIQUE,
 ): AnyFrame {
     setWorkbookTempDirectory()
-    val wb = WorkbookFactory.create(file)
+    @Suppress("ktlint:standard:comment-wrapping")
+    val wb = WorkbookFactory.create(file, /* password = */ null, /* readOnly = */ true)
     return wb.use {
         readExcel(it, sheetName, skipRows, columns, stringColumns?.toFormattingOptions(), rowsCount, nameRepairStrategy)
     }


### PR DESCRIPTION
WorkBook is used for reading, so it generally makes sense. It should fix the following error: 
```
OpenXML4JRuntimeException: Fail to save an error occurs while saving the package: The part/docProps/app.ant failed to be saved in the stream marshaller org.apache.pos.openxml4j
```