### PR TITLE
Specify slf4j-api instead of slf4j-simple.

### DIFF
--- a/dataframe-jdbc/build.gradle.kts
+++ b/dataframe-jdbc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     testImplementation(libs.h2db)
     testImplementation(libs.mssql)
     testImplementation(libs.junit)
-    testImplementation(libs.sl4j)
+    testImplementation(libs.sl4jsimple)
     testImplementation(libs.jts)
     testImplementation(libs.kotestAssertions) {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,7 +108,8 @@ kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotli
 swagger = { group = "io.swagger.parser.v3", name = "swagger-parser", version.ref = "openapi" }
 
 kotlinLogging = { group = "io.github.oshai", name = "kotlin-logging", version.ref = "kotlinLogging" }
-sl4j = { group = "org.slf4j", name = "slf4j-simple", version.ref = "sl4j" }
+sl4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "sl4j" }
+sl4jsimple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "sl4j" }
 android-gradle-api = { group = "com.android.tools.build", name = "gradle-api", version.ref = "android-gradle-api" }
 android-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-api" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin" }


### PR DESCRIPTION
When used as a library in other components slf4j-api should be used, allowing the component to select the logging backend themselves (for example logback).

This fixes an issue where slf4j would complain that there were two competing logging backends in any application using this along with somehing like logback.