### PR TITLE
[Compiler plugin] Propagate nullability in toDataFrame tree conversion

### DIFF
--- a/plugins/kotlin-dataframe/testData/box/toDataFrame_customIterable.kt
+++ b/plugins/kotlin-dataframe/testData/box/toDataFrame_customIterable.kt
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class D(
+    val s: String
+)
+
+class Subtree(
+    val p: Int,
+    val l: List<Int>,
+    val ld: List<D>,
+)
+
+class Root(val a: Subtree)
+
+class MyList(val l: List<Root?>): List<Root?> by l
+
+fun box(): String {
+    val l = listOf(
+        Root(Subtree(123, listOf(1), listOf(D("ff")))),
+        null
+    )
+    val df = MyList(l).toDataFrame(maxDepth = 2)
+    df.compareSchemas(strict = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableList.kt
+++ b/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableList.kt
@@ -1,0 +1,16 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class D(
+    val s: String
+)
+
+fun box(): String {
+    val df1 = listOf(D("bb"), null).toDataFrame()
+    df1.schema().print()
+    df1.compileTimeSchema().print()
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableListSubtree.kt
+++ b/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableListSubtree.kt
@@ -1,0 +1,27 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class D(
+    val s: String
+)
+
+class Subtree(
+    val p: Int,
+    val l: List<Int>,
+    val ld: List<D>,
+)
+
+class Root(val a: Subtree)
+
+fun box(): String {
+    val l = listOf(
+        Root(Subtree(123, listOf(1), listOf(D("ff")))),
+        null
+    )
+    val df = l.toDataFrame(maxDepth = 2)
+    df.compareSchemas(strict = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableSubtree.kt
+++ b/plugins/kotlin-dataframe/testData/box/toDataFrame_nullableSubtree.kt
@@ -1,0 +1,27 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+data class D(
+    val s: String
+)
+
+class Subtree(
+    val p: Int,
+    val l: List<Int>,
+    val ld: List<D>,
+)
+
+class Root(val a: Subtree?)
+
+fun box(): String {
+    val l = listOf(
+        Root(Subtree(123, listOf(1), listOf(D("ff")))),
+        Root(null)
+    )
+    val df = l.toDataFrame(maxDepth = 2)
+    df.compareSchemas(strict = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -437,6 +437,24 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("toDataFrame_nullableList.kt")
+  public void testToDataFrame_nullableList() {
+    runTest("testData/box/toDataFrame_nullableList.kt");
+  }
+
+  @Test
+  @TestMetadata("toDataFrame_nullableListSubtree.kt")
+  public void testToDataFrame_nullableListSubtree() {
+    runTest("testData/box/toDataFrame_nullableListSubtree.kt");
+  }
+
+  @Test
+  @TestMetadata("toDataFrame_nullableSubtree.kt")
+  public void testToDataFrame_nullableSubtree() {
+    runTest("testData/box/toDataFrame_nullableSubtree.kt");
+  }
+
+  @Test
   @TestMetadata("toDataFrame_superType.kt")
   public void testToDataFrame_superType() {
     runTest("testData/box/toDataFrame_superType.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -419,6 +419,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("toDataFrame_customIterable.kt")
+  public void testToDataFrame_customIterable() {
+    runTest("testData/box/toDataFrame_customIterable.kt");
+  }
+
+  @Test
   @TestMetadata("toDataFrame_dataSchema.kt")
   public void testToDataFrame_dataSchema() {
     runTest("testData/box/toDataFrame_dataSchema.kt");


### PR DESCRIPTION
There are 3 cases where plugin assumed non-null type for column and it actually should be nullable. With this fix, compile schema matches runtime schema 