### PR TITLE
[Important Fix!] Parse started to removed unselected columns

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -20,12 +20,13 @@ import org.jetbrains.kotlinx.dataframe.api.ParserOptions
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.asDataColumn
 import org.jetbrains.kotlinx.dataframe.api.cast
-import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
-import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
+import org.jetbrains.kotlinx.dataframe.api.convert
 import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.isFrameColumn
 import org.jetbrains.kotlinx.dataframe.api.isSubtypeOf
-import org.jetbrains.kotlinx.dataframe.api.toColumn
+import org.jetbrains.kotlinx.dataframe.api.map
+import org.jetbrains.kotlinx.dataframe.api.parse
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.tryParse
 import org.jetbrains.kotlinx.dataframe.columns.TypeSuggestion
 import org.jetbrains.kotlinx.dataframe.columns.size
@@ -531,17 +532,16 @@ internal fun <T> DataColumn<String?>.parse(parser: StringParser<T>, options: Par
     )
 }
 
-internal fun <T> DataFrame<T>.parseImpl(options: ParserOptions?, columns: ColumnsSelector<T, Any?>): DataFrame<T> {
-    val convertedCols = getColumnsWithPaths(columns).map { col ->
+internal fun <T> DataFrame<T>.parseImpl(options: ParserOptions?, columns: ColumnsSelector<T, Any?>): DataFrame<T> =
+    convert(columns).to { col ->
         when {
             // when a frame column is requested to be parsed,
             // parse each value/frame column at any depth inside each DataFrame in the frame column
-            col.isFrameColumn() ->
-                col.values.map {
-                    it.parseImpl(options) {
-                        colsAtAnyDepth { !it.isColumnGroup() }
-                    }
-                }.toColumn(col.name)
+            col.isFrameColumn() -> col.map {
+                it.parseImpl(options) {
+                    colsAtAnyDepth { !it.isColumnGroup() }
+                }
+            }
 
             // when a column group is requested to be parsed,
             // parse each column in the group
@@ -552,11 +552,8 @@ internal fun <T> DataFrame<T>.parseImpl(options: ParserOptions?, columns: Column
 
             // Base case, parse the column if it's a `String?` column
             col.isSubtypeOf<String?>() ->
-                col.cast<String?>().tryParse(options)
+                col.cast<String?>().tryParseImpl(options)
 
             else -> col
-        }.let { ColumnToInsert(col.path, it) }
+        }
     }
-
-    return emptyDataFrame<T>().insertImpl(convertedCols)
-}


### PR DESCRIPTION
Fixed `parseImpl()` removing unselected columns by reverting implementation to use `convert` instead of `insert`.

We didn't have a test that ran `parse { someCol }`, but I found it running the example in README.md