### PR TITLE
Version bump KtLint to 1.4.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,7 @@ ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_e
 ktlint_standard_chain-method-continuation = disabled
 ktlint_ignore_back_ticked_identifier = true
 ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_when-entry-bracing = disabled
 
 [{*/build/**/*,**/*keywords*/**,**/*.Generated.kt,**/*$Extensions.kt}]
 ktlint = disabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,7 @@ allprojects {
     afterEvaluate {
         try {
             configure<KtlintExtension> {
-                version = "1.3.0"
+                version = "1.4.1"
                 // rules are set up through .editorconfig
             }
         } catch (_: UnknownDomainObjectException) {


### PR DESCRIPTION
Bumping ktlint engine version to 1.4.1.

disabled new [`when-entry-bracing rule`](https://pinterest.github.io/ktlint/latest/rules/experimental/#when-entry-bracing) as it was a bit too aggressive in our project.

Make sure to install the latest (beta) version of the ktlint intellij plugin https://plugins.jetbrains.com/plugin/15057-ktlint/versions/beta/629291