### PR TITLE
Fixed error message for ColumnAccessor

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnAccessorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnAccessorImpl.kt
@@ -43,4 +43,6 @@ internal class ColumnAccessorImpl<T>(val path: ColumnPath) : ColumnAccessor<T> {
     override fun getValue(row: AnyRow) = path.getValue(row) as T
 
     override fun getValueOrNull(row: AnyRow) = path.getValueOrNull(row) as T
+
+    override fun toString(): String = path().toString()
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/get.kt
@@ -49,6 +49,9 @@ class GetTests {
         shouldThrow<IllegalArgumentException> { row.getValue(c) }
         shouldThrow<IllegalArgumentException> { row.getValue(A::c) }
 
+        val throwable = shouldThrow<IllegalArgumentException> { df[column<Int>("c")] }
+        throwable.message shouldContain "Column not found: '[c]'"
+
         val added = df.add(A::c) { "3" }[0]
 
         shouldThrow<ClassCastException> { added.getValue(c) + 1 }


### PR DESCRIPTION
Closes #690 

Introduce a toString override in ColumnAccessorImpl to enhance debugging and readability. Added tests to verify exception behavior when a column is not found, ensuring stability and clarity in error messages.