### PR TITLE
Fix: disabled FastDoubleParser debug logs overload in the tests

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     }
     testImplementation(libs.kotlin.scriptingJvm)
     testImplementation(libs.jsoup)
+    testImplementation(libs.sl4jsimple)
 }
 
 val samplesImplementation by configurations.getting {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/FastDoubleParserTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/FastDoubleParserTests.kt
@@ -9,22 +9,21 @@ import org.junit.Test
 import java.text.NumberFormat
 import java.util.Locale
 
-private const val LOG_LEVEL = "org.slf4j.simpleLogger.defaultLogLevel"
-
 class FastDoubleParserTests {
 
+    private val logLevel = "org.slf4j.simpleLogger.log.${FastDoubleParser::class.qualifiedName}"
     private var loggerBefore: String? = null
 
     @Before
     fun setLogger() {
-        loggerBefore = System.getProperty(LOG_LEVEL)
-        System.setProperty(LOG_LEVEL, "debug")
+        loggerBefore = System.getProperty(logLevel)
+        System.setProperty(logLevel, "debug")
     }
 
     @After
     fun restoreLogger() {
         if (loggerBefore != null) {
-            System.setProperty(LOG_LEVEL, loggerBefore)
+            System.setProperty(logLevel, loggerBefore)
         }
     }
 

--- a/core/src/test/resources/simplelogger.properties
+++ b/core/src/test/resources/simplelogger.properties
@@ -1,0 +1,38 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=debug
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false
+
+# Disables FastDoubleParser debug logs by default in our tests
+# Can be enabled by setting the system property programmatically
+org.slf4j.simpleLogger.log.org.jetbrains.kotlinx.dataframe.impl.io.FastDoubleParser=warn


### PR DESCRIPTION
Added `testImplementation` of `slf4jSimple` to `:core` so we can configure the logs.

Disabled `FastDoubleParser` debug logs for `:core:test`, except for `FastDoubleParserTests`