### PR TITLE
Adding some missing converters

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -15,6 +15,7 @@ import kotlinx.datetime.toJavaLocalTime
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.datetime.toKotlinLocalTime
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -350,6 +351,8 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
 
                 LocalDate::class -> convert<Long> { it.toLocalDate(defaultTimeZone) }
 
+                LocalTime::class -> convert<Long> { it.toLocalTime(defaultTimeZone) }
+
                 Instant::class -> convert<Long> { Instant.fromEpochMilliseconds(it) }
 
                 JavaLocalDateTime::class -> convert<Long> {
@@ -501,6 +504,16 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                     it.toKotlinLocalDate().atStartOfDayIn(defaultTimeZone).toJavaInstant()
                 }
 
+                else -> null
+            }
+
+            LocalTime::class -> when (toClass) {
+                JavaLocalTime::class -> convert<LocalTime> { it.toJavaLocalTime() }
+                else -> null
+            }
+
+            JavaLocalTime::class -> when (toClass) {
+                LocalTime::class -> convert<JavaLocalTime> { it.toKotlinLocalTime() }
                 else -> null
             }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -336,6 +336,82 @@ internal fun createConverter(from: KType, to: KType, options: ParserOptions? = n
                 else -> null
             }
 
+            Byte::class -> when (toClass) {
+                Double::class -> convert<Byte> { it.toDouble() }
+
+                Float::class -> convert<Byte> { it.toFloat() }
+
+                Int::class -> convert<Byte> { it.toInt() }
+
+                Short::class -> convert<Byte> { it.toShort() }
+
+                Long::class -> convert<Byte> { it.toLong() }
+
+                BigDecimal::class -> convert<Byte> { it.toBigDecimal() }
+
+                BigInteger::class -> convert<Byte> { it.toBigInteger() }
+
+                Boolean::class -> convert<Byte> { it != 0.toByte() }
+
+                LocalDateTime::class -> convert<Byte> { it.toLong().toLocalDateTime(defaultTimeZone) }
+
+                LocalDate::class -> convert<Byte> { it.toLong().toLocalDate(defaultTimeZone) }
+
+                LocalTime::class -> convert<Byte> { it.toLong().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<Byte> { Instant.fromEpochMilliseconds(it.toLong()) }
+
+                JavaLocalDateTime::class -> convert<Byte> {
+                    it.toLong().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
+                }
+
+                JavaLocalDate::class -> convert<Byte> { it.toLong().toLocalDate(defaultTimeZone).toJavaLocalDate() }
+
+                JavaLocalTime::class -> convert<Byte> { it.toLong().toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Byte> { JavaInstant.ofEpochMilli(it.toLong()) }
+
+                else -> null
+            }
+
+            Short::class -> when (toClass) {
+                Double::class -> convert<Short> { it.toDouble() }
+
+                Float::class -> convert<Short> { it.toFloat() }
+
+                Int::class -> convert<Short> { it.toInt() }
+
+                Byte::class -> convert<Short> { it.toByte() }
+
+                Long::class -> convert<Short> { it.toLong() }
+
+                BigDecimal::class -> convert<Short> { it.toBigDecimal() }
+
+                BigInteger::class -> convert<Short> { it.toBigInteger() }
+
+                Boolean::class -> convert<Short> { it != 0.toShort() }
+
+                LocalDateTime::class -> convert<Short> { it.toLong().toLocalDateTime(defaultTimeZone) }
+
+                LocalDate::class -> convert<Short> { it.toLong().toLocalDate(defaultTimeZone) }
+
+                LocalTime::class -> convert<Short> { it.toLong().toLocalTime(defaultTimeZone) }
+
+                Instant::class -> convert<Short> { Instant.fromEpochMilliseconds(it.toLong()) }
+
+                JavaLocalDateTime::class -> convert<Short> {
+                    it.toLong().toLocalDateTime(defaultTimeZone).toJavaLocalDateTime()
+                }
+
+                JavaLocalDate::class -> convert<Short> { it.toLong().toLocalDate(defaultTimeZone).toJavaLocalDate() }
+
+                JavaLocalTime::class -> convert<Short> { it.toLong().toLocalTime(defaultTimeZone).toJavaLocalTime() }
+
+                JavaInstant::class -> convert<Short> { JavaInstant.ofEpochMilli(it.toLong()) }
+
+                else -> null
+            }
+
             Double::class -> when (toClass) {
                 Int::class -> convert<Double> { it.roundToInt() }
                 Float::class -> convert<Double> { it.toFloat() }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -16,8 +16,19 @@ import org.jetbrains.kotlinx.dataframe.hasNulls
 import org.junit.Test
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.hours
+import java.time.LocalTime as JavaLocalTime
 
 class ConvertTests {
+
+    @Test
+    fun `convert LocalTime Kotlin to Java and back`() {
+        val time by columnOf(LocalTime(11, 22, 33))
+        val converted = time.toDataFrame().convert { time }.to<JavaLocalTime>()
+        converted[time][0] shouldBe JavaLocalTime.of(11, 22, 33)
+
+        val convertedBack = converted.convert(time).to<LocalTime>()
+        convertedBack[time][0] shouldBe time[0]
+    }
 
     @Test
     fun `convert nullable strings to time`() {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -13,7 +13,15 @@ import org.jetbrains.kotlinx.dataframe.exceptions.CellConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConversionException
 import org.jetbrains.kotlinx.dataframe.exceptions.TypeConverterNotFoundException
 import org.jetbrains.kotlinx.dataframe.hasNulls
+import org.jetbrains.kotlinx.dataframe.impl.api.toBigDecimal
+import org.jetbrains.kotlinx.dataframe.impl.api.toBigInteger
 import org.junit.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+import kotlin.random.Random
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.hours
 import java.time.LocalTime as JavaLocalTime
@@ -182,5 +190,129 @@ class ConvertTests {
         val col = columnOf(1.hours)
         val res = col.convertTo<String>()
         res.print()
+    }
+
+    @Test
+    fun `convert Int and Char by code`() {
+        val col = columnOf(65, 66)
+        col.convertTo<Char>() shouldBe columnOf('A', 'B')
+        col.convertTo<Char>().convertTo<Int>() shouldBe col
+    }
+
+    @Test
+    fun `convert all number types to each other`() {
+        val numberTypes: List<Number> = listOf(
+            Random.nextInt().toByte(),
+            Random.nextInt().toShort(),
+            Random.nextInt(),
+            Random.nextLong(),
+            Random.nextFloat(),
+            Random.nextDouble(),
+            BigInteger.valueOf(Random.nextLong()),
+            BigDecimal.valueOf(Random.nextDouble()),
+        )
+        for (a in numberTypes) {
+            val aCol = columnOf(a)
+            for (b in numberTypes) {
+                val bCol = aCol.convertTo(b::class.starProjectedType)
+                when (a) {
+                    is Byte ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is Short ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is Int ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is Long ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is Float ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.roundToInt().toByte()
+                            is Short -> bCol.first() shouldBe a.roundToInt().toShort()
+                            is Int -> bCol.first() shouldBe a.roundToInt()
+                            is Long -> bCol.first() shouldBe a.roundToLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is Double ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.roundToInt().toByte()
+                            is Short -> bCol.first() shouldBe a.roundToInt().toShort()
+                            is Int -> bCol.first() shouldBe a.roundToInt()
+                            is Long -> bCol.first() shouldBe a.roundToLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is BigInteger ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+
+                    is BigDecimal ->
+                        when (b) {
+                            is Byte -> bCol.first() shouldBe a.toByte()
+                            is Short -> bCol.first() shouldBe a.toShort()
+                            is Int -> bCol.first() shouldBe a.toInt()
+                            is Long -> bCol.first() shouldBe a.toLong()
+                            is Float -> bCol.first() shouldBe a.toFloat()
+                            is Double -> bCol.first() shouldBe a.toDouble()
+                            is BigInteger -> bCol.first() shouldBe a.toBigInteger()
+                            is BigDecimal -> bCol.first() shouldBe a.toBigDecimal()
+                        }
+                }
+            }
+        }
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -223,7 +223,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun convertToValueClass() {
         // SampleStart
-        dataFrameOf("value")("1", "2")
+        dataFrameOf("value")("1", "2") // note that values are strings; conversion is done automatically
             .convert("value").to<IntClass>()
         // SampleEnd
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -216,6 +216,18 @@ class Modify : TestBase() {
         // SampleEnd
     }
 
+    @JvmInline
+    value class IntClass(val value: Int)
+
+    @Test
+    @TransformDataFrameExpressions
+    fun convertToValueClass() {
+        // SampleStart
+        dataFrameOf("value")("1", "2")
+            .convert("value").to<IntClass>()
+        // SampleEnd
+    }
+
     @Test
     @TransformDataFrameExpressions
     fun convertAsFrame() {

--- a/docs/StardustDocs/snippets/org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertToValueClass.html
+++ b/docs/StardustDocs/snippets/org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertToValueClass.html
@@ -1,0 +1,486 @@
+<html>
+<head>
+<style type="text/css">
+:root {
+    --background: #fff;
+    --background-odd: #f5f5f5;
+    --background-hover: #d9edfd;
+    --header-text-color: #474747;
+    --text-color: #848484;
+    --text-color-dark: #000;
+    --text-color-medium: #737373;
+    --text-color-pale: #b3b3b3;
+    --inner-border-color: #aaa;
+    --bold-border-color: #000;
+    --link-color: #296eaa;
+    --link-color-pale: #296eaa;
+    --link-hover: #1a466c;
+}
+
+:root[theme="dark"], :root [data-jp-theme-light="false"], .dataframe_dark{
+    --background: #303030;
+    --background-odd: #3c3c3c;
+    --background-hover: #464646;
+    --header-text-color: #dddddd;
+    --text-color: #b3b3b3;
+    --text-color-dark: #dddddd;
+    --text-color-medium: #b2b2b2;
+    --text-color-pale: #737373;
+    --inner-border-color: #707070;
+    --bold-border-color: #777777;
+    --link-color: #008dc0;
+    --link-color-pale: #97e1fb;
+    --link-hover: #00688e;
+}
+
+p.dataframe_description {
+    color: var(--text-color-dark);
+}
+
+table.dataframe {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    background-color: var(--background);
+    color: var(--text-color-dark);
+    border: none;
+    border-collapse: collapse;
+}
+
+table.dataframe th, td {
+    padding: 6px;
+    border: 1px solid transparent;
+    text-align: left;
+}
+
+table.dataframe th {
+    background-color: var(--background);
+    color: var(--header-text-color);
+}
+
+table.dataframe td {
+    vertical-align: top;
+}
+
+table.dataframe th.bottomBorder {
+    border-bottom-color: var(--bold-border-color);
+}
+
+table.dataframe tbody > tr:nth-child(odd) {
+    background: var(--background-odd);
+}
+
+table.dataframe tbody > tr:nth-child(even) {
+    background: var(--background);
+}
+
+table.dataframe tbody > tr:hover {
+    background: var(--background-hover);
+}
+
+table.dataframe a {
+    cursor: pointer;
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+table.dataframe tr:hover > td a {
+    color: var(--link-color-pale);
+}
+
+table.dataframe a:hover {
+    color: var(--link-hover);
+    text-decoration: underline;
+}
+
+table.dataframe img {
+    max-width: fit-content;
+}
+
+table.dataframe th.complex {
+    background-color: var(--background);
+    border: 1px solid var(--background);
+}
+
+table.dataframe .leftBorder {
+    border-left-color: var(--inner-border-color);
+}
+
+table.dataframe .rightBorder {
+    border-right-color: var(--inner-border-color);
+}
+
+table.dataframe .rightAlign {
+    text-align: right;
+}
+
+table.dataframe .expanderSvg {
+    width: 8px;
+    height: 8px;
+    margin-right: 3px;
+}
+
+table.dataframe .expander {
+    display: flex;
+    align-items: center;
+}
+
+/* formatting */
+
+table.dataframe .null {
+    color: var(--text-color-pale);
+}
+
+table.dataframe .structural {
+    color: var(--text-color-medium);
+    font-weight: bold;
+}
+
+table.dataframe .dataFrameCaption {
+    font-weight: bold;
+}
+
+table.dataframe .numbers {
+    color: var(--text-color-dark);
+}
+
+table.dataframe td:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+table.dataframe tr:hover .formatted .structural, .null {
+    color: var(--text-color-dark);
+}
+
+
+body {
+    font-family: "JetBrains Mono",SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
+}       
+
+:root {
+    color: #19191C;
+    background-color: #fff;
+}
+
+:root[theme="dark"] {
+    background-color: #19191C;
+    color: #FFFFFFCC
+}
+
+details details {
+    margin-left: 20px; 
+}
+
+summary {
+    padding: 6px;
+}
+</style>
+</head>
+<body>
+                                <details>
+                                <summary>Input DataFrame: rowsCount = 2, columnsCount = 1</summary>
+                                 <table class="dataframe" id="df_0"></table>
+
+<p class="dataframe_description"></p>
+                                </details>
+<details>
+<summary>Step 1: Convert</summary>
+ <p>class org.jetbrains.kotlinx.dataframe.api.Convert</p>
+</details>
+                                <details>
+                                <summary>Output DataFrame: rowsCount = 2, columnsCount = 1</summary>
+                                 <table class="dataframe" id="df_1"></table>
+
+<p class="dataframe_description"></p>
+                                </details>
+</body>
+<script>
+(function () {
+    window.DataFrame = window.DataFrame || new (function () {
+        this.addTable = function (df) {
+            let cols = df.cols;
+            for (let i = 0; i < cols.length; i++) {
+                for (let c of cols[i].children) {
+                    cols[c].parent = i;
+                }
+            }
+            df.nrow = 0
+            for (let i = 0; i < df.cols.length; i++) {
+                if (df.cols[i].values.length > df.nrow) df.nrow = df.cols[i].values.length
+            }
+            if (df.id === df.rootId) {
+                df.expandedFrames = new Set()
+                df.childFrames = {}
+                const table = this.getTableElement(df.id)
+                table.df = df
+                for (let i = 0; i < df.cols.length; i++) {
+                    let col = df.cols[i]
+                    if (col.parent === undefined && col.children.length > 0) col.expanded = true
+                }
+            } else {
+                const rootDf = this.getTableData(df.rootId)
+                rootDf.childFrames[df.id] = df
+            }
+        }
+
+        this.computeRenderData = function (df) {
+            let result = []
+            let pos = 0
+            for (let col = 0; col < df.cols.length; col++) {
+                if (df.cols[col].parent === undefined)
+                    pos += this.computeRenderDataRec(df.cols, col, pos, 0, result, false, false)
+            }
+            for (let i = 0; i < result.length; i++) {
+                let row = result[i]
+                for (let j = 0; j < row.length; j++) {
+                    let cell = row[j]
+                    if (j === 0)
+                        cell.leftBd = false
+                    if (j < row.length - 1) {
+                        let nextData = row[j + 1]
+                        if (nextData.leftBd) cell.rightBd = true
+                        else if (cell.rightBd) nextData.leftBd = true
+                    } else cell.rightBd = false
+                }
+            }
+            return result
+        }
+
+        this.computeRenderDataRec = function (cols, colId, pos, depth, result, leftBorder, rightBorder) {
+            if (result.length === depth) {
+                const array = [];
+                if (pos > 0) {
+                    let j = 0
+                    for (let i = 0; j < pos; i++) {
+                        let c = result[depth - 1][i]
+                        j += c.span
+                        let copy = Object.assign({empty: true}, c)
+                        array.push(copy)
+                    }
+                }
+                result.push(array)
+            }
+            const col = cols[colId];
+            let size = 0;
+            if (col.expanded) {
+                let childPos = pos
+                for (let i = 0; i < col.children.length; i++) {
+                    let child = col.children[i]
+                    let childLeft = i === 0 && (col.children.length > 1 || leftBorder)
+                    let childRight = i === col.children.length - 1 && (col.children.length > 1 || rightBorder)
+                    let childSize = this.computeRenderDataRec(cols, child, childPos, depth + 1, result, childLeft, childRight)
+                    childPos += childSize
+                    size += childSize
+                }
+            } else {
+                for (let i = depth + 1; i < result.length; i++)
+                    result[i].push({id: colId, span: 1, leftBd: leftBorder, rightBd: rightBorder, empty: true})
+                size = 1
+            }
+            let left = leftBorder
+            let right = rightBorder
+            if (size > 1) {
+                left = true
+                right = true
+            }
+            result[depth].push({id: colId, span: size, leftBd: left, rightBd: right})
+            return size
+        }
+
+        this.getTableElement = function (id) {
+            return document.getElementById("df_" + id)
+        }
+
+        this.getTableData = function (id) {
+            return this.getTableElement(id).df
+        }
+
+        this.createExpander = function (isExpanded) {
+            const svgNs = "http://www.w3.org/2000/svg"
+            let svg = document.createElementNS(svgNs, "svg")
+            svg.classList.add("expanderSvg")
+            let path = document.createElementNS(svgNs, "path")
+            if (isExpanded) {
+                svg.setAttribute("viewBox", "0 -2 8 8")
+                path.setAttribute("d", "M1 0 l-1 1 4 4 4 -4 -1 -1 -3 3Z")
+            } else {
+                svg.setAttribute("viewBox", "-2 0 8 8")
+                path.setAttribute("d", "M1 0 l-1 1 3 3 -3 3 1 1 4 -4Z")
+            }
+            path.setAttribute("fill", "currentColor")
+            svg.appendChild(path)
+            return svg
+        }
+
+        this.renderTable = function (id) {
+
+            let table = this.getTableElement(id)
+
+            if (table === null) return
+
+            table.innerHTML = ""
+
+            let df = table.df
+            let rootDf = df.rootId === df.id ? df : this.getTableData(df.rootId)
+
+            // header
+            let header = document.createElement("thead")
+            table.appendChild(header)
+
+            let renderData = this.computeRenderData(df)
+            for (let j = 0; j < renderData.length; j++) {
+                let rowData = renderData[j]
+                let tr = document.createElement("tr");
+                let isLastRow = j === renderData.length - 1
+                header.appendChild(tr);
+                for (let i = 0; i < rowData.length; i++) {
+                    let cell = rowData[i]
+                    let th = document.createElement("th");
+                    th.setAttribute("colspan", cell.span)
+                    let colId = cell.id
+                    let col = df.cols[colId];
+                    if (!cell.empty) {
+                        if (col.children.length === 0) {
+                            th.innerHTML = col.name
+                        } else {
+                            let link = document.createElement("a")
+                            link.className = "expander"
+                            let that = this
+                            link.onclick = function () {
+                                col.expanded = !col.expanded
+                                that.renderTable(id)
+                            }
+                            link.appendChild(this.createExpander(col.expanded))
+                            link.innerHTML += col.name
+                            th.appendChild(link)
+                        }
+                    }
+                    let classes = (cell.leftBd ? " leftBorder" : "") + (cell.rightBd ? " rightBorder" : "")
+                    if (col.rightAlign)
+                        classes += " rightAlign"
+                    if (isLastRow)
+                        classes += " bottomBorder"
+                    if (classes.length > 0)
+                        th.setAttribute("class", classes)
+                    tr.appendChild(th)
+                }
+            }
+
+            // body
+            let body = document.createElement("tbody")
+            table.appendChild(body)
+
+            let columns = renderData.pop()
+            for (let row = 0; row < df.nrow; row++) {
+                let tr = document.createElement("tr");
+                body.appendChild(tr)
+                for (let i = 0; i < columns.length; i++) {
+                    let cell = columns[i]
+                    let td = document.createElement("td");
+                    let colId = cell.id
+                    let col = df.cols[colId]
+                    let classes = (cell.leftBd ? " leftBorder" : "") + (cell.rightBd ? " rightBorder" : "")
+                    if (col.rightAlign)
+                        classes += " rightAlign"
+                    if (classes.length > 0)
+                        td.setAttribute("class", classes)
+                    tr.appendChild(td)
+                    let value = col.values[row]
+                    if (value.frameId !== undefined) {
+                        let frameId = value.frameId
+                        let expanded = rootDf.expandedFrames.has(frameId)
+                        let link = document.createElement("a")
+                        link.className = "expander"
+                        let that = this
+                        link.onclick = function () {
+                            if (rootDf.expandedFrames.has(frameId))
+                                rootDf.expandedFrames.delete(frameId)
+                            else rootDf.expandedFrames.add(frameId)
+                            that.renderTable(id)
+                        }
+                        link.appendChild(this.createExpander(expanded))
+                        link.innerHTML += value.value
+                        if (expanded) {
+                            td.appendChild(link)
+                            td.appendChild(document.createElement("p"))
+                            const childTable = document.createElement("table")
+                            childTable.className = "dataframe"
+                            childTable.id = "df_" + frameId
+                            let childDf = rootDf.childFrames[frameId]
+                            childTable.df = childDf
+                            td.appendChild(childTable)
+                            this.renderTable(frameId)
+                            if (childDf.nrow !== childDf.totalRows) {
+                                const footer = document.createElement("p")
+                                footer.innerText = `... showing only top ${childDf.nrow} of ${childDf.totalRows} rows`
+                                td.appendChild(footer)
+                            }
+                        } else {
+                            td.appendChild(link)
+                        }
+                    } else if (value.style !== undefined) {
+                        td.innerHTML = value.value
+                        td.setAttribute("style", value.style)
+                    } else td.innerHTML = value
+                    this.nodeScriptReplace(td)
+                }
+            }
+        }
+
+        this.nodeScriptReplace = function (node) {
+            if (this.nodeScriptIs(node) === true) {
+                node.parentNode.replaceChild(this.nodeScriptClone(node), node);
+            } else {
+                let i = -1, children = node.childNodes;
+                while (++i < children.length) {
+                    this.nodeScriptReplace(children[i]);
+                }
+            }
+
+            return node;
+        }
+
+        this.nodeScriptClone = function (node) {
+            let script = document.createElement("script");
+            script.text = node.innerHTML;
+
+            let i = -1, attrs = node.attributes, attr;
+            while (++i < attrs.length) {
+                script.setAttribute((attr = attrs[i]).name, attr.value);
+            }
+            return script;
+        }
+
+        this.nodeScriptIs = function (node) {
+            return node.tagName === 'SCRIPT';
+        }
+    })()
+
+    window.call_DataFrame = function (f) {
+        return f();
+    };
+
+    let funQueue = window["kotlinQueues"] && window["kotlinQueues"]["DataFrame"];
+    if (funQueue) {
+        funQueue.forEach(function (f) {
+            f();
+        });
+        funQueue = [];
+    }
+})()
+
+/*<!--*/
+call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: "<span title=\"value: String\">value</span>", children: [], rightAlign: false, values: ["1","2"] }, 
+], id: 0, rootId: 0, totalRows: 2 } ) });
+/*-->*/
+
+call_DataFrame(function() { DataFrame.renderTable(0) });
+
+/*<!--*/
+call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: "<span title=\"value: samples.api.Modify.IntClass\">value</span>", children: [], rightAlign: false, values: ["IntClass(value=1)","IntClass(value=2)"] }, 
+], id: 1, rootId: 1, totalRows: 2 } ) });
+/*-->*/
+
+call_DataFrame(function() { DataFrame.renderTable(1) });
+
+</script>
+</html>

--- a/docs/StardustDocs/topics/convert.md
+++ b/docs/StardustDocs/topics/convert.md
@@ -81,8 +81,8 @@ dataFrameOf("direction")("NORTH", "WEST")
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertToEnum.html"/>
 <!---END-->
 
-And finally, [Value classes](https://kotlinlang.org/docs/inline-classes.html) can be created
-and unpacked using `convert`:
+And finally, [Value classes](https://kotlinlang.org/docs/inline-classes.html) can be used with `convert` too.
+Both as conversion source and target:
 
 ```kotlin
 @JvmInline 
@@ -92,7 +92,7 @@ value class IntClass(val value: Int)
 <!---FUN convertToValueClass-->
 
 ```kotlin
-dataFrameOf("value")("1", "2")
+dataFrameOf("value")("1", "2") // note that values are strings; conversion is done automatically
     .convert("value").to<IntClass>()
 ```
 

--- a/docs/StardustDocs/topics/convert.md
+++ b/docs/StardustDocs/topics/convert.md
@@ -64,7 +64,8 @@ df.convert { weight }.toFloat()
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertTo.html"/>
 <!---END-->
 
-Automatic conversion from `String` to enum classes is also supported:
+Automatic conversion from `String` to [enum classes](https://kotlinlang.org/docs/enum-classes.html#enum-classes.md)
+is also supported:
 
 ```kotlin
 enum class Direction { NORTH, SOUTH, WEST, EAST }
@@ -78,4 +79,22 @@ dataFrameOf("direction")("NORTH", "WEST")
 ```
 
 <dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertToEnum.html"/>
+<!---END-->
+
+And finally, [Value classes](https://kotlinlang.org/docs/inline-classes.html) can be created
+and unpacked using `convert`:
+
+```kotlin
+@JvmInline 
+value class IntClass(val value: Int)
+```
+
+<!---FUN convertToValueClass-->
+
+```kotlin
+dataFrameOf("value")("1", "2")
+    .convert("value").to<IntClass>()
+```
+
+<dataFrame src="org.jetbrains.kotlinx.dataframe.samples.api.Modify.convertToValueClass.html"/>
 <!---END-->

--- a/docs/StardustDocs/topics/convert.md
+++ b/docs/StardustDocs/topics/convert.md
@@ -37,17 +37,20 @@ df.convert { name }.asFrame { it.add("fullName") { "$firstName $lastName" } }
 <!---END-->
 
 `convert` supports automatic type conversions between the following types:
-* `Int`
-* `String`
-* `Double`
-* `Long`
+* `String` (uses [`parse`](parse.md) to convert from `String` to other types)
+* `Boolean`
+* `Byte`
 * `Short`
+* `Int` (and `Char`)
+* `Long`
 * `Float`
+* `Double`
 * `BigDecimal`
-* `LocalDateTime`
-* `LocalDate`
-* `LocalTime`
-* `Duration`
+* `BigInteger`
+* `LocalDateTime` (kotlinx.datetime and java.time)
+* `LocalDate` (kotlinx.datetime and java.time)
+* `LocalTime` (kotlinx.datetime and java.time)
+* `Instant` (kotlinx.datetime and java.time)
 
 <!---FUN convertTo-->
 


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/894 and updates some of the convert docs.

Added missing conversions:
- from Number
  - to BigInteger
  - to BigDecimal
- from Boolean
  - to BigInteger
- from Char
  - to Int (by code)
- from Int
  - to Char (by code)
  - to BigInteger
- from Byte
  - to Double, Float, Int, Short, Long, BigDecimal, BigInteger, Boolean, LocalDateTime, LocalTime, Instant (and java overloads), similar to Int
- from Short
  - to all of those as well
- from Double
  - to Byte
  - to BigInteger
- from Long
  - to BigInteger
  - to LocalTime (kotlinx was missing)
- from Float
  - to Byte
  - to BigInteger
- from BigDecimal
  - to Byte
  - to Short
  - to BigInteger
- from BigInteger
  - to Double, Int, Byte, Short, Float, Long, BigDecimal, Boolean
- from LocalTime (kotlinx)
  - to LocalTime (java) (fixes issue)
- from LocalTime (java)
  - to LocalTime (kotlinx) (fixes issue)

Added extra conversion tests