### PR TITLE
Full `BigInteger` support

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3813,6 +3813,8 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConvertKt {
 	public static synthetic fun convertTo$default (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/reflect/KType;Lorg/jetbrains/kotlinx/dataframe/api/ParserOptions;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun convertToBigDecimal (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun convertToBigDecimalFromT (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun convertToBigInteger (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun convertToBigIntegerFromT (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun convertToBoolean (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun convertToBooleanFromT (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun convertToByte (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -3891,6 +3893,8 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConvertKt {
 	public static final fun to (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlin/reflect/KType;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toBigDecimal (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toBigDecimalTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toBigInteger (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toBigIntegerTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toBoolean (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toBooleanTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toDataFrames (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Z)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -4078,10 +4082,12 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnArithmeticsKt {
 	public static final fun div (ILorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun div (JLorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Ljava/math/BigDecimal;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun div (Ljava/math/BigInteger;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/DataColumn;J)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigDecimal;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigInteger;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun div (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun divDouble (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun divInt (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -4101,10 +4107,12 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnArithmeticsKt {
 	public static final fun minus (ILorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun minus (JLorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Ljava/math/BigDecimal;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun minus (Ljava/math/BigInteger;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;J)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigDecimal;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigInteger;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minus (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun minusDouble (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun minusInt (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -4120,11 +4128,13 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnArithmeticsKt {
 	public static final fun plus (ILorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun plus (JLorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Ljava/math/BigDecimal;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun plus (Ljava/math/BigInteger;Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;J)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigDecimal;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigInteger;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun plus (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun plusDouble (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -4135,6 +4145,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnArithmeticsKt {
 	public static final fun times (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun times (Lorg/jetbrains/kotlinx/dataframe/DataColumn;J)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun times (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigDecimal;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun times (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Ljava/math/BigInteger;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun times (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun timesDouble (Lorg/jetbrains/kotlinx/dataframe/DataColumn;I)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun timesInt (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -4142,6 +4153,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnArithmeticsKt {
 	public static final fun unaryMinus (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun unaryMinus (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun unaryMinusBigDecimal (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun unaryMinusBigInteger (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun unaryMinusDouble (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun unaryMinusIntNullable (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun unaryMinusLong (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
@@ -10287,6 +10299,7 @@ public final class org/jetbrains/kotlinx/dataframe/io/CSVType : java/lang/Enum {
 
 public final class org/jetbrains/kotlinx/dataframe/io/ColType : java/lang/Enum {
 	public static final field BigDecimal Lorg/jetbrains/kotlinx/dataframe/io/ColType;
+	public static final field BigInteger Lorg/jetbrains/kotlinx/dataframe/io/ColType;
 	public static final field Boolean Lorg/jetbrains/kotlinx/dataframe/io/ColType;
 	public static final field Char Lorg/jetbrains/kotlinx/dataframe/io/ColType;
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/io/ColType$Companion;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnArithmetics.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import java.math.BigDecimal
+import java.math.BigInteger
 
 public operator fun DataColumn<Boolean>.not(): DataColumn<Boolean> = map { !it }
 
@@ -168,6 +169,23 @@ public operator fun DataColumn<BigDecimal>.times(value: BigDecimal): DataColumn<
 public operator fun DataColumn<BigDecimal>.div(value: BigDecimal): DataColumn<BigDecimal> = map { it / value }
 
 public operator fun BigDecimal.div(column: DataColumn<BigDecimal>): DataColumn<BigDecimal> = column.map { this / it }
+
+public operator fun DataColumn<BigInteger>.plus(value: BigInteger): DataColumn<BigInteger> = map { it + value }
+
+public operator fun DataColumn<BigInteger>.minus(value: BigInteger): DataColumn<BigInteger> = map { it - value }
+
+public operator fun BigInteger.plus(column: DataColumn<BigInteger>): DataColumn<BigInteger> = column.map { this + it }
+
+public operator fun BigInteger.minus(column: DataColumn<BigInteger>): DataColumn<BigInteger> = column.map { this - it }
+
+@JvmName("unaryMinusBigInteger")
+public operator fun DataColumn<BigInteger>.unaryMinus(): DataColumn<BigInteger> = map { -it }
+
+public operator fun DataColumn<BigInteger>.times(value: BigInteger): DataColumn<BigInteger> = map { it * value }
+
+public operator fun DataColumn<BigInteger>.div(value: BigInteger): DataColumn<BigInteger> = map { it / value }
+
+public operator fun BigInteger.div(column: DataColumn<BigInteger>): DataColumn<BigInteger> = column.map { this / it }
 
 public infix fun <T> DataColumn<T>.eq(value: T): DataColumn<Boolean> = isMatching { it == value }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -37,6 +37,7 @@ import org.jetbrains.kotlinx.dataframe.impl.api.withRowCellImpl
 import org.jetbrains.kotlinx.dataframe.impl.headPlusArray
 import org.jetbrains.kotlinx.dataframe.io.toDataFrame
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.net.URL
 import java.util.Locale
 import kotlin.reflect.KProperty
@@ -261,6 +262,11 @@ public fun <T : Any> DataColumn<T?>.convertToFloat(): DataColumn<Float?> = conve
 public fun <T : Any> DataColumn<T>.convertToBigDecimal(): DataColumn<BigDecimal> = convertTo()
 
 public fun <T : Any> DataColumn<T?>.convertToBigDecimal(): DataColumn<BigDecimal?> = convertTo()
+
+@JvmName("convertToBigIntegerFromT")
+public fun <T : Any> DataColumn<T>.convertToBigInteger(): DataColumn<BigInteger> = convertTo()
+
+public fun <T : Any> DataColumn<T?>.convertToBigInteger(): DataColumn<BigInteger?> = convertTo()
 
 @JvmName("convertToBooleanFromT")
 public fun <T : Any> DataColumn<T>.convertToBoolean(): DataColumn<Boolean> = convertTo()
@@ -495,6 +501,11 @@ public fun <T> Convert<T, Any?>.toFloat(): DataFrame<T> = to<Float?>()
 public fun <T> Convert<T, Any>.toBigDecimal(): DataFrame<T> = to<BigDecimal>()
 
 public fun <T> Convert<T, Any?>.toBigDecimal(): DataFrame<T> = to<BigDecimal?>()
+
+@JvmName("toBigIntegerTAny")
+public fun <T> Convert<T, Any>.toBigInteger(): DataFrame<T> = to<BigInteger>()
+
+public fun <T> Convert<T, Any?>.toBigInteger(): DataFrame<T> = to<BigInteger?>()
 
 @JvmName("toBooleanTAny")
 public fun <T> Convert<T, Any>.toBoolean(): DataFrame<T> = to<Boolean>()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -31,7 +31,6 @@ import kotlin.reflect.full.superclasses
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
-import kotlin.toBigDecimal as toBigDecimalKotlin
 
 internal inline fun <reified T> KClass<*>.createTypeUsing() = typeOf<T>().projectTo(this)
 
@@ -649,16 +648,3 @@ internal fun Any.asArrayAsListOrNull(): List<*>? =
     }
 
 internal fun Any.isBigNumber(): Boolean = this is BigInteger || this is BigDecimal
-
-internal fun Number.toBigDecimal(): BigDecimal =
-    when (this) {
-        is BigDecimal -> this
-        is BigInteger -> this.toBigDecimalKotlin()
-        is Int -> this.toBigDecimalKotlin()
-        is Byte -> this.toInt().toBigDecimalKotlin()
-        is Short -> this.toInt().toBigDecimalKotlin()
-        is Long -> this.toBigDecimalKotlin()
-        is Float -> this.toBigDecimalKotlin()
-        is Double -> this.toBigDecimalKotlin()
-        else -> BigDecimal(this.toString())
-    }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/Utils.kt
@@ -64,6 +64,7 @@ internal fun <T> List<T>.removeAt(index: Int) = subList(0, index) + subList(inde
 
 internal inline fun <reified T : Any> Int.cast() = convert(this, T::class)
 
+// TODO remove in favor of column convert logic, Issue #971
 internal fun <T : Any> convert(src: Int, tartypeOf: KClass<T>): T =
     when (tartypeOf) {
         Double::class -> src.toDouble() as T

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -55,10 +55,13 @@ import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import kotlin.text.trim
+import kotlin.toBigDecimal
 import java.time.Instant as JavaInstant
 import java.time.LocalDate as JavaLocalDate
 import java.time.LocalDateTime as JavaLocalDateTime
 import java.time.LocalTime as JavaLocalTime
+import kotlin.toBigDecimal as toBigDecimalKotlin
+import kotlin.toBigInteger as toBigIntegerKotlin
 
 @PublishedApi
 internal fun <T, C, R> Convert<T, C>.withRowCellImpl(
@@ -716,17 +719,25 @@ internal val defaultTimeZone = TimeZone.currentSystemDefault()
 internal fun Number.toBigDecimal(): BigDecimal =
     when (this) {
         is BigDecimal -> this
-        is BigInteger -> BigDecimal(this)
-        is Double -> BigDecimal.valueOf(this)
-        is Int -> BigDecimal(this)
-        is Long -> BigDecimal.valueOf(this)
-        else -> BigDecimal.valueOf(this.toDouble())
+        is BigInteger -> this.toBigDecimalKotlin()
+        is Int -> this.toBigDecimalKotlin()
+        is Byte -> this.toInt().toBigDecimalKotlin()
+        is Short -> this.toInt().toBigDecimalKotlin()
+        is Long -> this.toBigDecimalKotlin()
+        is Float -> this.toBigDecimalKotlin()
+        is Double -> this.toBigDecimalKotlin()
+        else -> BigDecimal(this.toString())
     }
 
 internal fun Number.toBigInteger(): BigInteger =
     when (this) {
         is BigInteger -> this
         is BigDecimal -> this.toBigInteger()
-        is Long -> BigInteger.valueOf(this)
-        else -> BigInteger.valueOf(this.toLong())
+        is Int -> this.toBigIntegerKotlin()
+        is Byte -> this.toInt().toBigIntegerKotlin()
+        is Short -> this.toInt().toBigIntegerKotlin()
+        is Long -> this.toBigIntegerKotlin()
+        is Float -> this.roundToInt().toBigIntegerKotlin()
+        is Double -> this.roundToLong().toBigIntegerKotlin()
+        else -> BigInteger(this.toString())
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/describe.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/describe.kt
@@ -30,7 +30,6 @@ import org.jetbrains.kotlinx.dataframe.impl.columns.addPath
 import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.isBigNumber
 import org.jetbrains.kotlinx.dataframe.impl.renderType
-import org.jetbrains.kotlinx.dataframe.impl.toBigDecimal
 import org.jetbrains.kotlinx.dataframe.index
 import org.jetbrains.kotlinx.dataframe.kind
 import org.jetbrains.kotlinx.dataframe.type

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlinx.dataframe.io.isUrl
 import org.jetbrains.kotlinx.dataframe.io.readJsonStr
 import org.jetbrains.kotlinx.dataframe.values
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.net.URL
 import java.text.ParsePosition
 import java.time.format.DateTimeFormatter
@@ -390,6 +391,8 @@ internal object Parsers : GlobalParserOptions {
         posixParserToDoubleWithOptions,
         // Boolean
         stringParser<Boolean> { it.toBooleanOrNull() },
+        // BigInteger
+        stringParser<BigInteger> { it.toBigIntegerOrNull() },
         // BigDecimal
         stringParser<BigDecimal> { it.toBigDecimalOrNull() },
         // JSON array as DataFrame<*>

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/csv.kt
@@ -38,6 +38,7 @@ import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.net.URL
 import java.nio.charset.Charset
 import java.util.zip.GZIPInputStream
@@ -298,6 +299,7 @@ public enum class ColType {
     Double,
     Boolean,
     BigDecimal,
+    BigInteger,
     LocalDate,
     LocalTime,
     LocalDateTime,
@@ -329,6 +331,7 @@ public fun ColType.toKType(): KType =
         ColType.Double -> typeOf<Double>()
         ColType.Boolean -> typeOf<Boolean>()
         ColType.BigDecimal -> typeOf<BigDecimal>()
+        ColType.BigInteger -> typeOf<BigInteger>()
         ColType.LocalDate -> typeOf<LocalDate>()
         ColType.LocalTime -> typeOf<LocalTime>()
         ColType.LocalDateTime -> typeOf<LocalDateTime>()

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readDelim.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readDelim.kt
@@ -58,6 +58,7 @@ import org.jetbrains.kotlinx.dataframe.io.toKType
 import org.jetbrains.kotlinx.dataframe.io.useDecompressed
 import java.io.InputStream
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.net.URL
 import java.util.Locale
 import kotlin.reflect.KType
@@ -351,6 +352,7 @@ internal fun KType.toColType(): ColType =
         typeOf<Double>() -> ColType.Double
         typeOf<Boolean>() -> ColType.Boolean
         typeOf<BigDecimal>() -> ColType.BigDecimal
+        typeOf<BigInteger>() -> ColType.BigInteger
         typeOf<LocalDate>() -> ColType.LocalDate
         typeOf<LocalTime>() -> ColType.LocalTime
         typeOf<LocalDateTime>() -> ColType.LocalDateTime


### PR DESCRIPTION
Added BigInteger support to the remaining places in the API where BigDecimal was supported already.

This small PR allows us to claim "full BigInteger support" for the 0.15 release. I already added support for it in a lot of places in previous PRs, this one finished the job,