### PR TITLE
Gradle bump to 8.11 with Gradle plugin backwards compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ kotlin-compile-testing = "1.6.0"
 duckdb = "1.1.3"
 buildconfig = "5.5.1"
 benchmark = "0.4.12"
+gradle-plugin-toolbox = "1.9.0"
 
 geotools = "32.1"
 jai-core = "1.1.3"
@@ -173,3 +174,4 @@ plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publi
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "benchmark" }
+plugin-toolbox = { id = "dev.gradleplugins.java-gradle-plugin", version.ref = "gradle-plugin-toolbox" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/dataframe-gradle-plugin/build.gradle.kts
+++ b/plugins/dataframe-gradle-plugin/build.gradle.kts
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    `kotlin-dsl`
-    `java-gradle-plugin`
+    kotlin("jvm")
     `maven-publish`
-    alias(libs.plugins.plugin.publish)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.plugin.toolbox)
+//    alias(libs.plugins.plugin.toolbox.functional.test) TODO
 }
 
 repositories {
@@ -14,6 +14,7 @@ repositories {
     google()
 }
 
+val minGradleVersion = "7.0"
 group = "org.jetbrains.kotlinx.dataframe"
 
 dependencies {
@@ -24,7 +25,7 @@ dependencies {
     implementation(project(":dataframe-excel"))
     implementation(project(":dataframe-jdbc"))
 
-    implementation(libs.kotlin.gradle.plugin.api)
+    implementation(gradleKotlinDsl())
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.serialization.core)
     implementation(libs.serialization.json)
@@ -67,6 +68,10 @@ gradlePlugin {
     // These settings are set for the whole plugin bundle
     website = "https://github.com/Kotlin/dataframe"
     vcsUrl = "https://github.com/Kotlin/dataframe"
+
+    compatibility {
+        minimumGradleVersion = minGradleVersion
+    }
 
     plugins {
         create("schemaGeneratorPlugin") {

--- a/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
+++ b/plugins/dataframe-gradle-plugin/src/main/kotlin/org/jetbrains/dataframe/gradle/SchemaGeneratorPlugin.kt
@@ -40,13 +40,13 @@ class SchemaGeneratorPlugin : Plugin<Project> {
                 createTask(target, extension, appliedPlugin, it)
             }
             val generateAll = target.tasks.create("generateDataFrames") {
-                group = GROUP
-                dependsOn(*generationTasks.toTypedArray())
+                it.group = GROUP
+                it.dependsOn(*generationTasks.toTypedArray())
             }
-            tasks.withType(KspTaskJvm::class.java).configureEach {
-                dependsOn(generateAll)
+            it.tasks.withType(KspTaskJvm::class.java).configureEach {
+                it.dependsOn(generateAll)
             }
-            tasks.withType<KotlinCompile> {
+            it.tasks.withType<KotlinCompile> {
                 dependsOn(generateAll)
             }
         }
@@ -84,8 +84,8 @@ class SchemaGeneratorPlugin : Plugin<Project> {
                 // Configure the right ksp task to be aware of these new sources
                 val kspTaskName = "ksp${sourceSetName.replaceFirstChar { it.uppercase() }}Kotlin"
                 target.tasks.withType(KspTaskJvm::class.java).configureEach {
-                    if (sourceSetName == "main" && name == "kspKotlin" || name == kspTaskName) {
-                        source(src)
+                    if (sourceSetName == "main" && it.name == "kspKotlin" || it.name == kspTaskName) {
+                        it.source(src)
                     }
                 }
 
@@ -125,18 +125,18 @@ class SchemaGeneratorPlugin : Plugin<Project> {
         val delimiters = schema.withNormalizationBy ?: extension.withNormalizationBy ?: setOf('\t', ' ', '_')
 
         return target.tasks.create("generateDataFrame$interfaceName", GenerateDataSchemaTask::class.java) {
-            (logging as? DefaultLoggingManager)?.setLevelInternal(LogLevel.QUIET)
-            group = GROUP
-            data.set(schema.data)
-            this.interfaceName.set(interfaceName)
-            this.packageName.set(packageName)
-            this.src.set(src)
-            this.schemaVisibility.set(visibility)
-            this.csvOptions.set(schema.csvOptions)
-            this.jsonOptions.set(schema.jsonOptions)
-            this.jdbcOptions.set(schema.jdbcOptions)
-            this.defaultPath.set(defaultPath)
-            this.delimiters.set(delimiters)
+            (it.logging as? DefaultLoggingManager)?.setLevelInternal(LogLevel.QUIET)
+            it.group = GROUP
+            it.data.set(schema.data)
+            it.interfaceName.set(interfaceName)
+            it.packageName.set(packageName)
+            it.src.set(src)
+            it.schemaVisibility.set(visibility)
+            it.csvOptions.set(schema.csvOptions)
+            it.jsonOptions.set(schema.jsonOptions)
+            it.jdbcOptions.set(schema.jdbcOptions)
+            it.defaultPath.set(defaultPath)
+            it.delimiters.set(delimiters)
         }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
+        maven(url = "https://repo.nokee.dev/release")
     }
 }
 plugins {


### PR DESCRIPTION
Required for https://github.com/Kotlin/dataframe/issues/995

Uses https://github.com/gradle-plugins/toolbox?tab=readme-ov-file in our gradle plugin to define a minimum gradle version.

The tests and integration tests of the plugin need to be rewritten using https://docs.nokee.dev/samples/gradle-plugin-development-with-test-suites/. This can also test multiple gradle versions to check for intercompatibility.