### PR TITLE
#890 - Cannot call .map {} on ColumnGroup

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
@@ -65,7 +65,7 @@ public fun <T, R> DataColumn<T>.mapIndexed(
 
 // region DataFrame
 
-public fun <T, R> DataFrame<T>.map(transform: RowExpression<T, R>): List<R> = rows().map { transform(it, it) }
+public fun <T, R> DataFrame<T>.map(transform: RowExpression<T, R>, rows: Iterable<DataRow<T>> = rows()): List<R> = rows.map { transform(it, it) }
 
 public inline fun <T, reified R> ColumnsContainer<T>.mapToColumn(
     name: String,


### PR DESCRIPTION
Fix issue https://github.com/Kotlin/dataframe/issues/890

If you want to use `DataFrame<T>.map()`, you can usually just call it with the default arguments. If you have something else you want to `transform`, I don't mind returning the result of passing it to you.

# before 

![image](https://github.com/user-attachments/assets/5ddcf123-4659-4f04-a83c-edbe2953c4b5)

# after

![image](https://github.com/user-attachments/assets/7eda7879-b84e-4830-8543-6093c8532c16)