### PR TITLE
Renaming all KoDEx documentation arguments to SCREAMING_SNAKE_CASE

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -8818,7 +8818,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/Update {
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/Update$Columns {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/api/Update$Columns$SelectingColumnsArg {
+public abstract interface class org/jetbrains/kotlinx/dataframe/api/Update$Columns$SELECTING_COLUMNS {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/Update$Grammar {
@@ -9739,6 +9739,18 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate {
 }
 
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$COLUMN_GROUP_FUNCTIONS {
+}
+
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$COLUMN_GROUP_PART {
+}
+
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$COLUMN_SET_FUNCTIONS {
+}
+
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$COLUMN_SET_PART {
+}
+
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnDef {
 }
 
@@ -9751,16 +9763,10 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupDef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupFunctionsArg {
-}
-
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupNoSingleColumnDef {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupNoSingleColumnRef {
-}
-
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupPart {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnGroupRef {
@@ -9796,12 +9802,6 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnSetDef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnSetFunctionsArg {
-}
-
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnSetPart {
-}
-
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnSetRef {
 }
 
@@ -9829,10 +9829,10 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ConditionRef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$DefinitionsArg {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$DEFINITIONS {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$DefinitionsPart {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$DEFINITIONS_PART {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$IgnoreCaseDef {
@@ -9877,10 +9877,10 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$NumberRef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$PlainDslFunctionsArg {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$PLAIN_DSL_FUNCTIONS {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$PlainDslPart {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$PLAIN_DSL_PART {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$RegexDef {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
@@ -3,10 +3,6 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl.DslGrammar.ColumnGroupPartOfGrammar
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl.DslGrammar.ColumnSetPartOfGrammar
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl.DslGrammar.DefinitionsPartOfGrammar
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl.DslGrammar.PlainDslPartOfGrammar
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
@@ -39,7 +35,7 @@ public annotation class ColumnsSelectionDslMarker
 /**
  * ## Columns Selection DSL
  * {@include [SelectingColumns.Dsl.WithExample]}
- * {@set [SelectingColumns.OperationArg] [select][DataFrame.select]}
+ * {@set [SelectingColumns.OPERATION] [select][DataFrame.select]}
  *
  * @comment This interface be safely cast to [SingleColumn] across the library because it's always
  * implemented in combination with [DataFrameReceiver] which is a [SingleColumn] itself.
@@ -114,10 +110,10 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
      *
      * @include [DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate]
      *
-     * @set [DslGrammarTemplate.DefinitionsArg] {@include [DefinitionsPartOfGrammar]}
-     * @set [DslGrammarTemplate.PlainDslFunctionsArg] {@include [PlainDslPartOfGrammar]}
-     * @set [DslGrammarTemplate.ColumnSetFunctionsArg] {@include [ColumnSetPartOfGrammar]}
-     * @set [DslGrammarTemplate.ColumnGroupFunctionsArg] {@include [ColumnGroupPartOfGrammar]}
+     * @set [DslGrammarTemplate.DEFINITIONS] {@include [DefinitionsPartOfGrammar]}
+     * @set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS] {@include [PlainDslPartOfGrammar]}
+     * @set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS] {@include [ColumnSetPartOfGrammar]}
+     * @set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS] {@include [ColumnGroupPartOfGrammar]}
      */
     public interface DslGrammar {
 
@@ -385,7 +381,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
 
     /**
      * @include [SelectColumnsSelectionDsl.CommonSelectDocs]
-     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.ExampleArg]
+     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColGroup.`[`select`][SingleColumn.select]`  { someCol  `[`and`][ColumnsSelectionDsl.and]` `[`colsOf`][SingleColumn.colsOf]`<`[`String`][String]`>() } }`
      *
@@ -396,7 +392,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
 
     /**
      * @include [SelectColumnsSelectionDsl.CommonSelectDocs]
-     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.ExampleArg]
+     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColGroup.`[`select`][KProperty.select]`  { someCol  `[`and`][ColumnsSelectionDsl.and]` `[`colsOf`][SingleColumn.colsOf]`<`[`String`][String]`>() } }`
      *
@@ -407,7 +403,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
 
     /**
      * @include [SelectColumnsSelectionDsl.CommonSelectDocs]
-     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.ExampleArg]
+     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[`select`][String.select]`  { someCol  `[`and`][ColumnsSelectionDsl.and]` `[`colsOf`][SingleColumn.colsOf]`<`[`String`][String]`>() } }`
      *
@@ -417,7 +413,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
 
     /**
      * @include [SelectColumnsSelectionDsl.CommonSelectDocs]
-     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.ExampleArg]
+     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColGroup"].`[`select`][ColumnPath.select]`  { someCol  `[`and`][ColumnsSelectionDsl.and]` `[`colsOf`][SingleColumn.colsOf]`<`[`String`][String]`>() } }`
      *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -10,10 +10,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.api.DropNA.DropNASelectingOptions
-import org.jetbrains.kotlinx.dataframe.api.DropNaNs.DropNaNsSelectingOptions
-import org.jetbrains.kotlinx.dataframe.api.DropNulls.DropNullsSelectingOptions
-import org.jetbrains.kotlinx.dataframe.api.Update.UpdateOperationArg
+import org.jetbrains.kotlinx.dataframe.api.Update.UPDATE_OPERATION
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -41,7 +38,7 @@ import kotlin.reflect.KProperty
  */
 internal interface FillNulls {
 
-    /** @include [Update.Grammar] {@set [UpdateOperationArg] [**fillNulls**][fillNulls]} */
+    /** @include [Update.Grammar] {@set [UPDATE_OPERATION] [**fillNulls**][fillNulls]} */
     interface Grammar
 
     /**
@@ -51,14 +48,14 @@ internal interface FillNulls {
     interface FillNullsSelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [fillNulls][fillNulls]} */
+/** {@set [SelectingColumns.OPERATION] [fillNulls][fillNulls]} */
 private interface SetFillNullsOperationArg
 
 /**
  * @include [FillNulls] {@comment Description of the fillNulls operation.}
  * @include [LineBreak]
  * @include [Update.Columns] {@comment Description of what this function expects the user to do: select columns}
- * {@set [Update.Columns.SelectingColumnsArg] [Selecting Columns][FillNulls.FillNullsSelectingOptions]}
+ * {@set [Update.Columns.SELECTING_COLUMNS] [Selecting Columns][FillNulls.FillNullsSelectingOptions]}
  * ### This Fill Nulls Overload
  *
  */
@@ -135,7 +132,7 @@ internal inline val Float?.isNA: Boolean get() = this == null || this.isNaN()
  */
 internal interface FillNaNs {
 
-    /** @include [Update.Grammar] {@set [Update.UpdateOperationArg] [fillNaNs][fillNaNs]} */
+    /** @include [Update.Grammar] {@set [Update.UPDATE_OPERATION] [fillNaNs][fillNaNs]} */
     interface Grammar
 
     /**
@@ -145,7 +142,7 @@ internal interface FillNaNs {
     interface FillNaNsSelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [fillNaNs][fillNaNs]} */
+/** {@set [SelectingColumns.OPERATION] [fillNaNs][fillNaNs]} */
 @ExcludeFromSources
 internal interface SetFillNaNsOperationArg
 
@@ -153,7 +150,7 @@ internal interface SetFillNaNsOperationArg
  * @include [FillNaNs] {@comment Description of the fillNaNs operation.}
  * @include [LineBreak]
  * @include [Update.Columns] {@comment Description of what this function expects the user to do: select columns}
- * {@set [Update.Columns.SelectingColumnsArg] [Selecting Columns][FillNaNs.FillNaNsSelectingOptions]}
+ * {@set [Update.Columns.SELECTING_COLUMNS] [Selecting Columns][FillNaNs.FillNaNsSelectingOptions]}
  * ### This Fill NaNs Overload
  */
 @ExcludeFromSources
@@ -207,7 +204,7 @@ public fun <T, C> DataFrame<T>.fillNaNs(vararg columns: ColumnReference<C>): Upd
  */
 internal interface FillNA {
 
-    /** @include [Update.Grammar] {@set [Update.UpdateOperationArg] [fillNA][fillNA]} */
+    /** @include [Update.Grammar] {@set [Update.UPDATE_OPERATION] [fillNA][fillNA]} */
     interface Grammar
 
     /**
@@ -217,7 +214,7 @@ internal interface FillNA {
     interface FillNASelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [fillNA][fillNA]} */
+/** {@set [SelectingColumns.OPERATION] [fillNA][fillNA]} */
 @ExcludeFromSources
 internal interface SetFillNAOperationArg
 
@@ -225,7 +222,7 @@ internal interface SetFillNAOperationArg
  * @include [FillNA] {@comment Description of the fillNA operation.}
  * @include [LineBreak]
  * @include [Update.Columns] {@comment Description of what this function expects the user to do: select columns}
- * {@set [Update.Columns.SelectingColumnsArg] [Selecting Columns][FillNA.FillNASelectingOptions]}
+ * {@set [Update.Columns.SELECTING_COLUMNS] [Selecting Columns][FillNA.FillNASelectingOptions]}
  * ### This Fill NA Overload
  */
 @ExcludeFromSources
@@ -312,7 +309,7 @@ internal interface DropNulls {
     interface DropNullsSelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [dropNulls][dropNulls]} */
+/** {@set [SelectingColumns.OPERATION] [dropNulls][dropNulls]} */
 @ExcludeFromSources
 private interface SetDropNullsOperationArg
 
@@ -420,7 +417,7 @@ internal interface DropNA {
     interface DropNASelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [dropNA][dropNA]} */
+/** {@set [SelectingColumns.OPERATION] [dropNA][dropNA]} */
 @ExcludeFromSources
 private interface SetDropNAOperationArg
 
@@ -529,7 +526,7 @@ internal interface DropNaNs {
     interface DropNaNsSelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [dropNaNs][dropNaNs]} */
+/** {@set [SelectingColumns.OPERATION] [dropNaNs][dropNaNs]} */
 @ExcludeFromSources
 private interface SetDropNaNsOperationArg
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
@@ -11,20 +11,6 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.RowFilter
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.BehaviorArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.ColumnDoesNotExistArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.ExampleArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.FunctionArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.FunctionColsArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.CommonAllSubsetDocs.TitleArg
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.After
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.Before
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.From
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.PlainDslName
-import org.jetbrains.kotlinx.dataframe.api.AllColumnsSelectionDsl.Grammar.UpTo
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -84,7 +70,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      * ## Grammar of All Flavors of All (Cols):
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -96,19 +82,19 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`()`**
      *
      *  `| `**`all`**`(`{@include [Before]}`|`{@include [After]}`|`{@include [From]}`|`{@include [UpTo]}`) ( `**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`)`**`  |  `**`{ `**{@include [DslGrammarTemplate.ColumnSelectorRef]}**` \}`**` )`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`()`**
      *
      *  {@include [Indent]}`| `**`.all`**`(`{@include [Before]}`|`{@include [After]}`|`{@include [From]}`|`{@include [UpTo]}`) ( `**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`)`**`  |  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` )`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`()`**
      *
      *  {@include [Indent]}`| `**`.allCols`**`(`{@include [Before]}`|`{@include [After]}`|`{@include [From]}`|`{@include [UpTo]}`) ( `**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`)`**`  |  `**`{ `**{@include [DslGrammarTemplate.ColumnSelectorRef]}**` \}`**` )`
@@ -160,15 +146,15 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
     private interface AllFlavors
 
     /**
-     * ## {@get [TitleArg]}
+     * ## {@get [TITLE]}
      *
      * Creates a new [ColumnSet] that contains a subset of columns from [this\],
-     * containing all columns {@get [BehaviorArg]}.
+     * containing all columns {@get [BEHAVIOR]}.
      *
      * [column\] can be specified both relative to the current [ColumnGroup] or the outer scope and
      * can be referenced using any {@include [AccessApiLink]}.
      *
-     * If [column\] does not exist, {@get [ColumnDoesNotExistArg]}.
+     * If [column\] does not exist, {@get [COLUMN_DOES_NOT_EXIST]}.
      * {@include [LineBreak]}
      * NOTE: Using the `{}` overloads of these functions requires a [ColumnSelector]
      * in the Plain DSL and on [column groups][ColumnGroup].
@@ -178,19 +164,19 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      *
      * #### For example:
      *
-     * `df.`[select][DataFrame.select]`  {  `[{@get [FunctionArg]}][ColumnsSelectionDsl.{@get [FunctionArg]}]`("someColumn") }`
+     * `df.`[select][DataFrame.select]`  {  `[{@get [FUNCTION]}][ColumnsSelectionDsl.{@get [FUNCTION]}]`("someColumn") }`
      *
-     * `df.`[select][DataFrame.select]`  {  `[colGroup][ColumnsSelectionDsl.colGroup]`(Type::myColGroup).`[{@get [FunctionColsArg]}][SingleColumn.{@get [FunctionColsArg]}]`(someColumn) }`
+     * `df.`[select][DataFrame.select]`  {  `[colGroup][ColumnsSelectionDsl.colGroup]`(Type::myColGroup).`[{@get [FUNCTION_COLS]}][SingleColumn.{@get [FUNCTION_COLS]}]`(someColumn) }`
      *
-     * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().`[{@get [FunctionArg]}][ColumnSet.{@get [FunctionArg]}]`(Type::someColumn) }`
+     * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().`[{@get [FUNCTION]}][ColumnSet.{@get [FUNCTION]}]`(Type::someColumn) }`
      *
      * #### Examples for this overload:
      *
-     * {@get [ExampleArg]}
+     * {@get [EXAMPLE]}
      *
      * {@include [AllFlavors]}
      *
-     * @return A new [ColumnSet] containing all columns {@get [BehaviorArg]}.
+     * @return A new [ColumnSet] containing all columns {@get [BEHAVIOR]}.
      * @see [allBefore\]
      * @see [allAfter\]
      * @see [allFrom\]
@@ -199,31 +185,32 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      * @see [all\]
      * @see [cols\]
      */
+    @Suppress("ClassName")
     @ExcludeFromSources
     private interface CommonAllSubsetDocs {
 
         // The title of the function, a.k.a. "All (Cols) After"
-        interface TitleArg
+        interface TITLE
 
         // The exact name of the function, a.k.a. "allAfter"
-        interface FunctionArg
+        interface FUNCTION
 
         // The exact name of the function, a.k.a. "allColsAfter"
-        interface FunctionColsArg
+        interface FUNCTION_COLS
 
         /*
          * Small line of text explaining the behavior of the function,
          * a.k.a. "after [column\], excluding [column\]"
          */
-        interface BehaviorArg
+        interface BEHAVIOR
 
         /*
          * Small line of text explaining what happens if `column` does not exist.
          */
-        interface ColumnDoesNotExistArg
+        interface COLUMN_DOES_NOT_EXIST
 
         // Example argument
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     // region all
@@ -327,11 +314,11 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonAllSubsetDocs]
-     * @set [CommonAllSubsetDocs.TitleArg] All (Cols) After
-     * @set [CommonAllSubsetDocs.FunctionArg] allAfter
-     * @set [CommonAllSubsetDocs.FunctionColsArg] allColsAfter
-     * @set [CommonAllSubsetDocs.BehaviorArg] after [column\], excluding [column\] itself
-     * @set [CommonAllSubsetDocs.ColumnDoesNotExistArg] the function will return an empty [ColumnSet][ColumnSet]
+     * @set [CommonAllSubsetDocs.TITLE] All (Cols) After
+     * @set [CommonAllSubsetDocs.FUNCTION] allAfter
+     * @set [CommonAllSubsetDocs.FUNCTION_COLS] allColsAfter
+     * @set [CommonAllSubsetDocs.BEHAVIOR] after [column\], excluding [column\] itself
+     * @set [CommonAllSubsetDocs.COLUMN_DOES_NOT_EXIST] the function will return an empty [ColumnSet][ColumnSet]
      * @param [column\] The specified column after which all columns should be taken. This column can be referenced
      *   to both relatively to the current [ColumnsResolver] and absolutely.
      */
@@ -339,7 +326,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[allAfter][ColumnSet.allAfter]`{@get [ColumnSetAllAfterDocs.Arg]} }`
      */
@@ -372,7 +359,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[allAfter][ColumnsSelectionDsl.allAfter]`{@get [ColumnsSelectionDslAllAfterDocs.Arg]} }`
      */
@@ -402,7 +389,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someColumnGroup.`[allColsAfter][SingleColumn.allColsAfter]`{@get [SingleColumnAllAfterDocs.Arg]} }`
      */
@@ -447,7 +434,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someColGroup".`[allColsAfter][String.allColsAfter]`{@get [StringAllAfterDocs.Arg]} }`
      */
@@ -475,7 +462,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColGroup.`[allColsAfter][KProperty.allColsAfter]`{@get [KPropertyAllAfterDocs.Arg]} }`
      */
@@ -507,7 +494,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllAfterDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someColGroup"].`[allColsAfter][ColumnPath.allColsAfter]`{@get [ColumnPathAllAfterDocs.Arg]} }`
      */
@@ -541,11 +528,11 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonAllSubsetDocs]
-     * @set [CommonAllSubsetDocs.TitleArg] All (Cols) From
-     * @set [CommonAllSubsetDocs.FunctionArg] allFrom
-     * @set [CommonAllSubsetDocs.FunctionColsArg] allColsFrom
-     * @set [CommonAllSubsetDocs.BehaviorArg] from [column\], including [column\] itself
-     * @set [CommonAllSubsetDocs.ColumnDoesNotExistArg] the function will return an empty [ColumnSet][ColumnSet]
+     * @set [CommonAllSubsetDocs.TITLE] All (Cols) From
+     * @set [CommonAllSubsetDocs.FUNCTION] allFrom
+     * @set [CommonAllSubsetDocs.FUNCTION_COLS] allColsFrom
+     * @set [CommonAllSubsetDocs.BEHAVIOR] from [column\], including [column\] itself
+     * @set [CommonAllSubsetDocs.COLUMN_DOES_NOT_EXIST] the function will return an empty [ColumnSet][ColumnSet]
      * @param [column\] The specified column from which all columns should be taken. This column can be referenced
      *   to both relatively to the current [ColumnsResolver] and absolutely.
      */
@@ -553,7 +540,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[allFrom][ColumnSet.allFrom]`{@get [ColumnSetAllFromDocs.Arg]} }`
      */
@@ -585,7 +572,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[allFrom][ColumnsSelectionDsl.allFrom]`{@get [ColumnsSelectionDslAllFromDocs.Arg]} }`
      */
@@ -615,7 +602,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someColumnGroup.`[allColsFrom][SingleColumn.allColsFrom]`{@get [SingleColumnAllFromDocs.Arg]} }`
      */
@@ -660,7 +647,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someColGroup".`[allColsFrom][String.allColsFrom]`{@get [StringAllFromDocs.Arg]} }`
      */
@@ -688,7 +675,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someColGroup.`[allColsFrom][KProperty.allColsFrom]`{@get [KPropertyAllFromDocs.Arg]} }`
      */
@@ -720,7 +707,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllFromDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someColGroup"].`[allFrom][ColumnPath.allColsFrom]`{@get [ColumnPathAllFromDocs.Arg]} }`
      */
@@ -753,11 +740,11 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonAllSubsetDocs]
-     * @set [CommonAllSubsetDocs.TitleArg] All (Cols) Before
-     * @set [CommonAllSubsetDocs.FunctionArg] allBefore
-     * @set [CommonAllSubsetDocs.FunctionColsArg] allColsBefore
-     * @set [CommonAllSubsetDocs.BehaviorArg] before [column\], excluding [column\] itself
-     * @set [CommonAllSubsetDocs.ColumnDoesNotExistArg] the function will return a [ColumnSet][ColumnSet] containing all columns
+     * @set [CommonAllSubsetDocs.TITLE] All (Cols) Before
+     * @set [CommonAllSubsetDocs.FUNCTION] allBefore
+     * @set [CommonAllSubsetDocs.FUNCTION_COLS] allColsBefore
+     * @set [CommonAllSubsetDocs.BEHAVIOR] before [column\], excluding [column\] itself
+     * @set [CommonAllSubsetDocs.COLUMN_DOES_NOT_EXIST] the function will return a [ColumnSet][ColumnSet] containing all columns
      * @param [column\] The specified column before which all columns should be taken. This column can be referenced
      *   to both relatively to the current [ColumnsResolver] and absolutely.
      */
@@ -765,7 +752,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[allBefore][ColumnSet.allBefore]`{@get [ColumnSetAllBeforeDocs.Arg]} }`
      */
@@ -798,7 +785,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[allBefore][ColumnsSelectionDsl.allBefore]`{@get [ColumnsSelectionDslAllBeforeDocs.Arg]} }`
      */
@@ -829,7 +816,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someColumnGroup.`[allColsBefore][SingleColumn.allColsBefore]`{@get [SingleColumnAllBeforeDocs.Arg]} }`
      */
@@ -871,7 +858,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someColGroup".`[allColsBefore][String.allColsBefore]`{@get [StringAllBeforeDocs.Arg]} }`
      */
@@ -900,7 +887,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someColGroup.`[allColsBefore][KProperty.allColsBefore]`{@get [KPropertyAllBeforeDocs.Arg]} }`
      */
@@ -932,7 +919,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllBeforeDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someColGroup"].`[allColsBefore][ColumnPath.allColsBefore]`{@get [ColumnPathAllBeforeDocs.Arg]} }`
      */
@@ -966,11 +953,11 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonAllSubsetDocs]
-     * @set [CommonAllSubsetDocs.TitleArg] All (Cols) Up To
-     * @set [CommonAllSubsetDocs.FunctionArg] allUpTo
-     * @set [CommonAllSubsetDocs.FunctionColsArg] allColsUpTo
-     * @set [CommonAllSubsetDocs.BehaviorArg] up to [column\], including [column\] itself
-     * @set [CommonAllSubsetDocs.ColumnDoesNotExistArg] the function will return a [ColumnSet][ColumnSet] containing all columns
+     * @set [CommonAllSubsetDocs.TITLE] All (Cols) Up To
+     * @set [CommonAllSubsetDocs.FUNCTION] allUpTo
+     * @set [CommonAllSubsetDocs.FUNCTION_COLS] allColsUpTo
+     * @set [CommonAllSubsetDocs.BEHAVIOR] up to [column\], including [column\] itself
+     * @set [CommonAllSubsetDocs.COLUMN_DOES_NOT_EXIST] the function will return a [ColumnSet][ColumnSet] containing all columns
      * @param [column\] The specified column up to which all columns should be taken. This column can be referenced
      *   to both relatively to the current [ColumnsResolver] and absolutely.
      */
@@ -978,7 +965,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[allUpTo][ColumnSet.allUpTo]`{@get [ColumnSetAllUpToDocs.Arg]} }`
      */
@@ -1010,7 +997,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[allUpTo][ColumnsSelectionDsl.allColsUpTo]`{@get [ColumnsSelectionDslAllUpToDocs.Arg]} }`
      */
@@ -1040,7 +1027,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someColumnGroup.`[allColsUpTo][SingleColumn.allColsUpTo]`{@get [SingleColumnAllUpToDocs.Arg]} }`
      */
@@ -1085,7 +1072,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someColGroup".`[allColsUpTo][String.allColsUpTo]`{@get [StringAllUpToDocs.Arg]} }`
      */
@@ -1113,7 +1100,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someColGroup.`[allColsUpTo][KProperty.allColsUpTo]`{@get [KPropertyAllUpToDocs.Arg]} }`
      */
@@ -1145,7 +1132,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [AllUpToDocs]
-     * @set [CommonAllSubsetDocs.ExampleArg]
+     * @set [CommonAllSubsetDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someColGroup"].`[allColsUpTo][ColumnPath.allColsUpTo]`{@get [ColumnPathAllUpToDocs.Arg]} }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
@@ -33,13 +33,14 @@ import kotlin.reflect.KProperty
  *
  * See [Grammar] for all functions in this interface.
  */
+@Suppress("ClassName")
 public interface AllExceptColumnsSelectionDsl {
 
     /**
      * ## (All) (Cols) Except Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -53,19 +54,19 @@ public interface AllExceptColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ColumnsResolverDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`   {   `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**` \}`**
      *
      *  `| `{@include [PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**` ..`**`)`**
      * }
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}` [`**`  {  `**`] `{@include [DslGrammarTemplate.ColumnsResolverRef]}` [`**`  \}  `**`]`
      *
      *  {@include [Indent]}`| `{@include [ColumnSetName]}` `{@include [DslGrammarTemplate.ColumnRef]}
      *
      *  {@include [Indent]}`| `**`.`**{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**` ..`**`)`**
      * }
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`  {  `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**`  \}  `**
      *
      *  {@include [Indent]}`| `{@include [ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnNoAccessorRef]}**`,`**` ..`**`)`**
@@ -155,9 +156,9 @@ public interface AllExceptColumnsSelectionDsl {
      * columns inside the group, 'lifting' them out.
      *
      * ### Examples for this overload
-     * {@get [ExampleArg]}
+     * {@get [EXAMPLE]}
      *
-     * {@get [ParamArg]}
+     * {@get [PARAM]}
      * @return A [ColumnSet] containing all columns in [this\] except the specified ones.
      * @see ColumnsSelectionDsl.select
      * @see ColumnsSelectionDsl.all
@@ -169,126 +170,126 @@ public interface AllExceptColumnsSelectionDsl {
     private interface CommonExceptDocs {
 
         // Example argument
-        interface ExampleArg
+        interface EXAMPLE
 
         // Parameter argument
-        interface ParamArg
+        interface PARAM
     }
 
     // region ColumnSet
 
     /**
      * @include [CommonExceptDocs]
-     * {@set [CommonExceptDocs.ExampleArg]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>() `[except][ColumnSet.except]` `{@get [ArgumentArg1]}` \}`
+     * {@set [CommonExceptDocs.EXAMPLE]
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>() `[except][ColumnSet.except]` `{@get [ARGUMENT_1]}` \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age) `[except][ColumnSet.except]` `{@get [ArgumentArg2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age) `[except][ColumnSet.except]` `{@get [ARGUMENT_2]}` \}`
      * }
      */
     private interface ColumnSetInfixDocs {
 
         // argument
-        interface ArgumentArg1
+        interface ARGUMENT_1
 
         // argument
-        interface ArgumentArg2
+        interface ARGUMENT_2
     }
 
     /**
      * @include [CommonExceptDocs]
-     * {@set [CommonExceptDocs.ExampleArg]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>().`[except][ColumnSet.except]{@get [ArgumentArg1]}` \}`
+     * {@set [CommonExceptDocs.EXAMPLE]
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>().`[except][ColumnSet.except]{@get [ARGUMENT_1]}` \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age).`[except][ColumnSet.except]{@get [ArgumentArg2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age).`[except][ColumnSet.except]{@get [ARGUMENT_2]}` \}`
      * }
      */
     private interface ColumnSetVarargDocs {
 
         // argument
-        interface ArgumentArg1
+        interface ARGUMENT_1
 
         // argument
-        interface ArgumentArg2
+        interface ARGUMENT_2
     }
 
     /**
      * @include [ColumnSetInfixDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [selector\] A lambda in which you specify the columns that need to be
+     * @set [CommonExceptDocs.PARAM] @param [selector\] A lambda in which you specify the columns that need to be
      *   excluded from the [ColumnSet]. The scope of the selector is the same as the outer scope.
-     * @set [ColumnSetInfixDocs.ArgumentArg1] `{ "age" `[and][ColumnsSelectionDsl.and]` height }`
-     * @set [ColumnSetInfixDocs.ArgumentArg2] `{ name.firstName }`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] `{ "age" `[and][ColumnsSelectionDsl.and]` height }`
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] `{ name.firstName }`
      */
     public infix fun <C> ColumnSet<C>.except(selector: () -> ColumnsResolver<*>): ColumnSet<C> = except(selector())
 
     /**
      * @include [ColumnSetInfixDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [other\] A [ColumnsResolver] containing the columns that need to be
+     * @set [CommonExceptDocs.PARAM] @param [other\] A [ColumnsResolver] containing the columns that need to be
      *   excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ArgumentArg1] `"age" `[and][ColumnsSelectionDsl.and]` height`
-     * @set [ColumnSetInfixDocs.ArgumentArg2] `name.firstName`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"age" `[and][ColumnsSelectionDsl.and]` height`
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] `name.firstName`
      */
     public infix fun <C> ColumnSet<C>.except(other: ColumnsResolver<*>): ColumnSet<C> = exceptInternal(other)
 
     /**
      * @include [ColumnSetVarargDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [ColumnsResolvers][ColumnsResolver] containing
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnsResolvers][ColumnsResolver] containing
      *  the columns that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ArgumentArg1] `(age, userData.height)`
-     * @set [ColumnSetVarargDocs.ArgumentArg2] `(name.firstName, name.middleName)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(age, userData.height)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] `(name.firstName, name.middleName)`
      */
     public fun <C> ColumnSet<C>.except(vararg others: ColumnsResolver<*>): ColumnSet<C> = except(others.toColumnSet())
 
     /**
      * @include [ColumnSetInfixDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [other\] A [String] referring to
+     * @set [CommonExceptDocs.PARAM] @param [other\] A [String] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ArgumentArg1] `"age"`
-     * @set [ColumnSetInfixDocs.ArgumentArg2] `"name"`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"age"`
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] `"name"`
      */
     public infix fun <C> ColumnSet<C>.except(other: String): ColumnSet<C> = except(column<Any?>(other))
 
     /**
      * @include [ColumnSetVarargDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [Strings][String] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [Strings][String] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ArgumentArg1] `("age", "height")`
-     * @set [ColumnSetVarargDocs.ArgumentArg2] `("name")`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] `("age", "height")`
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] `("name")`
      */
     public fun <C> ColumnSet<C>.except(vararg others: String): ColumnSet<C> = except(others.toColumnSet())
 
     /**
      * @include [ColumnSetInfixDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [other\] A [KProperty] referring to
+     * @set [CommonExceptDocs.PARAM] @param [other\] A [KProperty] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ArgumentArg1] `Person::age`
-     * @set [ColumnSetInfixDocs.ArgumentArg2] `Person::name`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] `Person::age`
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] `Person::name`
      */
     public infix fun <C> ColumnSet<C>.except(other: KProperty<C>): ColumnSet<C> = except(column(other))
 
     /**
      * @include [ColumnSetVarargDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [KProperties][KProperty] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [KProperties][KProperty] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ArgumentArg1] `(Person::age, Person::height)`
-     * @set [ColumnSetVarargDocs.ArgumentArg2] `(Person::name)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(Person::age, Person::height)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] `(Person::name)`
      */
     public fun <C> ColumnSet<C>.except(vararg others: KProperty<C>): ColumnSet<C> = except(others.toColumnSet())
 
     /**
      * @include [ColumnSetInfixDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [other\] A [ColumnPath] referring to
+     * @set [CommonExceptDocs.PARAM] @param [other\] A [ColumnPath] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ArgumentArg1] `"userdata"["age"]`
-     * @set [ColumnSetInfixDocs.ArgumentArg2] `pathOf("name", "firstName")`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"userdata"["age"]`
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] `pathOf("name", "firstName")`
      */
     public infix fun <C> ColumnSet<C>.except(other: ColumnPath): ColumnSet<C> = except(column<Any?>(other))
 
     /**
      * @include [ColumnSetVarargDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ArgumentArg1] `(pathOf("age"), "userdata"["height"])`
-     * @set [ColumnSetVarargDocs.ArgumentArg2] `("name"["firstName"], "name"["middleName"])`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(pathOf("age"), "userdata"["height"])`
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] `("name"["firstName"], "name"["middleName"])`
      */
     public fun <C> ColumnSet<C>.except(vararg others: ColumnPath): ColumnSet<C> = except(others.toColumnSet())
 
@@ -298,26 +299,26 @@ public interface AllExceptColumnsSelectionDsl {
 
     /**
      * @include [CommonExceptDocs]
-     * @set [CommonExceptDocs.ExampleArg]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ArgumentArg1]}` \}`
+     * @set [CommonExceptDocs.EXAMPLE]
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ARGUMENT_1]}` \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ArgumentArg2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ARGUMENT_2]}` \}`
      */
     private interface ColumnsSelectionDslDocs {
 
         // argument
-        interface ArgumentArg1
+        interface ARGUMENT_1
 
         // argument
-        interface ArgumentArg2
+        interface ARGUMENT_2
     }
 
     /**
      * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [selector\] A lambda in which you specify the columns that need to be
+     * @set [CommonExceptDocs.PARAM] @param [selector\] A lambda in which you specify the columns that need to be
      *  excluded from the current selection. The scope of the selector is the same as the outer scope.
-     * @set [ColumnsSelectionDslDocs.ArgumentArg1] `  { "age"  `[and][ColumnsSelectionDsl.and]` height }`
-     * @set [ColumnsSelectionDslDocs.ArgumentArg2] ` { name.firstName }`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `  { "age"  `[and][ColumnsSelectionDsl.and]` height }`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] ` { name.firstName }`
      */
     public fun <C> ColumnsSelectionDsl<C>.allExcept(selector: ColumnsSelector<C, *>): ColumnSet<*> =
         this.asSingleColumn().allColsExcept(selector)
@@ -325,40 +326,40 @@ public interface AllExceptColumnsSelectionDsl {
     /**
      * {@comment No scoping issues, this function can exist for legacy purposes}
      * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] A [ColumnsResolver] containing the columns that need to be
+     * @set [CommonExceptDocs.PARAM] @param [others\] A [ColumnsResolver] containing the columns that need to be
      *  excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ArgumentArg1] `(age, height)`
-     * @set [ColumnsSelectionDslDocs.ArgumentArg2] `(name.firstName, name.middleName)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(age, height)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `(name.firstName, name.middleName)`
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: ColumnsResolver<*>): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
 
     /**
      * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [Strings][String] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [Strings][String] referring to
      *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ArgumentArg1] `("age", "height")`
-     * @set [ColumnsSelectionDslDocs.ArgumentArg2] `("name")`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `("age", "height")`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `("name")`
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: String): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
 
     /**
      * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [KProperties][KProperty] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [KProperties][KProperty] referring to
      *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ArgumentArg1] `(Person::age, Person::height)`
-     * @set [ColumnsSelectionDslDocs.ArgumentArg2] `(Person::name)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(Person::age, Person::height)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `(Person::name)`
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: KProperty<*>): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
 
     /**
      * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
+     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
      *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ArgumentArg1] `(pathOf("age"), "userdata"["height"])`
-     * @set [ColumnsSelectionDslDocs.ArgumentArg2] `("name"["firstName"], "name"["middleName"])`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(pathOf("age"), "userdata"["height"])`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `("name"["firstName"], "name"["middleName"])`
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: ColumnPath): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
@@ -369,89 +370,90 @@ public interface AllExceptColumnsSelectionDsl {
 
     /**
      * @include [CommonExceptDocs]
-     * @set [CommonExceptDocs.ExampleArg] {@comment <code> blocks are there to prevent double ``}
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `<code>{@get [ReceiverArg1]}</code>[allColsExcept][{@get [ReceiverType]}.allColsExcept]<code>{@get [ArgumentArg1]}</code>` \}`
+     * @set [CommonExceptDocs.EXAMPLE] {@comment <code> blocks are there to prevent double ``}
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `<code>{@get [RECEIVER_1]}</code>[allColsExcept][{@get [RECEIVER_TYPE]}.allColsExcept]<code>{@get [ARGUMENT_1]}</code>` \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  { city  `[and][ColumnsSelectionDsl.and]` `<code>{@get [ReceiverArg2]}</code>[allColsExcept][{@get [ReceiverType]}.allColsExcept]<code>{@get [ArgumentArg2]}</code>` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  { city  `[and][ColumnsSelectionDsl.and]` `<code>{@get [RECEIVER_2]}</code>[allColsExcept][{@get [RECEIVER_TYPE]}.allColsExcept]<code>{@get [ARGUMENT_2]}</code>` \}`
      */
+    @Suppress("ClassName")
     private interface ColumnGroupDocs {
 
         // receiver
-        interface ReceiverArg1
+        interface RECEIVER_1
 
         // receiver
-        interface ReceiverArg2
+        interface RECEIVER_2
 
         // type
-        interface ReceiverType
+        interface RECEIVER_TYPE
 
         // argument
-        interface ArgumentArg1
+        interface ARGUMENT_1
 
         // argument
-        interface ArgumentArg2
+        interface ARGUMENT_2
 
         /**
-         * @set [ColumnGroupDocs.ReceiverArg1] `userData.`
-         * @set [ColumnGroupDocs.ReceiverArg2] `name.`
-         * @set [ColumnGroupDocs.ReceiverType] SingleColumn
+         * @set [ColumnGroupDocs.RECEIVER_1] `userData.`
+         * @set [ColumnGroupDocs.RECEIVER_2] `name.`
+         * @set [ColumnGroupDocs.RECEIVER_TYPE] SingleColumn
          */
         interface SingleColumnReceiverArgs
 
         /**
-         * @set [ColumnGroupDocs.ReceiverArg1] `"userData".`
-         * @set [ColumnGroupDocs.ReceiverArg2] `"name".`
-         * @set [ColumnGroupDocs.ReceiverType] String
+         * @set [ColumnGroupDocs.RECEIVER_1] `"userData".`
+         * @set [ColumnGroupDocs.RECEIVER_2] `"name".`
+         * @set [ColumnGroupDocs.RECEIVER_TYPE] String
          */
         interface StringReceiverArgs
 
         /**
-         * @set [ColumnGroupDocs.ReceiverArg1] `DataSchemaPerson::userData.`
-         * @set [ColumnGroupDocs.ReceiverArg2] `Person::name.`
-         * @set [ColumnGroupDocs.ReceiverType] KProperty
+         * @set [ColumnGroupDocs.RECEIVER_1] `DataSchemaPerson::userData.`
+         * @set [ColumnGroupDocs.RECEIVER_2] `Person::name.`
+         * @set [ColumnGroupDocs.RECEIVER_TYPE] KProperty
          */
         interface KPropertyReceiverArgs
 
         /**
-         * @set [ColumnGroupDocs.ReceiverArg1] `pathOf("userData").`
-         * @set [ColumnGroupDocs.ReceiverArg2] `"pathTo"["myColGroup"].`
-         * @set [ColumnGroupDocs.ReceiverType] ColumnPath
+         * @set [ColumnGroupDocs.RECEIVER_1] `pathOf("userData").`
+         * @set [ColumnGroupDocs.RECEIVER_2] `"pathTo"["myColGroup"].`
+         * @set [ColumnGroupDocs.RECEIVER_TYPE] ColumnPath
          */
         interface ColumnPathReceiverArgs
 
         /**
-         * @set [CommonExceptDocs.ParamArg] @param [selector\] A lambda in which you specify the columns that need to be
+         * @set [CommonExceptDocs.PARAM] @param [selector\] A lambda in which you specify the columns that need to be
          *  excluded from the current selection in [this\] column group. The other columns will be included in the selection
          *  by default. The scope of the selector is relative to the column group.
-         * @set [ColumnGroupDocs.ArgumentArg1] `  { "age"  `[and][ColumnsSelectionDsl.and]` height }`
-         * @set [ColumnGroupDocs.ArgumentArg2] ` { firstName }`
+         * @set [ColumnGroupDocs.ARGUMENT_1] `  { "age"  `[and][ColumnsSelectionDsl.and]` height }`
+         * @set [ColumnGroupDocs.ARGUMENT_2] ` { firstName }`
          */
         interface SelectorArgs
 
         /**
-         * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [Strings][String] referring to
+         * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [Strings][String] referring to
          *  the columns (relative to the column group) that need to be excluded from the current selection in [this\]
          *  column group. The other columns will be included in the selection by default.
-         * @set [ColumnGroupDocs.ArgumentArg1] `("age", "height")`
-         * @set [ColumnGroupDocs.ArgumentArg2] `("firstName", "middleName")`
+         * @set [ColumnGroupDocs.ARGUMENT_1] `("age", "height")`
+         * @set [ColumnGroupDocs.ARGUMENT_2] `("firstName", "middleName")`
          */
         interface StringArgs
 
         /**
-         * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [KProperties][KProperty] referring to
+         * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [KProperties][KProperty] referring to
          *  the columns (relative to the column group) that need to be excluded from the current selection in [this\]
          *  column group. The other columns will be included in the selection by default.
-         * @set [ColumnGroupDocs.ArgumentArg1] `(Person::age, Person::height)`
-         * @set [ColumnGroupDocs.ArgumentArg2] `(Person::firstName, Person::middleName)`
+         * @set [ColumnGroupDocs.ARGUMENT_1] `(Person::age, Person::height)`
+         * @set [ColumnGroupDocs.ARGUMENT_2] `(Person::firstName, Person::middleName)`
          */
         interface KPropertyArgs
 
         /**
-         * @set [CommonExceptDocs.ParamArg] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
+         * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
          *  the columns (relative to the column group) that need to be excluded from the current selection in [this\]
          *  column group. The other columns will be included in the selection by default.
-         * @set [ColumnGroupDocs.ArgumentArg1] `(pathOf("age"), "extraData"["item1"])`
-         * @set [ColumnGroupDocs.ArgumentArg2] `(pathOf("firstName"), "middleNames"["first"])`
+         * @set [ColumnGroupDocs.ARGUMENT_1] `(pathOf("age"), "extraData"["item1"])`
+         * @set [ColumnGroupDocs.ARGUMENT_2] `(pathOf("firstName"), "middleNames"["first"])`
          */
         interface ColumnPathArgs
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/and.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/and.kt
@@ -4,9 +4,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.AndColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.AndColumnsSelectionDsl.Grammar.InfixName
-import org.jetbrains.kotlinx.dataframe.api.AndColumnsSelectionDsl.Grammar.Name
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -33,7 +30,7 @@ public interface AndColumnsSelectionDsl {
      * ## And Operator Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -43,17 +40,17 @@ public interface AndColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ColumnOrColumnSetDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [DslGrammarTemplate.ColumnOrColumnSetRef]}` `{@include [InfixName]}`  [  `**`{`**`  ]  `{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}`  [  `**`\}`**` ]`
      *
      *  `| `{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}{@include [Name]}**` (`**`|`**`{ `**{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}**` \}`**`|`**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [Name]}**` (`**`|`**`{ `**{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}**` \}`**`|`**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [Name]}**` (`**`|`**`{ `**{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}**` \}`**`|`**`)`**
      * }
      */
@@ -92,21 +89,21 @@ public interface AndColumnsSelectionDsl {
      *
      * #### Example for this overload:
      *
-     * {@get [CommonAndDocs.ExampleArg]}
+     * {@get [CommonAndDocs.EXAMPLE]}
      *
      * @return A [ColumnSet] that contains all the columns from the [ColumnsResolvers][ColumnsResolver] on the left
      *   and right side of the [and] operator.
      */
     private interface CommonAndDocs {
 
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     // region ColumnsResolver
 
     /**
      * @include [CommonAndDocs]
-     * @set [CommonAndDocs.ExampleArg]
+     * @set [CommonAndDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[`cols`][ColumnsSelectionDsl.cols]`  { ... }  `[`and`][ColumnsResolver.and]` `<code>{@get [ColumnsResolverAndDocs.Argument]}</code>` }`
      */
@@ -135,7 +132,7 @@ public interface AndColumnsSelectionDsl {
 
     /**
      * @include [CommonAndDocs]
-     * @set [CommonAndDocs.ExampleArg]
+     * @set [CommonAndDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  { "colA"  `[`and`][String.and]` `<code>{@get [StringAndDocs.Argument]}</code>` }`
      */
@@ -163,7 +160,7 @@ public interface AndColumnsSelectionDsl {
 
     /**
      * @include [CommonAndDocs]
-     * @set [CommonAndDocs.ExampleArg]
+     * @set [CommonAndDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  { Type::colA  `[`and`][KProperty.and]` `<code>{@get [KPropertyAndDocs.Argument]}</code>` }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/col.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/col.kt
@@ -4,10 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ColColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -39,7 +35,7 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
      * ## Col Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -51,15 +47,15 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
      *  {@include [DslGrammarTemplate.ColumnTypeDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.IndexRef]}**`)`**`  |  `[**`[`**][ColumnsSelectionDsl.col]{@include [DslGrammarTemplate.IndexRef]}[**`]`**][ColumnsSelectionDsl.col]
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      */
@@ -87,7 +83,7 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
      * The function can also be called on [ColumnGroups][ColumnGroupReference] to create
      * an accessor for a column inside a [ColumnGroup].
      * {@include [LineBreak]}
-     * $[CommonColDocs.Note]
+     * $[CommonColDocs.NOTE]
      *
      * ### Check out: [Grammar]
      *
@@ -101,7 +97,7 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * $[CommonColDocs.ExampleArg]
+     * $[CommonColDocs.EXAMPLE]
      *
      * To create a [ColumnAccessor] for a specific kind of column with runtime checks, take a look at the functions
      * [valueCol][ColumnsSelectionDsl.valueCol],
@@ -115,33 +111,33 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
      * @see [ColumnsSelectionDsl.colGroup\]
      * @see [ColumnsSelectionDsl.frameCol\]
      * @see [ColumnsSelectionDsl.valueCol\]
-     * {@set [CommonColDocs.Note]}
+     * {@set [CommonColDocs.NOTE]}
      */
     private interface CommonColDocs {
 
         // Example argument, can be either {@include [SingleExample]} or {@include [DoubleExample]}
-        interface ExampleArg
+        interface EXAMPLE
 
         /**
-         * `df.`[select][DataFrame.select]` { $[CommonColDocs.ReceiverArg]`[col][col]`($[CommonColDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColDocs.RECEIVER]`[col][col]`($[CommonColDocs.ARG]) \}`
          */
         interface SingleExample
 
         /**
-         * `df.`[select][DataFrame.select]` { $[CommonColDocs.ReceiverArg]`[col][col]`($[CommonColDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColDocs.RECEIVER]`[col][col]`($[CommonColDocs.ARG]) \}`
          *
-         * `df.`[select][DataFrame.select]` { $[CommonColDocs.ReceiverArg]`[col][col]`<`[String][String]`>($[CommonColDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColDocs.RECEIVER]`[col][col]`<`[String][String]`>($[CommonColDocs.ARG]) \}`
          */
         interface DoubleExample
 
         // Receiver argument for the example(s)
-        interface ReceiverArg
+        interface RECEIVER
 
         // Argument for the example(s)
-        interface Arg
+        interface ARG
 
         // Optional note
-        interface Note
+        interface NOTE
 
         /** @param [C\] The type of the column. */
         interface ColumnTypeParam
@@ -151,22 +147,22 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColDocs]
-     * {@set [CommonColDocs.Arg] columnA}
-     * {@set [CommonColDocs.ExampleArg] {@include [CommonColDocs.SingleExample]}}
+     * {@set [CommonColDocs.ARG] columnA}
+     * {@set [CommonColDocs.EXAMPLE] {@include [CommonColDocs.SingleExample]}}
      * @param [col\] The [ColumnAccessor] pointing to the column.
      * @include [CommonColDocs.ColumnTypeParam]
      */
     private interface ColReferenceDocs
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg]}
-     * {@set [CommonColDocs.Note] NOTE: This overload is an identity function and can be omitted.}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER]}
+     * {@set [CommonColDocs.NOTE] NOTE: This overload is an identity function and can be omitted.}
      */
     @Deprecated(IDENTITY_FUNCTION, ReplaceWith(COL_REPLACE))
     public fun <C> col(col: ColumnAccessor<C>): ColumnAccessor<C> = col
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.col(col: ColumnAccessor<C>): SingleColumn<C> =
         this.ensureIsColumnGroup().transformSingle {
@@ -176,25 +172,25 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.col(col: ColumnAccessor<C>): ColumnAccessor<C> =
         this.ensureIsColumnGroup().column(col.path())
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.col(col: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(col.path())
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.col(col: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(col.path())
 
     /**
-     * @include [ColReferenceDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColReferenceDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.col(col: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(col.path())
@@ -205,34 +201,34 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColDocs]
-     * {@set [CommonColDocs.Arg] "columnName"}
-     * {@set [CommonColDocs.ExampleArg] {@include [CommonColDocs.DoubleExample]}}
+     * {@set [CommonColDocs.ARG] "columnName"}
+     * {@set [CommonColDocs.EXAMPLE] {@include [CommonColDocs.DoubleExample]}}
      * @param [name\] The name of the column.
      */
     private interface ColNameDocs
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun col(name: String): ColumnAccessor<*> = column<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER]}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> col(name: String): ColumnAccessor<C> = column(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun SingleColumn<DataRow<*>>.col(name: String): SingleColumn<*> = col<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.col(name: String): SingleColumn<C> =
@@ -243,27 +239,27 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun AnyColumnGroupAccessor.col(name: String): ColumnAccessor<*> = col<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.col(name: String): ColumnAccessor<C> = this.ensureIsColumnGroup().column(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun String.col(name: String): ColumnAccessor<*> = col<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> String.col(name: String): ColumnAccessor<C> =
@@ -272,28 +268,28 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
             .column(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun KProperty<*>.col(name: String): ColumnAccessor<*> = col<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> KProperty<*>.col(name: String): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun ColumnPath.col(name: String): ColumnAccessor<*> = col<Any?>(name)
 
     /**
-     * @include [ColNameDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColNameDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> ColumnPath.col(name: String): ColumnAccessor<C> =
@@ -305,34 +301,34 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColDocs]
-     * {@set [CommonColDocs.Arg] "pathTo"["columnName"\] }
-     * {@set [CommonColDocs.ExampleArg] {@include [CommonColDocs.DoubleExample]}}
+     * {@set [CommonColDocs.ARG] "pathTo"["columnName"\] }
+     * {@set [CommonColDocs.EXAMPLE] {@include [CommonColDocs.DoubleExample]}}
      * @param [path\] The path to the column.
      */
     private interface ColPathDocs
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun col(path: ColumnPath): ColumnAccessor<*> = column<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER]}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> col(path: ColumnPath): ColumnAccessor<C> = column(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun SingleColumn<DataRow<*>>.col(path: ColumnPath): SingleColumn<*> = col<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.col(path: ColumnPath): SingleColumn<C> =
@@ -343,56 +339,56 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun AnyColumnGroupAccessor.col(path: ColumnPath): ColumnAccessor<*> = col<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.col(path: ColumnPath): ColumnAccessor<C> =
         this.ensureIsColumnGroup().column(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun String.col(path: ColumnPath): ColumnAccessor<*> = col<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> String.col(path: ColumnPath): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun KProperty<*>.col(path: ColumnPath): ColumnAccessor<*> = col<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> KProperty<*>.col(path: ColumnPath): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun ColumnPath.col(path: ColumnPath): ColumnAccessor<*> = col<Any?>(path)
 
     /**
-     * @include [ColPathDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColPathDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> ColumnPath.col(path: ColumnPath): ColumnAccessor<C> =
@@ -404,43 +400,43 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColDocs]
-     * {@set [CommonColDocs.Arg] Type::columnA}
-     * {@set [CommonColDocs.ExampleArg] {@include [CommonColDocs.SingleExample]}}
+     * {@set [CommonColDocs.ARG] Type::columnA}
+     * {@set [CommonColDocs.EXAMPLE] {@include [CommonColDocs.SingleExample]}}
      * @param [property\] The [KProperty] reference to the column.
      * @include [CommonColDocs.ColumnTypeParam]
      */
     private interface ColKPropertyDocs
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER]}
      */
     public fun <C> col(property: KProperty<C>): SingleColumn<C> = column(property)
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.col(property: KProperty<C>): SingleColumn<C> = col<C>(property.name)
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.col(property: KProperty<C>): ColumnAccessor<C> =
         this.ensureIsColumnGroup().column(property)
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.col(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(property)
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.col(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(property)
 
     /**
-     * @include [ColKPropertyDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColKPropertyDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.col(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().column(property)
@@ -451,29 +447,29 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColDocs]
-     * {@set [CommonColDocs.Arg] 0}
-     * {@set [CommonColDocs.ExampleArg] {@include [CommonColDocs.DoubleExample]}}
+     * {@set [CommonColDocs.ARG] 0}
+     * {@set [CommonColDocs.EXAMPLE] {@include [CommonColDocs.DoubleExample]}}
      * @param [index\] The index of the column.
      * @throws [IndexOutOfBoundsException\] if the index is out of bounds.
      */
     private interface ColIndexDocs
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonColDocs.ColumnTypeParam]
-     * {@set [CommonColDocs.ExampleArg]
+     * {@set [CommonColDocs.EXAMPLE]
      * {@include [CommonColDocs.SingleExample]}
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[String][String]`>()`[`[`][col]`1`[`]`][col]` \}`
      * }
-     * {@set [CommonColDocs.Note] NOTE: You can use the get-[] operator on [ColumnSets][ColumnSet] as well!}
+     * {@set [CommonColDocs.NOTE] NOTE: You can use the get-[] operator on [ColumnSets][ColumnSet] as well!}
      */
     public fun <C> ColumnSet<C>.col(index: Int): SingleColumn<C> = getAt(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonColDocs.ColumnTypeParam]
-     * {@set [CommonColDocs.ExampleArg]
+     * {@set [CommonColDocs.EXAMPLE]
      * {@include [CommonColDocs.SingleExample]}
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[String][String]`>()`[`[`][col]`1`[`]`][col]` \}`
@@ -482,27 +478,27 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
     public operator fun <C> ColumnSet<C>.get(index: Int): SingleColumn<C> = col(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun ColumnsSelectionDsl<*>.col(index: Int): SingleColumn<*> = col<Any?>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg]}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER]}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> ColumnsSelectionDsl<*>.col(index: Int): SingleColumn<C> = asSingleColumn().col<C>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun SingleColumn<DataRow<*>>.col(index: Int): SingleColumn<*> = col<Any?>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.col(index: Int): SingleColumn<C> =
@@ -512,40 +508,40 @@ public interface ColColumnsSelectionDsl<out _UNUSED> {
             .cast()
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun String.col(index: Int): SingleColumn<*> = col<Any?>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> String.col(index: Int): SingleColumn<C> = columnGroup(this).col<C>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun KProperty<*>.col(index: Int): SingleColumn<*> = col<Any?>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> KProperty<*>.col(index: Int): SingleColumn<C> = columnGroup(this).col<C>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colUnTyped")
     public fun ColumnPath.col(index: Int): SingleColumn<*> = col<Any?>(index)
 
     /**
-     * @include [ColIndexDocs] {@set [CommonColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColIndexDocs] {@set [CommonColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColDocs.ColumnTypeParam]
      */
     public fun <C> ColumnPath.col(index: Int): SingleColumn<C> = columnGroup(this).col<C>(index)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroup.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroup.kt
@@ -4,10 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColGroupColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ColGroupColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColGroupColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColGroupColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -39,7 +35,7 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
      * ## Col Group Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -51,15 +47,15 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
      *  {@include [DslGrammarTemplate.ColumnTypeDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      */
@@ -88,7 +84,7 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
      * The function can also be called on [ColumnGroups][ColumnGroupReference] to create
      * an accessor for a column group inside a [ColumnGroup].
      * {@include [LineBreak]}
-     * $[CommonColGroupDocs.Note]
+     * $[CommonColGroupDocs.NOTE]
      *
      * ### Check out: [Grammar]
      *
@@ -102,7 +98,7 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * $[CommonColGroupDocs.ExampleArg]
+     * $[CommonColGroupDocs.EXAMPLE]
      *
      * To create a [ColumnAccessor] for another kind of column, take a look at the functions
      * [col][ColumnsSelectionDsl.col],
@@ -117,33 +113,33 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
      * @see [ColumnsSelectionDsl.frameCol\]
      * @see [ColumnsSelectionDsl.valueCol\]
      * @see [ColumnsSelectionDsl.col\]
-     * {@set [CommonColGroupDocs.Note]}
+     * {@set [CommonColGroupDocs.NOTE]}
      */
     private interface CommonColGroupDocs {
 
         // Example argument, can be either {@include [SingleExample]} or {@include [DoubleExample]}
-        interface ExampleArg
+        interface EXAMPLE
 
         /**
-         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.ReceiverArg]`[colGroup][colGroup]`($[CommonColGroupDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.RECEIVER]`[colGroup][colGroup]`($[CommonColGroupDocs.ARG]) \}`
          */
         interface SingleExample
 
         /**
-         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.ReceiverArg]`[colGroup][colGroup]`($[CommonColGroupDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.RECEIVER]`[colGroup][colGroup]`($[CommonColGroupDocs.ARG]) \}`
          *
-         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.ReceiverArg]`[colGroup][colGroup]`<`[String][String]`>($[CommonColGroupDocs.Arg]) \}`
+         * `df.`[select][DataFrame.select]` { $[CommonColGroupDocs.RECEIVER]`[colGroup][colGroup]`<`[String][String]`>($[CommonColGroupDocs.ARG]) \}`
          */
         interface DoubleExample
 
         // Receiver argument for the example(s)
-        interface ReceiverArg
+        interface RECEIVER
 
         // Argument for the example(s)
-        interface Arg
+        interface ARG
 
         // Optional note
-        interface Note
+        interface NOTE
 
         /** @param [C\] The type of the column group. */
         interface ColumnGroupTypeParam
@@ -153,21 +149,21 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColGroupDocs]
-     * {@set [CommonColGroupDocs.Arg] columnGroupA}
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.SingleExample]}}
+     * {@set [CommonColGroupDocs.ARG] columnGroupA}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.SingleExample]}}
      * @param [col\] The [ColumnAccessor] pointing to the value column.
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     private interface ColGroupReferenceDocs
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     public fun <C> colGroup(colGroup: ColumnAccessor<DataRow<C>>): ColumnAccessor<DataRow<C>> =
         colGroup.ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.colGroup(colGroup: ColumnAccessor<DataRow<C>>): SingleColumn<DataRow<C>> =
         this.ensureIsColumnGroup().transformSingle {
@@ -180,25 +176,25 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.colGroup(colGroup: ColumnAccessor<DataRow<C>>): ColumnAccessor<DataRow<C>> =
         this.ensureIsColumnGroup().columnGroup<C>(colGroup.path()).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.colGroup(colGroup: ColumnAccessor<DataRow<C>>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(colGroup.path()).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.colGroup(colGroup: ColumnAccessor<DataRow<C>>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(colGroup.path()).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupReferenceDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.colGroup(colGroup: ColumnAccessor<DataRow<C>>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(colGroup.path()).ensureIsColumnGroup()
@@ -209,34 +205,34 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColGroupDocs]
-     * {@set [CommonColGroupDocs.Arg] "columnGroupName"}
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.DoubleExample]}}
+     * {@set [CommonColGroupDocs.ARG] "columnGroupName"}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.DoubleExample]}}
      * @param [name\] The name of the value column.
      */
     private interface ColGroupNameDocs
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun colGroup(name: String): ColumnAccessor<DataRow<*>> = columnGroup<Any?>(name).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER]}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> colGroup(name: String): ColumnAccessor<DataRow<C>> = columnGroup<C>(name).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun SingleColumn<DataRow<*>>.colGroup(name: String): SingleColumn<DataRow<*>> = colGroup<Any?>(name)
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.colGroup(name: String): SingleColumn<DataRow<C>> =
@@ -248,56 +244,56 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun AnyColumnGroupAccessor.colGroup(name: String): ColumnAccessor<DataRow<*>> = colGroup<Any?>(name)
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.colGroup(name: String): ColumnAccessor<DataRow<C>> =
         this.ensureIsColumnGroup().columnGroup<C>(name).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun String.colGroup(name: String): ColumnAccessor<DataRow<*>> = colGroup<Any?>(name)
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> String.colGroup(name: String): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(name).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun KProperty<*>.colGroup(name: String): ColumnAccessor<DataRow<*>> = colGroup<Any?>(name)
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> KProperty<*>.colGroup(name: String): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(name).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun ColumnPath.colGroup(name: String): ColumnAccessor<DataRow<*>> = colGroup<Any?>(name)
 
     /**
-     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupNameDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> ColumnPath.colGroup(name: String): ColumnAccessor<DataRow<C>> =
@@ -309,34 +305,34 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColGroupDocs]
-     * {@set [CommonColGroupDocs.Arg] "pathTo"["columnGroupName"\] }
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.DoubleExample]}}
+     * {@set [CommonColGroupDocs.ARG] "pathTo"["columnGroupName"\] }
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.DoubleExample]}}
      * @param [path\] The path to the value column.
      */
     private interface ColGroupPathDocs
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun colGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = columnGroup<Any?>(path).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER]}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> colGroup(path: ColumnPath): ColumnAccessor<DataRow<C>> = columnGroup<C>(path).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun SingleColumn<DataRow<*>>.colGroup(path: ColumnPath): SingleColumn<DataRow<*>> = colGroup<Any?>(path)
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.colGroup(path: ColumnPath): SingleColumn<DataRow<C>> =
@@ -349,56 +345,56 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
             }.singleImpl()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun AnyColumnGroupAccessor.colGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = colGroup<Any?>(path)
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.colGroup(path: ColumnPath): ColumnAccessor<DataRow<C>> =
         this.ensureIsColumnGroup().columnGroup<C>(path).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun String.colGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = colGroup<Any?>(path)
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> String.colGroup(path: ColumnPath): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(path).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun KProperty<*>.colGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = colGroup<Any?>(path)
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> KProperty<*>.colGroup(path: ColumnPath): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup<C>(path).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun ColumnPath.colGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = colGroup<Any?>(path)
 
     /**
-     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupPathDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> ColumnPath.colGroup(path: ColumnPath): ColumnAccessor<DataRow<C>> =
@@ -410,15 +406,15 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColGroupDocs]
-     * {@set [CommonColGroupDocs.Arg] Type::columnGroupA}
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.SingleExample]}}
+     * {@set [CommonColGroupDocs.ARG] Type::columnGroupA}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.SingleExample]}}
      * @param [property\] The [KProperty] reference to the value column.
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     private interface ColGroupKPropertyDocs
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -426,13 +422,13 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     public fun <C> colGroup(property: KProperty<C>): SingleColumn<DataRow<C>> =
         columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -440,13 +436,13 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         colGroup<C>(property.name)
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.colGroup(property: KProperty<C>): SingleColumn<DataRow<C>> =
         colGroup<C>(property.name)
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -454,13 +450,13 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         this.ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.colGroup(property: KProperty<C>): ColumnAccessor<DataRow<C>> =
         this.ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -468,13 +464,13 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.colGroup(property: KProperty<C>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -482,13 +478,13 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.colGroup(property: KProperty<C>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupDataRowKProperty")
@@ -496,7 +492,7 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupKPropertyDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.colGroup(property: KProperty<C>): ColumnAccessor<DataRow<C>> =
         columnGroup(this).ensureIsColumnGroup().columnGroup(property).ensureIsColumnGroup()
@@ -507,17 +503,17 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColGroupDocs]
-     * {@set [CommonColGroupDocs.Arg] 0}
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.DoubleExample]}}
+     * {@set [CommonColGroupDocs.ARG] 0}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.DoubleExample]}}
      * @param [index\] The index of the value column.
      * @throws [IndexOutOfBoundsException\] if the index is out of bounds.
      */
     private interface ColGroupIndexDocs
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.SingleExample]}}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.SingleExample]}}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("ColumnSetDataRowColGroupIndex")
@@ -525,36 +521,36 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
         getAt(index).ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
-     * {@set [CommonColGroupDocs.ExampleArg] {@include [CommonColGroupDocs.SingleExample]}}
+     * {@set [CommonColGroupDocs.EXAMPLE] {@include [CommonColGroupDocs.SingleExample]}}
      */
     public fun ColumnSet<*>.colGroup(index: Int): SingleColumn<DataRow<*>> =
         getAt(index).cast<DataRow<*>>().ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun ColumnsSelectionDsl<*>.colGroup(index: Int): SingleColumn<DataRow<*>> = colGroup<Any?>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg]}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER]}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> ColumnsSelectionDsl<*>.colGroup(index: Int): SingleColumn<DataRow<C>> =
         asSingleColumn().colGroup<C>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun SingleColumn<DataRow<*>>.colGroup(index: Int): SingleColumn<DataRow<*>> = colGroup<Any?>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] myColumnGroup.}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.colGroup(index: Int): SingleColumn<DataRow<C>> =
@@ -565,40 +561,40 @@ public interface ColGroupColumnsSelectionDsl<out _UNUSED> {
             .ensureIsColumnGroup()
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun String.colGroup(index: Int): SingleColumn<DataRow<*>> = colGroup<Any?>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> String.colGroup(index: Int): SingleColumn<DataRow<C>> = columnGroup(this).colGroup<C>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun KProperty<*>.colGroup(index: Int): SingleColumn<DataRow<*>> = colGroup<Any?>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> KProperty<*>.colGroup(index: Int): SingleColumn<DataRow<C>> = columnGroup(this).colGroup<C>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("colGroupUnTyped")
     public fun ColumnPath.colGroup(index: Int): SingleColumn<DataRow<*>> = colGroup<Any?>(index)
 
     /**
-     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ColGroupIndexDocs] {@set [CommonColGroupDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonColGroupDocs.ColumnGroupTypeParam]
      */
     public fun <C> ColumnPath.colGroup(index: Int): SingleColumn<DataRow<C>> = columnGroup(this).colGroup<C>(index)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
@@ -4,10 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
-import org.jetbrains.kotlinx.dataframe.api.ColGroupsColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ColGroupsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColGroupsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColGroupsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -34,7 +30,7 @@ public interface ColGroupsColumnsSelectionDsl {
      * ## Column Groups Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -42,15 +38,15 @@ public interface ColGroupsColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */
@@ -87,7 +83,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonColGroupsDocs.ExampleArg]}
+     * {@get [CommonColGroupsDocs.EXAMPLE]}
      *
      * @param [filter\] An optional [predicate][Predicate] to filter the column groups by.
      * @return A [ColumnSet] of [ColumnGroups][ColumnGroup].
@@ -99,12 +95,12 @@ public interface ColGroupsColumnsSelectionDsl {
     private interface CommonColGroupsDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") }.`[colGroups][ColumnSet.colGroups]`() }`
      *
@@ -117,7 +113,7 @@ public interface ColGroupsColumnsSelectionDsl {
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]`() }`
      *
@@ -129,7 +125,7 @@ public interface ColGroupsColumnsSelectionDsl {
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColGroup.`[colGroups][SingleColumn.colGroups]`() }`
      *
@@ -141,7 +137,7 @@ public interface ColGroupsColumnsSelectionDsl {
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[colGroups][String.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -152,7 +148,7 @@ public interface ColGroupsColumnsSelectionDsl {
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colGroup][ColumnsSelectionDsl.colGroup]`(Type::myColGroup).`[colGroups][SingleColumn.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -163,7 +159,7 @@ public interface ColGroupsColumnsSelectionDsl {
 
     /**
      * @include [CommonColGroupsDocs]
-     * @set [CommonColGroupsDocs.ExampleArg]
+     * @set [CommonColGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[colGroups][ColumnPath.colGroups]`() }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
@@ -4,10 +4,6 @@ import org.jetbrains.kotlinx.dataframe.ColumnFilter
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColsColumnsSelectionDsl.CommonColsDocs.Vararg.AccessorType
-import org.jetbrains.kotlinx.dataframe.api.ColsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -37,7 +33,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      * ## Cols Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -54,7 +50,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      *  {@include [LineBreak]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRangeRef]}**`)`**
      *
      *  `| `{@include [PlainDslName]}`  [  `**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**`  \}  `**`]`
@@ -64,7 +60,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      *  `| `**`this`**`/`**`it `**[**`[`**][cols]{@include [DslGrammarTemplate.ColumnRef]}**`,`**`  ..  `[**`]`**][cols]
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.IndexRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRangeRef]}**`)`**
      *
      *  {@include [Indent]}`| `{@include [ColumnSetName]}`  [  `**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**`  \}  `**`]`
@@ -74,7 +70,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      *  {@include [Indent]}`| `[**`[`**][cols]{@include [DslGrammarTemplate.IndexRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRangeRef]}[**`]`**][cols]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRef]}**`,`**`  .. |  `{@include [DslGrammarTemplate.IndexRangeRef]}**`)`**
      *
      *  {@include [Indent]}`| `{@include [ColumnGroupName]}`  [  `**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**`  \}  `**`]`
@@ -178,7 +174,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonColsIndicesDocs.ExampleArg]}
+     * {@get [CommonColsIndicesDocs.EXAMPLE]}
      *
      * @throws [IndexOutOfBoundsException] If any index is out of bounds.
      * @param [firstIndex\] The index of the first column to retrieve.
@@ -188,7 +184,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface CommonColsIndicesDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
@@ -209,7 +205,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonColsRangeDocs.ExampleArg]}
+     * {@get [CommonColsRangeDocs.EXAMPLE]}
      *
      * @throws [IndexOutOfBoundsException\] if any of the indices in the [range\] are out of bounds.
      * @throws [IllegalArgumentException\] if the [range\] is empty.
@@ -219,7 +215,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface CommonColsRangeDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     // region predicate
@@ -856,7 +852,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]`  {  `[`colsOf`][SingleColumn.colsOf]`<`[`Int`][Int]`>().`[`cols`][ColumnSet.cols]`(1, 3) }`
      *
@@ -875,7 +871,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]`  {  `[`cols`][ColumnsSelectionDsl.cols]`(1, 3) }`
      *
@@ -895,7 +891,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { myColumnGroup.`[`cols`][SingleColumn.cols]`(1, 3) }`
      *
@@ -915,7 +911,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { "myColumnGroup".`[`cols`][String.cols]`(5, 3, 1) }`
      *
@@ -935,7 +931,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { Type::myColumnGroup.`[`cols`][SingleColumn.cols]`(5, 4) }`
      *
@@ -955,7 +951,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsIndicesDocs]
-     * @set [CommonColsIndicesDocs.ExampleArg]
+     * @set [CommonColsIndicesDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { "pathTo"["myColGroup"].`[`cols`][ColumnPath.cols]`(0, 1) }`
      *
@@ -979,7 +975,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]`  {  `[`colsOf`][SingleColumn.colsOf]`<`[`Int`][Int]`>().`[`cols`][ColumnSet.cols]`(1`[`..`][Int.rangeTo]`3) }`
      *
@@ -996,7 +992,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]`  {  `[`cols`][ColumnsSelectionDsl.cols]`(1`[`..`][Int.rangeTo]`3) }`
      *
@@ -1015,7 +1011,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { myColumnGroup.`[`cols`][SingleColumn.cols]`(1`[`..`][Int.rangeTo]`3) }`
      *
@@ -1034,7 +1030,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { "myColGroup".`[`cols`][String.cols]`(1`[`..`][Int.rangeTo]`3) }`
      *
@@ -1052,7 +1048,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { Type::myColumnGroup.`[`cols`][SingleColumn.cols]`(1`[`..`][Int.rangeTo]`3) }`
      *
@@ -1071,7 +1067,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonColsRangeDocs]
-     * @set [CommonColsRangeDocs.ExampleArg]
+     * @set [CommonColsRangeDocs.EXAMPLE]
      *
      * `df.`[`select`][DataFrame.select]` { "pathTo"["myColGroup"].`[`cols`][ColumnPath.cols]`(0`[`..`][Int.rangeTo]`1) }`
      *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
@@ -5,10 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.ColsAtAnyDepthColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ColsAtAnyDepthColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColsAtAnyDepthColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColsAtAnyDepthColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -35,7 +31,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * ## Cols At Any Depth Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -43,13 +39,13 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
@@ -4,9 +4,6 @@ import org.jetbrains.kotlinx.dataframe.ColumnFilter
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColsInGroupsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColsInGroupsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColsInGroupsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -32,7 +29,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      * ## Cols in Groups Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -40,15 +37,15 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */
@@ -98,7 +95,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * #### Examples of this overload:
      *
-     * {@get [ColsInGroupsDocs.ExampleArg]}
+     * {@get [ColsInGroupsDocs.EXAMPLE]}
      *
      * @see [ColumnsSelectionDsl.cols\]
      * @see [ColumnsSelectionDsl.colGroups\]
@@ -108,12 +105,12 @@ public interface ColsInGroupsColumnsSelectionDsl {
     private interface ColsInGroupsDocs {
 
         /** Example argument to use */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[colsInGroups][ColumnSet.colsInGroups]`  { "my"  `[in][String.contains]` it.`[name][DataColumn.name]` } }`
      *
@@ -124,7 +121,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnSet.colsInGroups]`  { "my"  `[in][String.contains]` it.`[name][DataColumn.name]` } }`
      *
@@ -135,7 +132,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsInGroups][SingleColumn.colsInGroups]`() }`
      *
@@ -146,7 +143,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsInGroups][String.colsInGroups]`() }`
      */
@@ -155,7 +152,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[colsInGroups][KProperty.colsInGroups]`() }`
      *
@@ -166,7 +163,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
 
     /**
      * @include [ColsInGroupsDocs]
-     * @set [ColsInGroupsDocs.ExampleArg]
+     * @set [ColsInGroupsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[colsInGroups][ColumnPath.colsInGroups]`() }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
@@ -5,10 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.ColsOfColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ColsOfColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColsOfColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColsOfColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
@@ -36,7 +32,7 @@ public interface ColsOfColumnsSelectionDsl {
      *
      * @include [DslGrammarTemplate]
      *
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.SingleColumnDef]}
@@ -52,16 +48,16 @@ public interface ColsOfColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.KTypeDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`  [  `**`(`**{@include [DslGrammarTemplate.KTypeRef]}**`)`**`  ] [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`  [  `**`(`**{@include [DslGrammarTemplate.KTypeRef]}**`)`**`  ] [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
      * {@comment We need to deviate from the template here, since we have overload discrepancies.}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]
      *  {@include [LineBreak]}
      *  ### On a column group reference:
      *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOfKind.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOfKind.kt
@@ -3,9 +3,6 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.ColumnFilter
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ColsOfKindColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ColsOfKindColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ColsOfKindColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -33,7 +30,7 @@ public interface ColsOfKindColumnsSelectionDsl {
      * ## Cols Of Kind Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -43,15 +40,15 @@ public interface ColsOfKindColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ColumnKindDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnKindRef]}**`,`**` ..`**`)`**`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.ColumnKindRef]}**`,`**` ..`**`)`**`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnKindRef]}**`,`**` ..`**`)`**`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */
@@ -88,7 +85,7 @@ public interface ColsOfKindColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonColsOfKindDocs.ExampleArg]}
+     * {@get [CommonColsOfKindDocs.EXAMPLE]}
      *
      * @param [filter\] An optional [predicate][ColumnFilter] to filter the columns of given kind(s) by.
      * @param [kind\] The [kind][ColumnKind] of columns to include.
@@ -102,12 +99,12 @@ public interface ColsOfKindColumnsSelectionDsl {
     private interface CommonColsOfKindDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") }.`[colsOfKind][ColumnSet.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) }`
      *
@@ -127,7 +124,7 @@ public interface ColsOfKindColumnsSelectionDsl {
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOfKind][ColumnsSelectionDsl.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -143,7 +140,7 @@ public interface ColsOfKindColumnsSelectionDsl {
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsOfKind][SingleColumn.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) }`
      */
@@ -159,7 +156,7 @@ public interface ColsOfKindColumnsSelectionDsl {
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsOfKind][SingleColumn.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) }`
      */
@@ -171,7 +168,7 @@ public interface ColsOfKindColumnsSelectionDsl {
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[colsOfKind][KProperty.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) }`
      */
@@ -183,7 +180,7 @@ public interface ColsOfKindColumnsSelectionDsl {
 
     /**
      * @include [CommonColsOfKindDocs]
-     * @set [CommonColsOfKindDocs.ExampleArg]
+     * @set [CommonColsOfKindDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[colsOfKind][ColumnPath.colsOfKind]`(`[Value][ColumnKind.Value]`, `[Frame][ColumnKind.Frame]`) }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnNameFilters.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnNameFilters.kt
@@ -35,7 +35,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      * ## (Cols) Name (Contains / StartsWith / EndsWith) Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -47,19 +47,19 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.RegexDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslNameContains]}**`(`**{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`] | `{@include [DslGrammarTemplate.RegexRef]}**`)`**
      *
      *  `| `{@include [PlainDslNameStartsEndsWith]}__`(`__{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`]`**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetNameContains]}**`(`**{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`] | `{@include [DslGrammarTemplate.RegexRef]}**`)`**
      *
      *  {@include [Indent]}`| `{@include [ColumnSetNameStartsEndsWith]}__`(`__{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`]`**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupNameContains]}**`(`**{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`] | `{@include [DslGrammarTemplate.RegexRef]}**`)`**
      *
      *  {@include [Indent]}`| `{@include [ColumnGroupNameStartsWith]}__`(`__{@include [DslGrammarTemplate.TextRef]}`[`**`, `**{@include [DslGrammarTemplate.IgnoreCaseRef]}`]`**`)`**
@@ -91,13 +91,13 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
     /**
      * ## (Cols) Name Contains
      * Returns a [ColumnSet] containing all columns from [this\] having
-     * {@get [CommonNameContainsDocs.ArgumentArg]} in their name.
+     * {@get [CommonNameContainsDocs.ARGUMENT]} in their name.
      *
      * This function operates solely on columns at the top-level.
      *
      * NOTE: For [column groups][ColumnGroup], `nameContains` is named `colsNameContains` to avoid confusion.
      *
-     * This function is a shorthand for [cols][ColumnsSelectionDsl.cols]`  {  `{@get [ArgumentArg]}{@get [ArgumentArg]}` `[in][String.contains]` it.`[name][DataColumn.name]` }`.
+     * This function is a shorthand for [cols][ColumnsSelectionDsl.cols]`  {  `{@get [ARGUMENT]}{@get [ARGUMENT]}` `[in][String.contains]` it.`[name][DataColumn.name]` }`.
      *
      * ### Check out: [Grammar]
      *
@@ -111,33 +111,34 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [ExampleArg]}
+     * {@get [EXAMPLE]}
      *
-     * @param {@get [ArgumentArg]} what the column name should contain to be included in the result.
-     * {@get [ExtraParamsArg]}
+     * @param {@get [ARGUMENT]} what the column name should contain to be included in the result.
+     * {@get [EXTRA_PARAMS]}
      * @return A [ColumnSet] containing
-     *   all columns containing {@get [CommonNameContainsDocs.ArgumentArg]} in their name.
+     *   all columns containing {@get [CommonNameContainsDocs.ARGUMENT]} in their name.
      * @see [nameEndsWith\]
      * @see [nameStartsWith\]
-     * {@set [ExtraParamsArg]}
+     * {@set [EXTRA_PARAMS]}
      */
+    @Suppress("ClassName")
     @ExcludeFromSources
     private interface CommonNameContainsDocs {
 
         // Example to give
-        interface ExampleArg
+        interface EXAMPLE
 
         // [text\] or [regex\]
-        interface ArgumentArg
+        interface ARGUMENT
 
         // Optional extra params.
-        interface ExtraParamsArg
+        interface EXTRA_PARAMS
     }
 
     /**
      * @include [CommonNameContainsDocs]
-     * @set [CommonNameContainsDocs.ArgumentArg] [text\]
-     * {@set [CommonNameContainsDocs.ExtraParamsArg]
+     * @set [CommonNameContainsDocs.ARGUMENT] [text\]
+     * {@set [CommonNameContainsDocs.EXTRA_PARAMS]
      *  @param [ignoreCase\] `true` to ignore character case when comparing strings. By default `false`.
      * }
      */
@@ -146,7 +147,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[nameContains][ColumnSet.nameContains]`("my") }`
      *
@@ -160,7 +161,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[nameContains][ColumnsSelectionDsl.colsNameContains]`("my") }`
      */
@@ -171,7 +172,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someGroupCol.`[colsNameContains][SingleColumn.colsNameContains]`("my") }`
      */
@@ -182,7 +183,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameContains][String.colsNameContains]`("my") }`
      */
@@ -191,7 +192,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someGroupCol.`[colsNameContains][KProperty.colsNameContains]`("my") }`
      */
@@ -202,7 +203,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsTextDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameContains][ColumnPath.colsNameContains]`("my") }`
      */
@@ -213,12 +214,12 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameContainsDocs]
-     * @set [CommonNameContainsDocs.ArgumentArg] [regex\] */
+     * @set [CommonNameContainsDocs.ARGUMENT] [regex\] */
     private interface NameContainsRegexDocs
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[nameContains][ColumnSet.nameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      *
@@ -230,7 +231,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[nameContains][ColumnsSelectionDsl.nameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
@@ -239,7 +240,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someGroupCol.`[colsNameContains][SingleColumn.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
@@ -248,7 +249,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameContains][String.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
@@ -257,7 +258,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someGroupCol.`[colsNameContains][KProperty.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
@@ -266,7 +267,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [NameContainsRegexDocs]
-     * @set [CommonNameContainsDocs.ExampleArg]
+     * @set [CommonNameContainsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameContains][ColumnPath.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
@@ -276,70 +277,71 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
     // endregion
 
     /**
-     * ## (Cols) Name {@get [CommonNameStartsEndsDocs.CapitalTitleArg]} With
+     * ## (Cols) Name {@get [CommonNameStartsEndsDocs.CAPITAL_TITLE]} With
      * Returns a [ColumnSet] containing all columns from [this\]
-     * {@get [CommonNameStartsEndsDocs.NounArg]} with {@get [CommonNameStartsEndsDocs.ArgumentArg]} in their name.
+     * {@get [CommonNameStartsEndsDocs.NOUN]} with {@get [CommonNameStartsEndsDocs.ARGUMENT]} in their name.
      *
      * This function operates solely on columns at the top-level.
      *
-     * NOTE: For [column groups][ColumnGroup], the function is named `{@get [CommonNameStartsEndsDocs.ColsNameOperationNameArg]}` to avoid confusion.
+     * NOTE: For [column groups][ColumnGroup], the function is named `{@get [CommonNameStartsEndsDocs.COLS_NAME_OPERATION_NAME]}` to avoid confusion.
      *
-     * This function is a shorthand for [cols][ColumnsSelectionDsl.cols]` { it.`[name][DataColumn.name]`.`[{@get [OperationNameArg]}][String.{@get [OperationNameArg]}]`(`{@get [ArgumentArg]}{@get [ArgumentArg]}`) }`.
+     * This function is a shorthand for [cols][ColumnsSelectionDsl.cols]` { it.`[name][DataColumn.name]`.`[{@get [OPERATION_NAME]}][String.{@get [OPERATION_NAME]}]`(`{@get [ARGUMENT]}{@get [ARGUMENT]}`) }`.
      *
      * ### Check out: [Grammar]
      *
      * #### For example:
      *
-     * `df.`[select][DataFrame.select]`  {  `[{@get [NameOperationNameArg]}][ColumnsSelectionDsl.{@get [NameOperationNameArg]}]`("order") }`
+     * `df.`[select][DataFrame.select]`  {  `[{@get [NAME_OPERATION_NAME]}][ColumnsSelectionDsl.{@get [NAME_OPERATION_NAME]}]`("order") }`
      *
-     * `df.`[select][DataFrame.select]` { "someGroupCol".`[{@get [ColsNameOperationNameArg]}][String.{@get [ColsNameOperationNameArg]}]`("b") }`
+     * `df.`[select][DataFrame.select]` { "someGroupCol".`[{@get [COLS_NAME_OPERATION_NAME]}][String.{@get [COLS_NAME_OPERATION_NAME]}]`("b") }`
      *
-     * `df.`[select][DataFrame.select]` { Type::someGroupCol.`[{@get [ColsNameOperationNameArg]}][SingleColumn.{@get [ColsNameOperationNameArg]}]`("a", ignoreCase = true) }`
+     * `df.`[select][DataFrame.select]` { Type::someGroupCol.`[{@get [COLS_NAME_OPERATION_NAME]}][SingleColumn.{@get [COLS_NAME_OPERATION_NAME]}]`("a", ignoreCase = true) }`
      *
      * #### Examples for this overload:
      *
-     * {@get [ExampleArg]}
+     * {@get [EXAMPLE]}
      *
-     * @param {@get [ArgumentArg]} Columns {@get [CommonNameStartsEndsDocs.NounArg]} with this {@get [CommonNameStartsEndsDocs.ArgumentArg]} in their name will be returned.
+     * @param {@get [ARGUMENT]} Columns {@get [CommonNameStartsEndsDocs.NOUN]} with this {@get [CommonNameStartsEndsDocs.ARGUMENT]} in their name will be returned.
      * @param [ignoreCase\] `true` to ignore character case when comparing strings. By default `false`.
      *
      * @return A [ColumnSet] containing
-     *   all columns {@get [CommonNameStartsEndsDocs.NounArg]} with {@get [CommonNameStartsEndsDocs.ArgumentArg]} in their name.
+     *   all columns {@get [CommonNameStartsEndsDocs.NOUN]} with {@get [CommonNameStartsEndsDocs.ARGUMENT]} in their name.
      */
+    @Suppress("ClassName")
     @ExcludeFromSources
     private interface CommonNameStartsEndsDocs {
 
         // "Starts" or "Ends"
-        interface CapitalTitleArg
+        interface CAPITAL_TITLE
 
         // "starting" or "ending"
-        interface NounArg
+        interface NOUN
 
         // "startsWith" or "endsWith"
-        interface OperationNameArg
+        interface OPERATION_NAME
 
         // "nameStartsWith" or "nameEndsWith"
-        interface NameOperationNameArg
+        interface NAME_OPERATION_NAME
 
         // "colsNameStartsWith" or "colsNameEndsWith"
-        interface ColsNameOperationNameArg
+        interface COLS_NAME_OPERATION_NAME
 
         // [prefix\] or [suffix\]
-        interface ArgumentArg
+        interface ARGUMENT
 
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     // region nameStartsWith
 
     /**
      * @include [CommonNameStartsEndsDocs]
-     * @set [CommonNameStartsEndsDocs.CapitalTitleArg] Starts
-     * @set [CommonNameStartsEndsDocs.NounArg] starting
-     * @set [CommonNameStartsEndsDocs.OperationNameArg] startsWith
-     * @set [CommonNameStartsEndsDocs.NameOperationNameArg] nameStartsWith
-     * @set [CommonNameStartsEndsDocs.ColsNameOperationNameArg] colsNameStartsWith
-     * @set [CommonNameStartsEndsDocs.ArgumentArg] [prefix\]
+     * @set [CommonNameStartsEndsDocs.CAPITAL_TITLE] Starts
+     * @set [CommonNameStartsEndsDocs.NOUN] starting
+     * @set [CommonNameStartsEndsDocs.OPERATION_NAME] startsWith
+     * @set [CommonNameStartsEndsDocs.NAME_OPERATION_NAME] nameStartsWith
+     * @set [CommonNameStartsEndsDocs.COLS_NAME_OPERATION_NAME] colsNameStartsWith
+     * @set [CommonNameStartsEndsDocs.ARGUMENT] [prefix\]
      *
      * @see [nameEndsWith\]
      * @see [nameContains\]
@@ -349,7 +351,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[nameStartsWith][ColumnSet.nameStartsWith]`("order-") }`
      */
@@ -361,7 +363,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[nameStartsWith][ColumnsSelectionDsl.nameStartsWith]`("order-") }`
      */
@@ -372,7 +374,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someGroupCol.`[colsNameStartsWith][SingleColumn.colsNameStartsWith]`("order-") }`
      */
@@ -383,7 +385,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameStartsWith][String.colsNameStartsWith]`("order-") }`
      */
@@ -394,7 +396,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someGroupCol.`[colsNameStartsWith][KProperty.colsNameStartsWith]`("order-") }`
      */
@@ -405,7 +407,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameStartsWith][ColumnPath.colsNameStartsWith]`("order-") }`
      */
@@ -420,12 +422,12 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameStartsEndsDocs]
-     * @set [CommonNameStartsEndsDocs.CapitalTitleArg] Ends
-     * @set [CommonNameStartsEndsDocs.NounArg] ending
-     * @set [CommonNameStartsEndsDocs.OperationNameArg] endsWith
-     * @set [CommonNameStartsEndsDocs.NameOperationNameArg] nameEndsWith
-     * @set [CommonNameStartsEndsDocs.ColsNameOperationNameArg] colsNameEndsWith
-     * @set [CommonNameStartsEndsDocs.ArgumentArg] [suffix\]
+     * @set [CommonNameStartsEndsDocs.CAPITAL_TITLE] Ends
+     * @set [CommonNameStartsEndsDocs.NOUN] ending
+     * @set [CommonNameStartsEndsDocs.OPERATION_NAME] endsWith
+     * @set [CommonNameStartsEndsDocs.NAME_OPERATION_NAME] nameEndsWith
+     * @set [CommonNameStartsEndsDocs.COLS_NAME_OPERATION_NAME] colsNameEndsWith
+     * @set [CommonNameStartsEndsDocs.ARGUMENT] [suffix\]
      *
      * @see [nameStartsWith\]
      * @see [nameContains\]
@@ -435,7 +437,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[nameEndsWith][ColumnSet.nameEndsWith]`("-order") }`
      */
@@ -447,7 +449,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[nameEndsWith][ColumnsSelectionDsl.nameEndsWith]`("-order") }`
      */
@@ -458,7 +460,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { someGroupCol.`[colsNameEndsWith][SingleColumn.colsNameEndsWith]`("-order") }`
      */
@@ -469,7 +471,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameEndsWith][String.colsNameEndsWith]`("-order") }`
      */
@@ -478,7 +480,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::someGroupCol.`[colsNameEndsWith][KProperty.colsNameEndsWith]`("-order") }`
      */
@@ -489,7 +491,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
 
     /**
      * @include [CommonNameEndsWithDocs]
-     * @set [CommonNameStartsEndsDocs.ExampleArg]
+     * @set [CommonNameStartsEndsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameEndsWith][ColumnPath.colsNameEndsWith]`("-order") }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnRange.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnRange.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.ColumnRangeColumnsSelectionDsl.Grammar
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.AccessApiLink
@@ -25,15 +24,15 @@ public interface ColumnRangeColumnsSelectionDsl {
      * ## Range of Columns Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [DslGrammarTemplate.ColumnRef]}` `{@include [Grammar.PlainDslName]}` `{@include [DslGrammarTemplate.ColumnRef]}
      * }
-     * {@set [DslGrammarTemplate.ColumnSetPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.COLUMN_SET_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
@@ -4,8 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
-import org.jetbrains.kotlinx.dataframe.api.DistinctColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.DistinctColumnsSelectionDsl.Grammar.ColumnSetName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -66,16 +64,16 @@ public interface DistinctColumnsSelectionDsl {
      * ## Distinct Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`()`**
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.PLAIN_DSL_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.RowFilter
+import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -81,8 +82,8 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [TakeAndDropColumnsSelectionDslGrammar]
-     * @set [TakeAndDropColumnsSelectionDslGrammar.TitleArg] Drop
-     * @set [TakeAndDropColumnsSelectionDslGrammar.OperationArg] drop
+     * @set [TakeAndDropColumnsSelectionDslGrammar.TITLE] Drop
+     * @set [TakeAndDropColumnsSelectionDslGrammar.OPERATION] drop
      */
     public interface Grammar {
 
@@ -109,16 +110,16 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropDocs]
-     * @set [CommonTakeAndDropDocs.TitleArg] Drop
-     * @set [CommonTakeAndDropDocs.OperationArg] drop
-     * @set [CommonTakeAndDropDocs.NounArg] drop
-     * @set [CommonTakeAndDropDocs.FirstOrLastArg] first
+     * @set [CommonTakeAndDropDocs.TITLE] Drop
+     * @set [CommonTakeAndDropDocs.OPERATION] drop
+     * @set [CommonTakeAndDropDocs.NOUN] drop
+     * @set [CommonTakeAndDropDocs.FIRST_OR_LAST] first
      */
     private interface CommonDropFirstDocs
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[drop][ColumnSet.drop]`(2) }`
      *
@@ -128,7 +129,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[drop][ColumnsSelectionDsl.drop]`(5) }`
      */
@@ -136,7 +137,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[dropCols][SingleColumn.dropCols]`(1) }`
      */
@@ -145,7 +146,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[dropCols][String.dropCols]`(1) }`
      */
@@ -153,7 +154,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColumnGroup.`[dropCols][KProperty.dropCols]`(1) }`
      */
@@ -161,7 +162,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[dropCols][ColumnPath.dropCols]`(1) }`
      */
@@ -173,16 +174,16 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropDocs]
-     * @set [CommonTakeAndDropDocs.TitleArg] Drop Last
-     * @set [CommonTakeAndDropDocs.OperationArg] dropLast
-     * @set [CommonTakeAndDropDocs.NounArg] drop
-     * @set [CommonTakeAndDropDocs.FirstOrLastArg] last
+     * @set [CommonTakeAndDropDocs.TITLE] Drop Last
+     * @set [CommonTakeAndDropDocs.OPERATION] dropLast
+     * @set [CommonTakeAndDropDocs.NOUN] drop
+     * @set [CommonTakeAndDropDocs.FIRST_OR_LAST] last
      */
     private interface CommonDropLastDocs
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[dropLast][ColumnSet.dropLast]`(2) }`
      *
@@ -192,7 +193,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[dropLast][ColumnsSelectionDsl.dropLast]`(5) }`
      */
@@ -200,7 +201,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[dropLastCols][SingleColumn.dropLastCols]`() }`
      */
@@ -209,7 +210,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[dropLastCols][String.dropLastCols]`(1) }`
      */
@@ -217,7 +218,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColumnGroup.`[dropLastCols][KProperty.dropLastCols]`(1) }`
      */
@@ -225,7 +226,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[dropLastCols][ColumnPath.dropLastCols]`(1) }`
      */
@@ -237,16 +238,16 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.TitleArg] Drop
-     * @set [CommonTakeAndDropWhileDocs.OperationArg] drop
-     * @set [CommonTakeAndDropWhileDocs.NounArg] drop
-     * @set [CommonTakeAndDropWhileDocs.FirstOrLastArg] first
+     * @set [CommonTakeAndDropWhileDocs.TITLE] Drop
+     * @set [CommonTakeAndDropWhileDocs.OPERATION] drop
+     * @set [CommonTakeAndDropWhileDocs.NOUN] drop
+     * @set [CommonTakeAndDropWhileDocs.FIRST_OR_LAST] first
      */
     private interface CommonDropWhileDocs
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[dropWhile][ColumnSet.dropWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -257,7 +258,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[dropWhile][ColumnsSelectionDsl.dropWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
@@ -266,7 +267,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[dropColsWhile][SingleColumn.dropColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -275,7 +276,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[dropColsWhile][String.dropColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -284,7 +285,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColumnGroup.`[dropColsWhile][KProperty.dropColsWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
@@ -293,7 +294,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[dropColsWhile][ColumnPath.dropColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -306,16 +307,16 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.TitleArg] Drop Last
-     * @set [CommonTakeAndDropWhileDocs.OperationArg] dropLast
-     * @set [CommonTakeAndDropWhileDocs.NounArg] drop
-     * @set [CommonTakeAndDropWhileDocs.FirstOrLastArg] last
+     * @set [CommonTakeAndDropWhileDocs.TITLE] Drop Last
+     * @set [CommonTakeAndDropWhileDocs.OPERATION] dropLast
+     * @set [CommonTakeAndDropWhileDocs.NOUN] drop
+     * @set [CommonTakeAndDropWhileDocs.FIRST_OR_LAST] last
      */
     private interface CommonDropLastWhileDocs
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[dropLastWhile][ColumnSet.dropLastWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -326,7 +327,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[dropLastWhile][ColumnsSelectionDsl.dropLastWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
@@ -335,7 +336,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[dropLastColsWhile][SingleColumn.dropLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -344,7 +345,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[dropLastColsWhile][String.dropLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -353,7 +354,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[dropLastColsWhile][SingleColumn.dropLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -364,7 +365,7 @@ public interface DropColumnsSelectionDsl {
 
     /**
      * @include [CommonDropLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[dropLastColsWhile][ColumnPath.dropLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
@@ -4,8 +4,6 @@ import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.ExprColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ExprColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.documentation.ColumnExpression
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
@@ -24,18 +22,18 @@ public interface ExprColumnsSelectionDsl {
      *
      * @include [DslGrammarTemplate]
      *
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.NameDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.InferDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnExpressionDef]}
      * }
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`(`**`[`{@include [DslGrammarTemplate.NameRef]}**`,`**`][`{@include [DslGrammarTemplate.InferRef]}`]`**`) { `**{@include [DslGrammarTemplate.ColumnExpressionRef]}**` \}`**
      * }
-     * {@set [DslGrammarTemplate.ColumnSetPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.COLUMN_SET_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/filter.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/filter.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.RowFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
-import org.jetbrains.kotlinx.dataframe.api.FilterColumnsSelectionDsl.Grammar.ColumnSetName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -70,18 +69,18 @@ public interface FilterColumnsSelectionDsl {
      *
      * {@include [DslGrammarTemplate]}
      *
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**` { `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.PLAIN_DSL_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
@@ -5,11 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowFilter
-import org.jetbrains.kotlinx.dataframe.api.FirstColumnsSelectionDsl.CommonFirstDocs.Examples
-import org.jetbrains.kotlinx.dataframe.api.FirstColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.FirstColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.FirstColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.FirstColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -95,7 +90,7 @@ public interface FirstColumnsSelectionDsl {
      * ## First (Col) Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -103,15 +98,15 @@ public interface FirstColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCol.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCol.kt
@@ -4,9 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.FrameColColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.FrameColColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.FrameColColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -39,7 +36,7 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
      * ## Frame Col Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -51,15 +48,15 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
      *  {@include [DslGrammarTemplate.ColumnTypeDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      */
@@ -88,7 +85,7 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
      * The function can also be called on [ColumnGroups][ColumnGroupReference] to create
      * an accessor for a frame column inside a [ColumnGroup].
      * {@include [LineBreak]}
-     * {@get [CommonFrameColDocs.Note]}
+     * {@get [CommonFrameColDocs.NOTE]}
      *
      * ### Check out: [Grammar]
      *
@@ -102,7 +99,7 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonFrameColDocs.ExampleArg]}
+     * {@get [CommonFrameColDocs.EXAMPLE]}
      *
      * To create a [ColumnAccessor] for another kind of column, take a look at the functions
      * [col][ColumnsSelectionDsl.col],
@@ -117,33 +114,32 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
      * @see [ColumnsSelectionDsl.colGroup\]
      * @see [ColumnsSelectionDsl.valueCol\]
      * @see [ColumnsSelectionDsl.col\]
-     * {@set [CommonFrameColDocs.Note]}
      */
     private interface CommonFrameColDocs {
 
         // Example argument, can be either {@include [SingleExample]} or {@include [DoubleExample]}
-        interface ExampleArg
+        interface EXAMPLE
 
         /**
-         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.ReceiverArg]}`[frameCol][frameCol]`({@get [CommonFrameColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.RECEIVER]}`[frameCol][frameCol]`({@get [CommonFrameColDocs.ARG]}) \}`
          */
         interface SingleExample
 
         /**
-         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.ReceiverArg]}`[frameCol][frameCol]`({@get [CommonFrameColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.RECEIVER]}`[frameCol][frameCol]`({@get [CommonFrameColDocs.ARG]}) \}`
          *
-         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.ReceiverArg]}`[frameCol][frameCol]`<`[String][String]`>({@get [CommonFrameColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonFrameColDocs.RECEIVER]}`[frameCol][frameCol]`<`[String][String]`>({@get [CommonFrameColDocs.ARG]}) \}`
          */
         interface DoubleExample
 
         // Receiver argument for the example(s)
-        interface ReceiverArg
+        interface RECEIVER
 
         // Argument for the example(s)
-        interface Arg
+        interface ARG
 
         // Optional note
-        interface Note
+        interface NOTE
 
         /** @param [C\] The type of the frame column. */
         interface FrameColumnTypeParam
@@ -153,21 +149,21 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonFrameColDocs]
-     * {@set [CommonFrameColDocs.Arg] frameColumnA}
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.SingleExample]}}
+     * {@set [CommonFrameColDocs.ARG] frameColumnA}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.SingleExample]}}
      * @param [col\] The [ColumnAccessor] pointing to the value column.
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     private interface FrameColReferenceDocs
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     public fun <C> frameCol(frameCol: ColumnAccessor<DataFrame<C>>): ColumnAccessor<DataFrame<C>> =
         frameCol.ensureIsFrameColumn()
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.frameCol(
         frameCol: ColumnAccessor<DataFrame<C>>,
@@ -182,26 +178,26 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.frameCol(
         frameCol: ColumnAccessor<DataFrame<C>>,
     ): ColumnAccessor<DataFrame<C>> = this.ensureIsColumnGroup().frameColumn<C>(frameCol.path()).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.frameCol(frameCol: ColumnAccessor<DataFrame<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(frameCol.path()).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.frameCol(frameCol: ColumnAccessor<DataFrame<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(frameCol.path()).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColReferenceDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.frameCol(frameCol: ColumnAccessor<DataFrame<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(frameCol.path()).ensureIsFrameColumn()
@@ -212,34 +208,34 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonFrameColDocs]
-     * {@set [CommonFrameColDocs.Arg] "frameColumnName"}
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.DoubleExample]}}
+     * {@set [CommonFrameColDocs.ARG] "frameColumnName"}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.DoubleExample]}}
      * @param [name\] The name of the value column.
      */
     private interface FrameColNameDocs
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun frameCol(name: String): ColumnAccessor<DataFrame<*>> = frameColumn<Any?>(name).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER]}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> frameCol(name: String): ColumnAccessor<DataFrame<C>> = frameColumn<C>(name).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun SingleColumn<DataRow<*>>.frameCol(name: String): SingleColumn<DataFrame<*>> = frameCol<Any?>(name)
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.frameCol(name: String): SingleColumn<DataFrame<C>> =
@@ -251,56 +247,56 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun AnyColumnGroupAccessor.frameCol(name: String): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(name)
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.frameCol(name: String): ColumnAccessor<DataFrame<C>> =
         this.ensureIsColumnGroup().frameColumn<C>(name).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun String.frameCol(name: String): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(name)
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> String.frameCol(name: String): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(name).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun KProperty<*>.frameCol(name: String): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(name)
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> KProperty<*>.frameCol(name: String): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(name).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun ColumnPath.frameCol(name: String): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(name)
 
     /**
-     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColNameDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> ColumnPath.frameCol(name: String): ColumnAccessor<DataFrame<C>> =
@@ -312,34 +308,34 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonFrameColDocs]
-     * {@set [CommonFrameColDocs.Arg] "pathTo"["frameColumnName"\] }
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.DoubleExample]}}
+     * {@set [CommonFrameColDocs.ARG] "pathTo"["frameColumnName"\] }
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.DoubleExample]}}
      * @param [path\] The path to the value column.
      */
     private interface FrameColPathDocs
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun frameCol(path: ColumnPath): ColumnAccessor<DataFrame<*>> = frameColumn<Any?>(path).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER]}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> frameCol(path: ColumnPath): ColumnAccessor<DataFrame<C>> = frameColumn<C>(path).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun SingleColumn<DataRow<*>>.frameCol(path: ColumnPath): SingleColumn<DataFrame<*>> = frameCol<Any?>(path)
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.frameCol(path: ColumnPath): SingleColumn<DataFrame<C>> =
@@ -351,56 +347,56 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun AnyColumnGroupAccessor.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(path)
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<C>> =
         this.ensureIsColumnGroup().frameColumn<C>(path).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun String.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(path)
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> String.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(path).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun KProperty<*>.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(path)
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> KProperty<*>.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn<C>(path).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun ColumnPath.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<*>> = frameCol<Any?>(path)
 
     /**
-     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColPathDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> ColumnPath.frameCol(path: ColumnPath): ColumnAccessor<DataFrame<C>> =
@@ -412,15 +408,15 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonFrameColDocs]
-     * {@set [CommonFrameColDocs.Arg] Type::frameColumnA}
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.SingleExample]}}
+     * {@set [CommonFrameColDocs.ARG] Type::frameColumnA}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.SingleExample]}}
      * @param [property\] The [KProperty] reference to the value column.
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     private interface FrameColKPropertyDocs
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -428,13 +424,13 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     public fun <C> frameCol(property: KProperty<List<C>>): SingleColumn<DataFrame<C>> =
         frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -442,13 +438,13 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         frameCol<C>(property.name)
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.frameCol(property: KProperty<List<C>>): SingleColumn<DataFrame<C>> =
         frameCol<C>(property.name)
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -456,13 +452,13 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         this.ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.frameCol(property: KProperty<List<C>>): ColumnAccessor<DataFrame<C>> =
         this.ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -470,13 +466,13 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.frameCol(property: KProperty<List<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -484,13 +480,13 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.frameCol(property: KProperty<List<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColDataFrameKProperty")
@@ -498,7 +494,7 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColKPropertyDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.frameCol(property: KProperty<List<C>>): ColumnAccessor<DataFrame<C>> =
         columnGroup(this).ensureIsColumnGroup().frameColumn(property).ensureIsFrameColumn()
@@ -509,17 +505,17 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonFrameColDocs]
-     * {@set [CommonFrameColDocs.Arg] 0}
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.DoubleExample]}}
+     * {@set [CommonFrameColDocs.ARG] 0}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.DoubleExample]}}
      * @param [index\] The index of the value column.
      * @throws [IndexOutOfBoundsException\] if the index is out of bounds.
      */
     private interface FrameColIndexDocs
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.SingleExample]}}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.SingleExample]}}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("ColumnSetDataFrameFrameColIndex")
@@ -527,36 +523,36 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
         getAt(index).ensureIsFrameColumn()
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
-     * {@set [CommonFrameColDocs.ExampleArg] {@include [CommonFrameColDocs.SingleExample]}}
+     * {@set [CommonFrameColDocs.EXAMPLE] {@include [CommonFrameColDocs.SingleExample]}}
      */
     public fun ColumnSet<*>.frameCol(index: Int): SingleColumn<DataFrame<*>> =
         getAt(index).cast<DataFrame<*>>().ensureIsFrameColumn()
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun ColumnsSelectionDsl<*>.frameCol(index: Int): SingleColumn<DataFrame<*>> = frameCol<Any?>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg]}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER]}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> ColumnsSelectionDsl<*>.frameCol(index: Int): SingleColumn<DataFrame<C>> =
         asSingleColumn().frameCol<C>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun SingleColumn<DataRow<*>>.frameCol(index: Int): SingleColumn<DataFrame<*>> = frameCol<Any?>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] myColumnGroup.}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.frameCol(index: Int): SingleColumn<DataFrame<C>> =
@@ -568,40 +564,40 @@ public interface FrameColColumnsSelectionDsl<out _UNUSED> {
             .ensureIsFrameColumn()
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun String.frameCol(index: Int): SingleColumn<DataFrame<*>> = frameCol<Any?>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> String.frameCol(index: Int): SingleColumn<DataFrame<C>> = columnGroup(this).frameCol<C>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun KProperty<*>.frameCol(index: Int): SingleColumn<DataFrame<*>> = frameCol<Any?>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> KProperty<*>.frameCol(index: Int): SingleColumn<DataFrame<C>> = columnGroup(this).frameCol<C>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("frameColUnTyped")
     public fun ColumnPath.frameCol(index: Int): SingleColumn<DataFrame<*>> = frameCol<Any?>(index)
 
     /**
-     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [FrameColIndexDocs] {@set [CommonFrameColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonFrameColDocs.FrameColumnTypeParam]
      */
     public fun <C> ColumnPath.frameCol(index: Int): SingleColumn<DataFrame<C>> = columnGroup(this).frameCol<C>(index)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCols.kt
@@ -5,9 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
-import org.jetbrains.kotlinx.dataframe.api.FrameColsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.FrameColsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.FrameColsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -34,7 +31,7 @@ public interface FrameColsColumnsSelectionDsl {
      * ## Frame Cols Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -42,15 +39,15 @@ public interface FrameColsColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */
@@ -87,7 +84,7 @@ public interface FrameColsColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonFrameColsDocs.ExampleArg]}
+     * {@get [CommonFrameColsDocs.EXAMPLE]}
      *
      * @param [filter\] An optional [predicate][Predicate] to filter the frame columns by.
      * @return A [ColumnSet] of [FrameColumns][FrameColumn].
@@ -99,12 +96,12 @@ public interface FrameColsColumnsSelectionDsl {
     private interface CommonFrameColsDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") }.`[frameCols][ColumnSet.frameCols]`() }`
      *
@@ -119,7 +116,7 @@ public interface FrameColsColumnsSelectionDsl {
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[frameCols][ColumnsSelectionDsl.frameCols]`() }`
      *
@@ -131,7 +128,7 @@ public interface FrameColsColumnsSelectionDsl {
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColGroup.`[frameCols][SingleColumn.frameCols]`() }`
      *
@@ -143,7 +140,7 @@ public interface FrameColsColumnsSelectionDsl {
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[frameCols][String.frameCols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -154,7 +151,7 @@ public interface FrameColsColumnsSelectionDsl {
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colGroup][ColumnsSelectionDsl.colGroup]`(Type::myColGroup).`[frameCols][SingleColumn.frameCols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -168,7 +165,7 @@ public interface FrameColsColumnsSelectionDsl {
 
     /**
      * @include [CommonFrameColsDocs]
-     * @set [CommonFrameColsDocs.ExampleArg]
+     * @set [CommonFrameColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[frameCols][ColumnPath.frameCols]`() }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
@@ -5,11 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowFilter
-import org.jetbrains.kotlinx.dataframe.api.LastColumnsSelectionDsl.CommonLastDocs.Examples
-import org.jetbrains.kotlinx.dataframe.api.LastColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.LastColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.LastColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.LastColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -95,7 +90,7 @@ public interface LastColumnsSelectionDsl {
      * ## Last (Col) Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -103,15 +98,15 @@ public interface LastColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/none.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/none.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.NoneColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
@@ -21,12 +20,12 @@ public interface NoneColumnsSelectionDsl {
      *
      * @include [DslGrammarTemplate]
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`()`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.COLUMN_SET_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -7,13 +7,6 @@ import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.CommonRenameDocs.ParamNameArg
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.CommonRenameDocs.ParamTypeArg
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.CommonRenameDocs.ReceiverTypeArg
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.Grammar.InfixIntoName
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.Grammar.InfixNamedName
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.Grammar.IntoName
-import org.jetbrains.kotlinx.dataframe.api.RenameColumnsSelectionDsl.Grammar.NamedName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -133,11 +126,11 @@ public interface RenameColumnsSelectionDsl {
      * ## Rename: `named` / `into` Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [DslGrammarTemplate.ColumnRef]}` `{@include [InfixNamedName]}`/`{@include [InfixIntoName]}` `{@include [DslGrammarTemplate.ColumnRef]}
      *
      *  `| `{@include [DslGrammarTemplate.ColumnRef]}{@include [NamedName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`)`**
@@ -145,8 +138,8 @@ public interface RenameColumnsSelectionDsl {
      *  `| `{@include [DslGrammarTemplate.ColumnRef]}{@include [IntoName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
-     * {@set [DslGrammarTemplate.ColumnSetPart]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_SET_PART]}
      */
     public interface Grammar {
 
@@ -182,71 +175,72 @@ public interface RenameColumnsSelectionDsl {
      *
      * #### Example for this overload:
      *
-     * `df.`[select][DataFrame.select]`  { {@get [CommonRenameDocs.ReceiverArg]}  `[{@get [CommonRenameDocs.FunctionNameArg]}][{@get [CommonRenameDocs.ReceiverTypeArg]}.{@get [CommonRenameDocs.FunctionNameArg]}]` {@get [CommonRenameDocs.ParamArg]} }`
+     * `df.`[select][DataFrame.select]`  { {@get [CommonRenameDocs.RECEIVER]}  `[{@get [CommonRenameDocs.FUNCTION_NAME]}][{@get [CommonRenameDocs.RECEIVER_TYPE]}.{@get [CommonRenameDocs.FUNCTION_NAME]}]` {@get [CommonRenameDocs.PARAM]} }`
      *
-     * @receiver The [{@get [ReceiverTypeArg]}] referencing the column to rename.
-     * @param [{@get [ParamNameArg]}\] A [{@get [ParamTypeArg]}\] used to specify the new name of the column.
+     * @receiver The [{@get [RECEIVER_TYPE]}] referencing the column to rename.
+     * @param [{@get [PARAM_NAME]}\] A [{@get [PARAM_TYPE]}\] used to specify the new name of the column.
      * @return A [ColumnReference] to the renamed column.
      */
+    @Suppress("ClassName")
     private interface CommonRenameDocs {
 
-        interface ReceiverArg
+        interface RECEIVER
 
-        interface ReceiverTypeArg
+        interface RECEIVER_TYPE
 
         /** "named" or "into" */
-        interface FunctionNameArg
+        interface FUNCTION_NAME
 
         /** "newName" or "nameOf" */
-        interface ParamNameArg
+        interface PARAM_NAME
 
-        interface ParamArg
+        interface PARAM
 
-        interface ParamTypeArg
+        interface PARAM_TYPE
 
         /**
-         * @set [ReceiverArg] columnA
-         * @set [ReceiverTypeArg] ColumnReference
+         * @set [RECEIVER] columnA
+         * @set [RECEIVER_TYPE] ColumnReference
          */
         interface ColumnReferenceReceiver
 
         /**
-         * @set [ReceiverArg] "columnA"
-         * @set [ReceiverTypeArg] String
+         * @set [RECEIVER] "columnA"
+         * @set [RECEIVER_TYPE] String
          */
         interface StringReceiver
 
         /**
-         * @set [ReceiverArg] Type::columnA
-         * @set [ReceiverTypeArg] KProperty
+         * @set [RECEIVER] Type::columnA
+         * @set [RECEIVER_TYPE] KProperty
          */
         interface KPropertyReceiver
 
         /**
-         * @set [ParamArg] columnB
-         * @set [ParamNameArg] nameOf
-         * @set [ParamTypeArg] ColumnReference
+         * @set [PARAM] columnB
+         * @set [PARAM_NAME] nameOf
+         * @set [PARAM_TYPE] ColumnReference
          */
         interface ColumnReferenceParam
 
         /**
-         * @set [ParamArg] "columnB"
-         * @set [ParamNameArg] newName
-         * @set [ParamTypeArg] String
+         * @set [PARAM] "columnB"
+         * @set [PARAM_NAME] newName
+         * @set [PARAM_TYPE] String
          */
         interface StringParam
 
         /**
-         * @set [ParamArg] Type::columnB
-         * @set [ParamNameArg] nameOf
-         * @set [ParamTypeArg] KProperty
+         * @set [PARAM] Type::columnB
+         * @set [PARAM_NAME] nameOf
+         * @set [PARAM_TYPE] KProperty
          */
         interface KPropertyParam
 
-        /** @set [CommonRenameDocs.FunctionNameArg] named */
+        /** @set [CommonRenameDocs.FUNCTION_NAME] named */
         interface NamedFunctionName
 
-        /** @set [CommonRenameDocs.FunctionNameArg] into */
+        /** @set [CommonRenameDocs.FUNCTION_NAME] into */
         interface IntoFunctionName
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
@@ -8,9 +8,6 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.api.Select.SelectSelectingOptions
-import org.jetbrains.kotlinx.dataframe.api.SelectColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.SelectColumnsSelectionDsl.Grammar.ColumnGroupName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -32,7 +29,7 @@ import kotlin.reflect.KProperty
 /**
  * ## The Select Operation
  *
- * Returns a new [DataFrame] with only the columns selected by [columns].
+ * Returns a new [DataFrame] with only the columns selected by [columns\].
  *
  * See [Selecting Columns][SelectSelectingOptions].
  *
@@ -47,7 +44,7 @@ internal interface Select {
     interface SelectSelectingOptions
 }
 
-/** {@set [SelectingColumns.OperationArg] [select][select]} */
+/** {@set [SelectingColumns.OPERATION] [select][select]} */
 @ExcludeFromSources
 private interface SetSelectOperationArg
 
@@ -106,7 +103,7 @@ public interface SelectColumnsSelectionDsl {
      * ## Select from [ColumnGroup] Grammar
      * {@include [DslGrammarTemplate]}
      *
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -114,13 +111,13 @@ public interface SelectColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ColumnsSelectorDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`  {  `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**` \}`**
      *
      *  {@include [Indent]}`| `[**`{`**][ColumnsSelectionDsl.select]` `{@include [DslGrammarTemplate.ColumnsSelectorRef]}` `[**`\}`**][ColumnsSelectionDsl.select]
      * }
-     * {@set [DslGrammarTemplate.PlainDslPart]}
-     * {@set [DslGrammarTemplate.ColumnSetPart]}
+     * {@set [DslGrammarTemplate.PLAIN_DSL_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_SET_PART]}
      */
     public interface Grammar {
 
@@ -154,7 +151,7 @@ public interface SelectColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonSelectDocs.ExampleArg]}
+     * {@get [CommonSelectDocs.EXAMPLE]}
      *
      * {@include [LineBreak]}
      *
@@ -168,12 +165,12 @@ public interface SelectColumnsSelectionDsl {
      */
     private interface CommonSelectDocs {
 
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonSelectDocs]
-     * @set [CommonSelectDocs.ExampleArg]
+     * @set [CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColGroup.`[select][SingleColumn.select]`  { someCol  `[and][ColumnsSelectionDsl.and]` `[colsOf][SingleColumn.colsOf]`<`[String][String]`>() } }`
      *
@@ -184,7 +181,7 @@ public interface SelectColumnsSelectionDsl {
 
     /**
      * @include [CommonSelectDocs]
-     * @set [CommonSelectDocs.ExampleArg]
+     * @set [CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColGroup.`[select][KProperty.select]`  { someCol  `[and][ColumnsSelectionDsl.and]` `[colsOf][SingleColumn.colsOf]`<`[String][String]`>() } }`
      *
@@ -195,7 +192,7 @@ public interface SelectColumnsSelectionDsl {
 
     /**
      * @include [SelectColumnsSelectionDsl.CommonSelectDocs]
-     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.ExampleArg]
+     * @set [SelectColumnsSelectionDsl.CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[select][String.select]`  { someCol  `[and][ColumnsSelectionDsl.and]` `[colsOf][SingleColumn.colsOf]`<`[String][String]`>() } }`
      *
@@ -205,7 +202,7 @@ public interface SelectColumnsSelectionDsl {
 
     /**
      * @include [CommonSelectDocs]
-     * @set [CommonSelectDocs.ExampleArg]
+     * @set [CommonSelectDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColGroup"].`[select][ColumnPath.select]`  { someCol  `[and][ColumnsSelectionDsl.and]` `[colsOf][SingleColumn.colsOf]`<`[String][String]`>() } }`
      *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/simplify.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/simplify.kt
@@ -2,8 +2,6 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.SimplifyColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.SimplifyColumnsSelectionDsl.Grammar.ColumnSetName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
@@ -25,16 +23,16 @@ public interface SimplifyColumnsSelectionDsl {
      * ## Simplify [ColumnSet] Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`()`**
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslPart]}
-     * {@set [DslGrammarTemplate.ColumnGroupPart]}
+     * {@set [DslGrammarTemplate.PLAIN_DSL_PART]}
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_PART]}
      */
     public interface Grammar {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
@@ -5,11 +5,6 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
-import org.jetbrains.kotlinx.dataframe.api.SingleColumnsSelectionDsl.CommonSingleDocs.Examples
-import org.jetbrains.kotlinx.dataframe.api.SingleColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.SingleColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.SingleColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.SingleColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -65,7 +60,7 @@ public interface SingleColumnsSelectionDsl {
      * ## Single (Col) Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -73,15 +68,15 @@ public interface SingleColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/take.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/take.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowFilter
+import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -73,8 +74,8 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [TakeAndDropColumnsSelectionDslGrammar]
-     * @set [TakeAndDropColumnsSelectionDslGrammar.TitleArg] Take
-     * @set [TakeAndDropColumnsSelectionDslGrammar.OperationArg] take
+     * @set [TakeAndDropColumnsSelectionDslGrammar.TITLE] Take
+     * @set [TakeAndDropColumnsSelectionDslGrammar.OPERATION] take
      */
     public interface Grammar {
 
@@ -101,16 +102,16 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropDocs]
-     * @set [CommonTakeAndDropDocs.TitleArg] Take
-     * @set [CommonTakeAndDropDocs.OperationArg] take
-     * @set [CommonTakeAndDropDocs.NounArg] take
-     * @set [CommonTakeAndDropDocs.FirstOrLastArg] first
+     * @set [CommonTakeAndDropDocs.TITLE] Take
+     * @set [CommonTakeAndDropDocs.OPERATION] take
+     * @set [CommonTakeAndDropDocs.NOUN] take
+     * @set [CommonTakeAndDropDocs.FIRST_OR_LAST] first
      */
     private interface CommonTakeFirstDocs
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[take][ColumnSet.take]`(2) }`
      *
@@ -120,7 +121,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[take][ColumnsSelectionDsl.take]`(5) }`
      */
@@ -128,7 +129,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[takeCols][SingleColumn.takeCols]`(1) }`
      */
@@ -137,7 +138,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[takeCols][String.takeCols]`(1) }`
      */
@@ -145,7 +146,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[takeCols][SingleColumn.takeCols]`(1) }`
      *
@@ -155,7 +156,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[takeCols][ColumnPath.takeCols]`(1) }`
      */
@@ -167,16 +168,16 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropDocs]
-     * @set [CommonTakeAndDropDocs.TitleArg] Take Last
-     * @set [CommonTakeAndDropDocs.OperationArg] takeLast
-     * @set [CommonTakeAndDropDocs.NounArg] take
-     * @set [CommonTakeAndDropDocs.FirstOrLastArg] last
+     * @set [CommonTakeAndDropDocs.TITLE] Take Last
+     * @set [CommonTakeAndDropDocs.OPERATION] takeLast
+     * @set [CommonTakeAndDropDocs.NOUN] take
+     * @set [CommonTakeAndDropDocs.FIRST_OR_LAST] last
      */
     private interface CommonTakeLastDocs
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[takeLast][ColumnSet.takeLast]`(2) }`
      *
@@ -186,7 +187,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[takeLast][ColumnsSelectionDsl.takeLast]`(5) }`
      */
@@ -194,7 +195,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[takeLast][SingleColumn.takeLastCols]`(1) }`
      */
@@ -203,7 +204,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[takeLastCols][String.takeLastCols]`(1) }`
      */
@@ -211,7 +212,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[takeLastCols][SingleColumn.takeLastCols]`(1) }`
      *
@@ -221,7 +222,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastDocs]
-     * @set [CommonTakeAndDropDocs.ExampleArg]
+     * @set [CommonTakeAndDropDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[takeLastCols][ColumnPath.takeLastCols]`(1) }`
      */
@@ -233,16 +234,16 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.TitleArg] Take
-     * @set [CommonTakeAndDropWhileDocs.OperationArg] take
-     * @set [CommonTakeAndDropWhileDocs.NounArg] take
-     * @set [CommonTakeAndDropWhileDocs.FirstOrLastArg] first
+     * @set [CommonTakeAndDropWhileDocs.TITLE] Take
+     * @set [CommonTakeAndDropWhileDocs.OPERATION] take
+     * @set [CommonTakeAndDropWhileDocs.NOUN] take
+     * @set [CommonTakeAndDropWhileDocs.FIRST_OR_LAST] first
      */
     private interface CommonTakeFirstWhileDocs
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[takeWhile][ColumnSet.takeWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -253,7 +254,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[takeWhile][ColumnsSelectionDsl.takeWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
@@ -262,7 +263,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[takeWhile][SingleColumn.takeColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -271,7 +272,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[takeColsWhile][String.takeColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -280,7 +281,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[takeColsWhile][SingleColumn.takeColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -291,7 +292,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeFirstWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[takeColsWhile][ColumnPath.takeColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -304,16 +305,16 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeAndDropWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.TitleArg] Take Last
-     * @set [CommonTakeAndDropWhileDocs.OperationArg] takeLast
-     * @set [CommonTakeAndDropWhileDocs.NounArg] take
-     * @set [CommonTakeAndDropWhileDocs.FirstOrLastArg] last
+     * @set [CommonTakeAndDropWhileDocs.TITLE] Take Last
+     * @set [CommonTakeAndDropWhileDocs.OPERATION] takeLast
+     * @set [CommonTakeAndDropWhileDocs.NOUN] take
+     * @set [CommonTakeAndDropWhileDocs.FIRST_OR_LAST] last
      */
     private interface CommonTakeLastWhileDocs
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().`[takeLastWhile][ColumnSet.takeLastWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -324,7 +325,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[takeLastWhile][ColumnsSelectionDsl.takeLastWhile]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
@@ -333,7 +334,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[takeLastColsWhile][SingleColumn.takeLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -342,7 +343,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[takeLastColsWhile][String.takeLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
@@ -351,7 +352,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[takeLastColsWhile][SingleColumn.takeLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      *
@@ -362,7 +363,7 @@ public interface TakeColumnsSelectionDsl {
 
     /**
      * @include [CommonTakeLastWhileDocs]
-     * @set [CommonTakeAndDropWhileDocs.ExampleArg]
+     * @set [CommonTakeAndDropWhileDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[takeLastColsWhile][ColumnPath.takeLastColsWhile]` { it.`[name][ColumnWithPath.name]`.`[startsWith][String.startsWith]`("my") } }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dataframe.RowValueFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.api.Update.Grammar
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -59,16 +58,17 @@ public class Update<T, C>(
      * This argument providing the (clickable) name of the update-like function.
      * Note: If clickable, make sure to [alias][your type].
      */
+    @Suppress("ClassName")
     @ExcludeFromSources
-    internal interface UpdateOperationArg
+    internal interface UPDATE_OPERATION
 
     /**
-     * ## {@get [UpdateOperationArg]} Operation Grammar
+     * ## {@get [UPDATE_OPERATION]} Operation Grammar
      * {@include [LineBreak]}
      * {@include [DslGrammarLink]}
      * {@include [LineBreak]}
      *
-     * {@get [UpdateOperationArg]}**`  {  `**[`columns`][SelectingColumns]**` }`**
+     * {@get [UPDATE_OPERATION]}**`  {  `**[`columns`][SelectingColumns]**` }`**
      *
      * {@include [Indent]}
      * `\[ `__`.`__[**`where`**][Update.where]**`  {  `**[`rowValueCondition`][SelectingRows.RowValueCondition.WithExample]**`  }  `**`]`
@@ -97,18 +97,19 @@ public class Update<T, C>(
      * {@include [Indent]}
      * `| `__`.`__[**`asFrame`**][Update.asFrame]**`  {  `**[`dataFrameExpression`][ExpressionsGivenDataFrame.DataFrameExpression.WithExample]**` }`**
      *
-     * {@set [UpdateOperationArg] [**`update`**][update]}{@comment The default name of the `update` operation function name.}
+     * {@set [UPDATE_OPERATION] [**`update`**][update]}{@comment The default name of the `update` operation function name.}
      */
     public interface Grammar
 
     /**
-     * The columns to update need to be selected. See {@get [Columns.SelectingColumnsArg]}
-     * for all the selecting options. {@set [Columns.SelectingColumnsArg] [Selecting Columns][UpdateSelectingOptions]}
+     * The columns to update need to be selected. See {@get [Columns.SELECTING_COLUMNS]}
+     * for all the selecting options. {@set [Columns.SELECTING_COLUMNS] [Selecting Columns][UpdateSelectingOptions]}
      */
     public interface Columns {
 
         // Optional argument that can be set to redirect where the [Selecting Columns] link points to
-        public interface SelectingColumnsArg
+        @Suppress("ClassName")
+        public interface SELECTING_COLUMNS
     }
 
     /**
@@ -134,7 +135,7 @@ public class Update<T, C>(
 
 // region update
 
-/** {@set [SelectingColumns.OperationArg] [update][update]} */
+/** {@set [SelectingColumns.OPERATION] [update][update]} */
 @ExcludeFromSources
 private interface SetSelectingColumnsOperationArg
 
@@ -194,8 +195,8 @@ public fun <T, C> DataFrame<T>.update(vararg columns: ColumnReference<C>): Updat
 
 /** ## Where
  * @include [SelectingRows.RowValueCondition.WithExample]
- * {@set [SelectingRows.FirstOperationArg] [update][update]}
- * {@set [SelectingRows.SecondOperationArg] [where][where]}
+ * {@set [SelectingRows.FIRST_OPERATION] [update][update]}
+ * {@set [SelectingRows.SECOND_OPERATION] [where][where]}
  *
  * @param [predicate] The [row value filter][RowValueFilter] to select the rows to update.
  */
@@ -251,7 +252,7 @@ public fun <T, C> Update<T, C>.at(rowRange: IntRange): Update<T, C> = where { in
 
 /** ## Per Row Col
  * @include [ExpressionsGivenRowAndColumn.RowColumnExpression.WithExample]
- * {@set [ExpressionsGivenRowAndColumn.OperationArg] [update][update]` { age \}.`[perRowCol][perRowCol]}
+ * {@set [ExpressionsGivenRowAndColumn.OPERATION] [update][update]` { age \}.`[perRowCol][perRowCol]}
  *
  * ## See Also
  *  - {@include [SeeAlsoWith]}
@@ -274,7 +275,7 @@ public typealias UpdateExpression<T, C, R> = AddDataRow<T>.(C) -> R
 
 /** ## With
  * {@include [ExpressionsGivenRow.RowValueExpression.WithExample]}
- * {@set [ExpressionsGivenRow.OperationArg] [update][update]` { city \}.`[with][with]}
+ * {@set [ExpressionsGivenRow.OPERATION] [update][update]` { city \}.`[with][with]}
  *
  * ## Note
  * @include [ExpressionsGivenRow.AddDataRowNote]
@@ -299,7 +300,7 @@ private interface SeeAlsoWith
  * Updates selected [column group][ColumnGroup] as a [DataFrame] with the given [expression].
  *
  * {@include [ExpressionsGivenDataFrame.DataFrameExpression.WithExample]}
- * {@set [ExpressionsGivenDataFrame.OperationArg] `df.`[update][update]` { name \}.`[asFrame][asFrame]}
+ * {@set [ExpressionsGivenDataFrame.OPERATION] `df.`[update][update]` { name \}.`[asFrame][asFrame]}
  * @param [expression] The {@include [ExpressionsGivenDataFrame.DataFrameExpressionLink]} to replace the selected column group with.
  */
 public fun <T, C, R> Update<T, DataRow<C>>.asFrame(expression: DataFrameExpression<C, DataFrame<R>>): DataFrame<T> =
@@ -368,7 +369,7 @@ public fun <T, C> Update<T, C>.perCol(values: AnyRow): DataFrame<T> = perCol(val
 /**
  * @include [CommonUpdatePerColDoc]
  * @include [ExpressionsGivenColumn.ColumnExpression.WithExample]
- * {@set [ExpressionsGivenColumn.OperationArg] [update][update]` { age \}.`[perCol][perCol]}
+ * {@set [ExpressionsGivenColumn.OPERATION] [update][update]` { age \}.`[perCol][perCol]}
  *
  * @param [valueSelector] The {@include [ExpressionsGivenColumn.ColumnExpressionLink]} to provide a new value for every selected cell giving its column.
  */
@@ -420,7 +421,7 @@ public fun <T, C> Update<T, C?>.notNull(expression: UpdateExpression<T, C, C>): 
  * @include [SelectingColumns.ColumnAccessors]
  *
  * {@include [ExpressionsGivenRow.RowValueExpression.WithExample]}
- * {@set [ExpressionsGivenRow.OperationArg] [update][update]<code>`("city")`</code>}
+ * {@set [ExpressionsGivenRow.OPERATION] [update][update]<code>`("city")`</code>}
  *
  * @include [Update.ColumnAccessorsParam]
  * @param [expression] The {@include [ExpressionsGivenRow.RowValueExpressionLink]} to update the rows with.
@@ -439,7 +440,7 @@ public fun <T, C> DataFrame<T>.update(
  * @include [SelectingColumns.KProperties]
  *
  * {@include [ExpressionsGivenRow.RowValueExpression.WithExample]}
- * {@set [ExpressionsGivenRow.OperationArg] [update][update]<code>`("city")`</code>}
+ * {@set [ExpressionsGivenRow.OPERATION] [update][update]<code>`("city")`</code>}
  *
  * @include [Update.KPropertiesParam]
  * @param [expression] The {@include [ExpressionsGivenRow.RowValueExpressionLink]} to update the rows with.
@@ -458,7 +459,7 @@ public fun <T, C> DataFrame<T>.update(
  * @include [SelectingColumns.ColumnNames]
  *
  * {@include [ExpressionsGivenRow.RowValueExpression.WithExample]}
- * {@set [ExpressionsGivenRow.OperationArg] [update][update]<code>`("city")`</code>}
+ * {@set [ExpressionsGivenRow.OPERATION] [update][update]<code>`("city")`</code>}
  *
  * @include [Update.ColumnNamesParam]
  * @param [expression] The {@include [ExpressionsGivenRow.RowValueExpressionLink]} to update the rows with.
@@ -470,34 +471,34 @@ public fun <T> DataFrame<T>.update(
 ): DataFrame<T> = update(*headPlusArray(firstCol, cols)).with(expression)
 
 /**
- * Specific version of [with] that simply sets the value of each selected row to {@get [FirstArg]}.
+ * Specific version of [with] that simply sets the value of each selected row to {@get [FIRST]}.
  *
  * For example:
  *
- * `df.`[update][update]` { id }.`[where][Update.where]` { it < 0 }.`{@get [SecondArg]}`
+ * `df.`[update][update]` { id }.`[where][Update.where]` { it < 0 }.`{@get [SECOND]}`
  */
 @ExcludeFromSources
 private interface CommonSpecificWithDoc {
 
     /** Arg for the resulting value */
-    private interface FirstArg
+    private interface FIRST
 
     /** Arg for the function call */
-    private interface SecondArg
+    private interface SECOND
 }
 
 /**
  * ## With Null
  * @include [CommonSpecificWithDoc]
- * {@set [CommonSpecificWithDoc.FirstArg] `null`}
- * {@set [CommonSpecificWithDoc.SecondArg] [withNull][withNull]`()}
+ * {@set [CommonSpecificWithDoc.FIRST] `null`}
+ * {@set [CommonSpecificWithDoc.SECOND] [withNull][withNull]`()}
  */
 public fun <T, C> Update<T, C>.withNull(): DataFrame<T> = with { null }
 
 /**
  * ## With Zero
  * @include [CommonSpecificWithDoc]
- * {@set [CommonSpecificWithDoc.FirstArg] `0`}
- * {@set [CommonSpecificWithDoc.SecondArg] [withZero][withZero]`()}
+ * {@set [CommonSpecificWithDoc.FIRST] `0`}
+ * {@set [CommonSpecificWithDoc.SECOND] [withZero][withZero]`()}
  */
 public fun <T, C> Update<T, C>.withZero(): DataFrame<T> = updateWithValuePerColumnImpl { 0 as C }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCol.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCol.kt
@@ -4,10 +4,6 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.ValueColColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.ValueColColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ValueColColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ValueColColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -40,7 +36,7 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
      * ## Value Col Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -52,15 +48,15 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
      *  {@include [DslGrammarTemplate.ColumnTypeDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`[`**`<`**{@include [DslGrammarTemplate.ColumnTypeRef]}**`>`**`]`**`(`**{@include [DslGrammarTemplate.ColumnRef]}`  |  `{@include [DslGrammarTemplate.IndexRef]}**`)`**
      * }
      */
@@ -89,7 +85,7 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
      * The function can also be called on [ColumnGroups][ColumnGroupReference] to create
      * an accessor for a value column inside a [ColumnGroup].
      * {@include [LineBreak]}
-     * {@get [CommonValueColDocs.Note]}
+     * {@get [CommonValueColDocs.NOTE]}
      *
      * ### Check out: [Grammar]
      *
@@ -103,7 +99,7 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonValueColDocs.ExampleArg]}
+     * {@get [CommonValueColDocs.EXAMPLE]}
      *
      * To create a [ColumnAccessor] for another kind of column, take a look at the functions
      * [col][ColumnsSelectionDsl.col],
@@ -118,33 +114,32 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
      * @see [ColumnsSelectionDsl.colGroup\]
      * @see [ColumnsSelectionDsl.frameCol\]
      * @see [ColumnsSelectionDsl.col\]
-     * {@set [CommonValueColDocs.Note]}
      */
     private interface CommonValueColDocs {
 
         // Example argument, can be either {@include [SingleExample]} or {@include [DoubleExample]}
-        interface ExampleArg
+        interface EXAMPLE
 
         /**
-         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.ReceiverArg]}`[valueCol][valueCol]`({@get [CommonValueColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.RECEIVER]}`[valueCol][valueCol]`({@get [CommonValueColDocs.ARG]}) \}`
          */
         interface SingleExample
 
         /**
-         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.ReceiverArg]}`[valueCol][valueCol]`({@get [CommonValueColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.RECEIVER]}`[valueCol][valueCol]`({@get [CommonValueColDocs.ARG]}) \}`
          *
-         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.ReceiverArg]}`[valueCol][valueCol]`<`[String][String]`>({@get [CommonValueColDocs.Arg]}) \}`
+         * `df.`[select][DataFrame.select]` { {@get [CommonValueColDocs.RECEIVER]}`[valueCol][valueCol]`<`[String][String]`>({@get [CommonValueColDocs.ARG]}) \}`
          */
         interface DoubleExample
 
         // Receiver argument for the example(s)
-        interface ReceiverArg
+        interface RECEIVER
 
         // Argument for the example(s)
-        interface Arg
+        interface ARG
 
         // Optional note
-        interface Note
+        interface NOTE
 
         /** @param [C\] The type of the value column. */
         interface ValueColumnTypeParam
@@ -154,20 +149,20 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonValueColDocs]
-     * {@set [CommonValueColDocs.Arg] valueColumnA}
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.SingleExample]}}
+     * {@set [CommonValueColDocs.ARG] valueColumnA}
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.SingleExample]}}
      * @param [col\] The [ColumnAccessor] pointing to the value column.
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     private interface ValueColReferenceDocs
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER]}
      */
     public fun <C> valueCol(valueCol: ColumnAccessor<C>): ColumnAccessor<C> = valueCol.ensureIsValueColumn()
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.valueCol(valueCol: ColumnAccessor<C>): SingleColumn<C> =
         this.ensureIsColumnGroup().transformSingle {
@@ -180,25 +175,25 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.valueCol(valueCol: ColumnAccessor<C>): ColumnAccessor<C> =
         this.ensureIsColumnGroup().valueColumn<C>(valueCol.path()).ensureIsValueColumn()
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.valueCol(valueCol: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(valueCol.path()).ensureIsValueColumn()
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.valueCol(valueCol: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(valueCol.path()).ensureIsValueColumn()
 
     /**
-     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColReferenceDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.valueCol(valueCol: ColumnAccessor<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(valueCol.path()).ensureIsValueColumn()
@@ -209,34 +204,34 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonValueColDocs]
-     * {@set [CommonValueColDocs.Arg] "valueColumnName"}
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.DoubleExample]}}
+     * {@set [CommonValueColDocs.ARG] "valueColumnName"}
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.DoubleExample]}}
      * @param [name\] The name of the value column.
      */
     private interface ValueColNameDocs
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun valueCol(name: String): ColumnAccessor<*> = valueColumn<Any?>(name).ensureIsValueColumn()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER]}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> valueCol(name: String): ColumnAccessor<C> = valueColumn<C>(name).ensureIsValueColumn()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun SingleColumn<DataRow<*>>.valueCol(name: String): SingleColumn<*> = valueCol<Any?>(name)
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.valueCol(name: String): SingleColumn<C> =
@@ -248,56 +243,56 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun AnyColumnGroupAccessor.valueCol(name: String): ColumnAccessor<*> = valueCol<Any?>(name)
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.valueCol(name: String): ColumnAccessor<C> =
         this.ensureIsColumnGroup().valueColumn<C>(name).ensureIsValueColumn()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun String.valueCol(name: String): ColumnAccessor<*> = valueCol<Any?>(name)
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> String.valueCol(name: String): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(name).ensureIsValueColumn()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun KProperty<*>.valueCol(name: String): ColumnAccessor<*> = valueCol<Any?>(name)
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> KProperty<*>.valueCol(name: String): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(name).ensureIsValueColumn()
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun ColumnPath.valueCol(name: String): ColumnAccessor<*> = valueCol<Any?>(name)
 
     /**
-     * @include [ValueColNameDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColNameDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> ColumnPath.valueCol(name: String): ColumnAccessor<C> =
@@ -309,34 +304,34 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonValueColDocs]
-     * {@set [CommonValueColDocs.Arg] "pathTo"["valueColumnName"\] }
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.DoubleExample]}}
+     * {@set [CommonValueColDocs.ARG] "pathTo"["valueColumnName"\] }
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.DoubleExample]}}
      * @param [path\] The path to the value column.
      */
     private interface ValueColPathDocs
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun valueCol(path: ColumnPath): ColumnAccessor<*> = valueColumn<Any?>(path).ensureIsValueColumn()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER]}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> valueCol(path: ColumnPath): ColumnAccessor<C> = valueColumn<C>(path).ensureIsValueColumn()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun SingleColumn<DataRow<*>>.valueCol(path: ColumnPath): SingleColumn<*> = valueCol<Any?>(path)
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.valueCol(path: ColumnPath): SingleColumn<C> =
@@ -348,56 +343,56 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
         }.singleImpl()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun AnyColumnGroupAccessor.valueCol(path: ColumnPath): ColumnAccessor<*> = valueCol<Any?>(path)
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> AnyColumnGroupAccessor.valueCol(path: ColumnPath): ColumnAccessor<C> =
         this.ensureIsColumnGroup().valueColumn<C>(path).ensureIsValueColumn()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun String.valueCol(path: ColumnPath): ColumnAccessor<*> = valueCol<Any?>(path)
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> String.valueCol(path: ColumnPath): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(path).ensureIsValueColumn()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun KProperty<*>.valueCol(path: ColumnPath): ColumnAccessor<*> = valueCol<Any?>(path)
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> KProperty<*>.valueCol(path: ColumnPath): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn<C>(path).ensureIsValueColumn()
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun ColumnPath.valueCol(path: ColumnPath): ColumnAccessor<*> = valueCol<Any?>(path)
 
     /**
-     * @include [ValueColPathDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColPathDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> ColumnPath.valueCol(path: ColumnPath): ColumnAccessor<C> =
@@ -409,44 +404,44 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonValueColDocs]
-     * {@set [CommonValueColDocs.Arg] Type::valueColumnA}
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.SingleExample]}}
+     * {@set [CommonValueColDocs.ARG] Type::valueColumnA}
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.SingleExample]}}
      * @param [property\] The [KProperty] reference to the value column.
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     private interface ValueColKPropertyDocs
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER]}
      */
     public fun <C> valueCol(property: KProperty<C>): SingleColumn<C> = valueColumn(property).ensureIsValueColumn()
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> SingleColumn<DataRow<*>>.valueCol(property: KProperty<C>): SingleColumn<C> =
         valueCol<C>(property.name)
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     public fun <C> AnyColumnGroupAccessor.valueCol(property: KProperty<C>): ColumnAccessor<C> =
         this.ensureIsColumnGroup().valueColumn(property).ensureIsValueColumn()
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      */
     public fun <C> String.valueCol(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn(property).ensureIsValueColumn()
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      */
     public fun <C> KProperty<*>.valueCol(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn(property).ensureIsValueColumn()
 
     /**
-     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColKPropertyDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     public fun <C> ColumnPath.valueCol(property: KProperty<C>): ColumnAccessor<C> =
         columnGroup(this).ensureIsColumnGroup().valueColumn(property).ensureIsValueColumn()
@@ -457,42 +452,42 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
 
     /**
      * @include [CommonValueColDocs]
-     * {@set [CommonValueColDocs.Arg] 0}
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.DoubleExample]}}
+     * {@set [CommonValueColDocs.ARG] 0}
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.DoubleExample]}}
      * @param [index\] The index of the value column.
      * @throws [IndexOutOfBoundsException\] if the index is out of bounds.
      */
     private interface ValueColIndexDocs
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Int][Int]`>().}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
-     * {@set [CommonValueColDocs.ExampleArg] {@include [CommonValueColDocs.SingleExample]}}
+     * {@set [CommonValueColDocs.EXAMPLE] {@include [CommonValueColDocs.SingleExample]}}
      */
     public fun <C> ColumnSet<C>.valueCol(index: Int): SingleColumn<C> = getAt(index).ensureIsValueColumn()
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER]}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun ColumnsSelectionDsl<*>.valueCol(index: Int): SingleColumn<*> = valueCol<Any?>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg]}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER]}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> ColumnsSelectionDsl<*>.valueCol(index: Int): SingleColumn<C> = asSingleColumn().valueCol<C>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun SingleColumn<DataRow<*>>.valueCol(index: Int): SingleColumn<*> = valueCol<Any?>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] myColumnGroup.}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> SingleColumn<DataRow<*>>.valueCol(index: Int): SingleColumn<C> =
@@ -503,40 +498,40 @@ public interface ValueColColumnsSelectionDsl<out _UNUSED> {
             .cast()
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun String.valueCol(index: Int): SingleColumn<*> = valueCol<Any?>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] "myColumnGroup".}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] "myColumnGroup".}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> String.valueCol(index: Int): SingleColumn<C> = columnGroup(this).valueCol<C>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun KProperty<*>.valueCol(index: Int): SingleColumn<*> = valueCol<Any?>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] Type::myColumnGroup.}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] Type::myColumnGroup.}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> KProperty<*>.valueCol(index: Int): SingleColumn<C> = columnGroup(this).valueCol<C>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("valueColUnTyped")
     public fun ColumnPath.valueCol(index: Int): SingleColumn<*> = valueCol<Any?>(index)
 
     /**
-     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.ReceiverArg] "pathTo"["myColumnGroup"].}
+     * @include [ValueColIndexDocs] {@set [CommonValueColDocs.RECEIVER] "pathTo"["myColumnGroup"].}
      * @include [CommonValueColDocs.ValueColumnTypeParam]
      */
     public fun <C> ColumnPath.valueCol(index: Int): SingleColumn<C> = columnGroup(this).valueCol<C>(index)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCols.kt
@@ -3,9 +3,6 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
-import org.jetbrains.kotlinx.dataframe.api.ValueColsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.ValueColsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.ValueColsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -33,7 +30,7 @@ public interface ValueColsColumnsSelectionDsl {
      * ## Value Columns Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -41,15 +38,15 @@ public interface ValueColsColumnsSelectionDsl {
      *  {@include [DslGrammarTemplate.ConditionDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}`  [  `**`{ `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**` ]`
      * }
      */
@@ -86,7 +83,7 @@ public interface ValueColsColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonValueColsDocs.ExampleArg]}
+     * {@get [CommonValueColsDocs.EXAMPLE]}
      *
      * @param [filter\] An optional [predicate][Predicate] to filter the value columns by.
      * @return A [ColumnSet] of [ValueColumns][ValueColumn].
@@ -98,12 +95,12 @@ public interface ValueColsColumnsSelectionDsl {
     private interface CommonValueColsDocs {
 
         /** Example argument */
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") }.`[valueCols][ColumnSet.valueCols]`() }`
      *
@@ -116,7 +113,7 @@ public interface ValueColsColumnsSelectionDsl {
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[valueCols][ColumnsSelectionDsl.valueCols]`() }`
      *
@@ -128,7 +125,7 @@ public interface ValueColsColumnsSelectionDsl {
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColGroup.`[valueCols][SingleColumn.valueCols]`() }`
      *
@@ -140,7 +137,7 @@ public interface ValueColsColumnsSelectionDsl {
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[valueCols][String.valueCols]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -151,7 +148,7 @@ public interface ValueColsColumnsSelectionDsl {
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { Type::myColumnGroup.`[valueCols][KProperty.valueCols]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      *
@@ -164,7 +161,7 @@ public interface ValueColsColumnsSelectionDsl {
 
     /**
      * @include [CommonValueColsDocs]
-     * @set [CommonValueColsDocs.ExampleArg]
+     * @set [CommonValueColsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[valueCols][ColumnPath.valueCols]`() }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/withoutNulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/withoutNulls.kt
@@ -2,10 +2,6 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
-import org.jetbrains.kotlinx.dataframe.api.WithoutNullsColumnsSelectionDsl.Grammar
-import org.jetbrains.kotlinx.dataframe.api.WithoutNullsColumnsSelectionDsl.Grammar.ColumnGroupName
-import org.jetbrains.kotlinx.dataframe.api.WithoutNullsColumnsSelectionDsl.Grammar.ColumnSetName
-import org.jetbrains.kotlinx.dataframe.api.WithoutNullsColumnsSelectionDsl.Grammar.PlainDslName
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -29,21 +25,21 @@ public interface WithoutNullsColumnsSelectionDsl {
      * ## (Cols) Without Nulls Grammar
      *
      * @include [DslGrammarTemplate]
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
      * }
      *
-     * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+     * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`()`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`()`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`()`**
      * }
      */
@@ -79,18 +75,18 @@ public interface WithoutNullsColumnsSelectionDsl {
      *
      * #### Examples for this overload:
      *
-     * {@get [CommonWithoutNullsDocs.ExampleArg]]}
+     * {@get [CommonWithoutNullsDocs.EXAMPLE]]}
      *
      * @return A [ColumnSet] containing only columns that do not contain `null`s and are thus non-nullable.
      */
     private interface CommonWithoutNullsDocs {
 
-        interface ExampleArg
+        interface EXAMPLE
     }
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[cols][ColumnsSelectionDsl.cols]` { .. }.`[withoutNulls][ColumnSet.withoutNulls]`() }`
      */
@@ -100,7 +96,7 @@ public interface WithoutNullsColumnsSelectionDsl {
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]`  {  `[withoutNulls][ColumnsSelectionDsl.colsWithoutNulls]`() }`
      */
@@ -108,7 +104,7 @@ public interface WithoutNullsColumnsSelectionDsl {
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsWithoutNulls][SingleColumn.colsWithoutNulls]`() }`
      */
@@ -117,7 +113,7 @@ public interface WithoutNullsColumnsSelectionDsl {
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsWithoutNulls][String.colsWithoutNulls]`() }`
      */
@@ -125,7 +121,7 @@ public interface WithoutNullsColumnsSelectionDsl {
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColumnGroup.`[colsWithoutNulls][KProperty.colsWithoutNulls]`() }`
      */
@@ -133,7 +129,7 @@ public interface WithoutNullsColumnsSelectionDsl {
 
     /**
      * @include [CommonWithoutNullsDocs]
-     * @set [CommonWithoutNullsDocs.ExampleArg]
+     * @set [CommonWithoutNullsDocs.EXAMPLE]
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColGroup"].`[colsWithoutNulls][ColumnPath.colsWithoutNulls]`() }`
      */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/AccessApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/AccessApi.kt
@@ -34,7 +34,7 @@ internal interface AccessApi {
      *
      * For more information: {@include [DocumentationUrls.AccessApis.StringApi]}
      *
-     * For example:
+     * For example: {@comment This works if you include the test module when running KoDEx}
      * @sample [org.jetbrains.kotlinx.dataframe.samples.api.ApiLevels.strings]
      */
     interface StringApi
@@ -49,7 +49,7 @@ internal interface AccessApi {
      *
      * For more information: {@include [DocumentationUrls.AccessApis.ColumnAccessorsApi]}
      *
-     * For example:
+     * For example: {@comment This works if you include the test module when running KoDEx}
      * @sample [org.jetbrains.kotlinx.dataframe.samples.api.ApiLevels.accessors3]
      */
     interface ColumnAccessorsApi
@@ -66,7 +66,7 @@ internal interface AccessApi {
      *
      * For more information: {@include [DocumentationUrls.AccessApis.KPropertiesApi]}
      *
-     * For example:
+     * For example: {@comment This works if you include the test module when running KoDEx}
      * @sample [org.jetbrains.kotlinx.dataframe.samples.api.ApiLevels.kproperties1]
      */
     interface KPropertiesApi
@@ -81,7 +81,7 @@ internal interface AccessApi {
      *
      * For more information: {@include [DocumentationUrls.AccessApis.ExtensionPropertiesApi]}
      *
-     * For example:
+     * For example: {@comment This works if you include the test module when running KoDEx}
      * @sample [org.jetbrains.kotlinx.dataframe.samples.api.ApiLevels.extensionProperties1]
      */
     interface ExtensionPropertiesApi

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonTakeAndDropDocs.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonTakeAndDropDocs.kt
@@ -1,63 +1,59 @@
 @file:ExcludeFromSources
+@file:Suppress("ClassName")
 
 package org.jetbrains.kotlinx.dataframe.documentation
 
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl
 import org.jetbrains.kotlinx.dataframe.api.name
 import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropDocs.FirstOrLastArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropDocs.NounArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropDocs.OperationArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropDocs.TitleArg
 
 /**
- * ## {@get [TitleArg]} (Cols)
- * This {@get [NounArg]}s the {@get [FirstOrLastArg]} [n\] columns from [this\] collecting
+ * ## {@get [TITLE]} (Cols)
+ * This {@get [NOUN]}s the {@get [FIRST_OR_LAST]} [n\] columns from [this\] collecting
  * the result into a [ColumnSet].
  *
  * This function operates solely on columns at the top-level.
  *
  * Any {@include [AccessApiLink]} can be used as receiver for these functions.
  *
- * NOTE: To avoid ambiguity, `{@get [CommonTakeAndDropDocs.OperationArg]}` is called `{@get [CommonTakeAndDropDocs.OperationArg]}Cols` when called on
+ * NOTE: To avoid ambiguity, `{@get [CommonTakeAndDropDocs.OPERATION]}` is called `{@get [CommonTakeAndDropDocs.OPERATION]}Cols` when called on
  * a [ColumnGroup].
  *
  * ### Check out: [Grammar\]
  *
  * #### Examples:
- * `df.`[select][DataFrame.select]` { `[cols][ColumnsSelectionDsl.cols]` { "my" `[in][String.contains]` it.`[name][DataColumn.name]` }.`[{@get [OperationArg]}][ColumnSet.{@get [OperationArg]}]`(5) }`
+ * `df.`[select][DataFrame.select]` { `[cols][ColumnsSelectionDsl.cols]` { "my" `[in][String.contains]` it.`[name][DataColumn.name]` }.`[{@get [OPERATION]}][ColumnSet.{@get [OPERATION]}]`(5) }`
  *
- * `df.`[select][DataFrame.select]` { `[{@get [OperationArg]}][ColumnsSelectionDsl.{@get [OperationArg]}]`(1) }`
+ * `df.`[select][DataFrame.select]` { `[{@get [OPERATION]}][ColumnsSelectionDsl.{@get [OPERATION]}]`(1) }`
  *
- * `df.`[select][DataFrame.select]` { myColumnGroup.`[{@get [OperationArg]}Cols][SingleColumn.{@get [OperationArg]}Cols]`(2) }`
+ * `df.`[select][DataFrame.select]` { myColumnGroup.`[{@get [OPERATION]}Cols][SingleColumn.{@get [OPERATION]}Cols]`(2) }`
  *
- * `df.`[select][DataFrame.select]` { "myColumnGroup".`[{@get [OperationArg]}Cols][String.{@get [OperationArg]}Cols]`(3) }`
+ * `df.`[select][DataFrame.select]` { "myColumnGroup".`[{@get [OPERATION]}Cols][String.{@get [OPERATION]}Cols]`(3) }`
  *
  * #### Examples for this overload:
  *
- * {@get [CommonTakeAndDropDocs.ExampleArg]}
+ * {@get [CommonTakeAndDropDocs.EXAMPLE]}
  *
- * @param [n\] The number of columns to {@get [NounArg]}.
- * @return A [ColumnSet] containing the {@get [FirstOrLastArg]} [n\] columns.
+ * @param [n\] The number of columns to {@get [NOUN]}.
+ * @return A [ColumnSet] containing the {@get [FIRST_OR_LAST]} [n\] columns.
  */
 internal interface CommonTakeAndDropDocs {
 
     /** Title, like "Take Last" */
-    interface TitleArg
+    interface TITLE
 
     /** Operation, like "takeLast" */
-    interface OperationArg
+    interface OPERATION
 
     /** Operation, like "take" */
-    interface NounArg
+    interface NOUN
 
     /** like "first" */
-    interface FirstOrLastArg
+    interface FIRST_OR_LAST
 
     /** Example argument to use */
-    interface ExampleArg
+    interface EXAMPLE
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonTakeAndDropWhileDocs.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonTakeAndDropWhileDocs.kt
@@ -5,8 +5,6 @@ package org.jetbrains.kotlinx.dataframe.documentation
 import org.jetbrains.kotlinx.dataframe.ColumnFilter
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.ColumnsSelectionDsl
-import org.jetbrains.kotlinx.dataframe.api.any
 import org.jetbrains.kotlinx.dataframe.api.name
 import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
@@ -14,54 +12,51 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropWhileDocs.FirstOrLastArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropWhileDocs.NounArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropWhileDocs.OperationArg
-import org.jetbrains.kotlinx.dataframe.documentation.CommonTakeAndDropWhileDocs.TitleArg
 
 /**
- * ## {@get [TitleArg]} (Cols) While
- * This function {@get [NounArg]}s the {@get [FirstOrLastArg]} columns from [this\] adhering to the
+ * ## {@get [TITLE]} (Cols) While
+ * This function {@get [NOUN]}s the {@get [FIRST_OR_LAST]} columns from [this\] adhering to the
  * given [predicate\] collecting the result into a [ColumnSet].
  *
  * This function operates solely on columns at the top-level.
  *
  * Any {@include [AccessApiLink]} can be used as receiver for these functions.
  *
- * NOTE: To avoid ambiguity, `{@get [CommonTakeAndDropWhileDocs.OperationArg]}While` is called
- * `{@get [CommonTakeAndDropWhileDocs.OperationArg]}ColsWhile` when called on a [String] or [ColumnPath] resembling
+ * NOTE: To avoid ambiguity, `{@get [CommonTakeAndDropWhileDocs.OPERATION]}While` is called
+ * `{@get [CommonTakeAndDropWhileDocs.OPERATION]}ColsWhile` when called on a [String] or [ColumnPath] resembling
  * a [ColumnGroup].
  *
  * ### Check out: [Usage\]
  *
  * #### Examples:
- * `df.`[select][DataFrame.select]` { `[`cols`][ColumnsSelectionDsl.cols]` { "my" `[`in`][String.contains]` it.`[`name`][DataColumn.name]` }.`[\`{@get [OperationArg]}While\`][ColumnSet.{@get [OperationArg]}While]` { "my" `[`in`][String.contains]` it.`[`name`][DataColumn.name]` } }`
+ * `df.`[select][DataFrame.select]` { `[`cols`][ColumnsSelectionDsl.cols]` { "my" `[`in`][String.contains]` it.`[`name`][DataColumn.name]` }.`[\`{@get [OPERATION]}While\`][ColumnSet.{@get [OPERATION]}While]` { "my" `[`in`][String.contains]` it.`[`name`][DataColumn.name]` } }`
  *
- * `df.`[select][DataFrame.select]` { myColumnGroup.`[\`{@get [OperationArg]}While\`][SingleColumn.{@get [OperationArg]}ColsWhile]` { it.`[`any`][ColumnWithPath.any]` { it == "Alice" } } }`
+ * `df.`[select][DataFrame.select]` { myColumnGroup.`[\`{@get [OPERATION]}While\`][SingleColumn.{@get [OPERATION]}ColsWhile]` { it.`[`any`][ColumnWithPath.any]` { it == "Alice" } } }`
  *
- * `df.`[select][DataFrame.select]` { "myColumnGroup".`[\`{@get [OperationArg]}ColsWhile\`][String.{@get [OperationArg]}ColsWhile]` { it.`[`kind`][ColumnWithPath.kind]`() == `[`ColumnKind.Value`][ColumnKind.Value]` } }`
+ * `df.`[select][DataFrame.select]` { "myColumnGroup".`[\`{@get [OPERATION]}ColsWhile\`][String.{@get [OPERATION]}ColsWhile]` { it.`[`kind`][ColumnWithPath.kind]`() == `[`ColumnKind.Value`][ColumnKind.Value]` } }`
  *
  * #### Examples for this overload:
  *
- * {@get [CommonTakeAndDropWhileDocs.ExampleArg]}
+ * {@get [CommonTakeAndDropWhileDocs.EXAMPLE]}
  *
- * @param [predicate\] The [ColumnFilter] to control which columns to {@get [NounArg]}.
- * @return A [ColumnSet] containing the {@get [FirstOrLastArg]} columns adhering to the [predicate\].
+ * @param [predicate\] The [ColumnFilter] to control which columns to {@get [NOUN]}.
+ * @return A [ColumnSet] containing the {@get [FIRST_OR_LAST]} columns adhering to the [predicate\].
  */
+@Suppress("ClassName")
 internal interface CommonTakeAndDropWhileDocs {
 
     /** Title, like "Take Last" */
-    interface TitleArg
+    interface TITLE
 
     /** Operation, like "takeLast" */
-    interface OperationArg
+    interface OPERATION
 
     /** Operation, like "take" */
-    interface NounArg
+    interface NOUN
 
     /** like "last" */
-    interface FirstOrLastArg
+    interface FIRST_OR_LAST
 
     /** Example argument to use */
-    interface ExampleArg
+    interface EXAMPLE
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl.kt
@@ -23,71 +23,72 @@ public interface DslGrammarTemplateColumnsSelectionDsl {
     /**
      * {@include [LineBreak]}
      * {@include [DslGrammarLink]}
-     * {@get [DslGrammarTemplate.DefinitionsPart]
+     * {@get [DslGrammarTemplate.DEFINITIONS_PART]
      *  {@include [LineBreak]}
      *  ### Definitions:
-     *  {@get [DslGrammarTemplate.DefinitionsArg]}
+     *  {@get [DslGrammarTemplate.DEFINITIONS]}
      * }
      * {@comment -------------------------------------------------------------------------------------------- }
-     * {@get [DslGrammarTemplate.PlainDslPart]
+     * {@get [DslGrammarTemplate.PLAIN_DSL_PART]
      *  {@include [LineBreak]}
      *  ### What can be called directly in the {@include [ColumnsSelectionDslLink]}:
      *
      *  {@include [LineBreak]}
-     *  {@get [DslGrammarTemplate.PlainDslFunctionsArg]}
+     *  {@get [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]}
      * }
      * {@comment -------------------------------------------------------------------------------------------- }
-     * {@get [DslGrammarTemplate.ColumnSetPart]
+     * {@get [DslGrammarTemplate.COLUMN_SET_PART]
      *  {@include [LineBreak]}
      *  ### What can be called on a [ColumnSet][org.jetbrains.kotlinx.dataframe.columns.ColumnSet]:
      *
      *  {@include [LineBreak]}
      *  {@include [ColumnSetRef]}
      *
-     *  {@get [DslGrammarTemplate.ColumnSetFunctionsArg]}
+     *  {@get [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]}
      * }
      * {@comment -------------------------------------------------------------------------------------------- }
-     * {@get [DslGrammarTemplate.ColumnGroupPart]
+     * {@get [DslGrammarTemplate.COLUMN_GROUP_PART]
      *  {@include [LineBreak]}
      *  ### What can be called on a [Column Group (reference)][DslGrammarTemplate.ColumnGroupDef]:
      *
      *  {@include [LineBreak]}
      *  {@include [ColumnGroupRef]}
      *
-     *  {@get [DslGrammarTemplate.ColumnGroupFunctionsArg]}
+     *  {@get [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]}
      * }
      */
+    @Suppress("ClassName")
     public interface DslGrammarTemplate {
 
         // region parts
 
         // Can be set to nothing to disable the definitions part
-        public interface DefinitionsPart
+        public interface DEFINITIONS_PART
 
         // Can be set to nothing to disable the plain dsl part
-        public interface PlainDslPart
+        public interface PLAIN_DSL_PART
 
         // Can be set to nothing to disable the column set part
-        public interface ColumnSetPart
+        public interface COLUMN_SET_PART
 
         // Can be set to nothing to disable the column group part
-        public interface ColumnGroupPart
+        public interface COLUMN_GROUP_PART
 
         // endregion
 
         // region Template arguments
 
         // What to put in definitions part aside from the default part.
-        public interface DefinitionsArg
+        public interface DEFINITIONS
 
         // What to put in the plain dsl part. Does not need indents.
-        public interface PlainDslFunctionsArg
+        public interface PLAIN_DSL_FUNCTIONS
 
         // What to put in the column set part. Needs indents.
-        public interface ColumnSetFunctionsArg
+        public interface COLUMN_SET_FUNCTIONS
 
         // What to put in the column group part. Needs indents.
-        public interface ColumnGroupFunctionsArg
+        public interface COLUMN_GROUP_FUNCTIONS
 
         // endregion
 
@@ -256,7 +257,7 @@ public interface DslGrammarTemplateColumnsSelectionDsl {
      *  Don't forget to add the definitions for ColumnSet and ColumnGroup if you're going to use them.
      *  Also, add LineBreaks in between them.
      * }
-     * {@set [DslGrammarTemplate.DefinitionsArg]
+     * {@set [DslGrammarTemplate.DEFINITIONS]
      *  {@include [DslGrammarTemplate.ColumnSetDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -268,16 +269,16 @@ public interface DslGrammarTemplateColumnsSelectionDsl {
      *  the parts belonging to each of these sections. Don't forget to add indents to the ColumnSet and ColumnGroup
      *  parts. Also note we're using -Ref instead of -Def here to refer to definitions.
      * }
-     * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}**`(`**`[`{@include [DslGrammarTemplate.NumberRef]}`]`**`)`**
      * }
      *
-     * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+     * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`(`**`[`{@include [DslGrammarTemplate.NumberRef]}`]`**`)`**
      * }
      *
      * {@comment Our example function has no Plain DSL part, so we set it to nothing. No need to set PlainDslFunctionsArg.}
-     * {@set [DslGrammarTemplate.PlainDslPart]}
+     * {@set [DslGrammarTemplate.PLAIN_DSL_PART]}
      */
     public interface UsageTemplateExample {
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenColumn.kt
@@ -5,7 +5,6 @@ package org.jetbrains.kotlinx.dataframe.documentation
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.count
 import org.jetbrains.kotlinx.dataframe.api.mean
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenColumn.ColumnExpressionLink
 import org.jetbrains.kotlinx.dataframe.ColumnExpression as DfColumnExpression
 
 /**
@@ -19,9 +18,9 @@ internal interface ExpressionsGivenColumn {
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface OperationArg
+    interface OPERATION
 
-    /** {@set [OperationArg] operation} */
+    /** {@set [OPERATION] operation} */
     interface SetDefaultOperationArg
 
     /** Provide a new value for every selected cell given its column using a [column expression][DfColumnExpression]. */
@@ -32,9 +31,9 @@ internal interface ExpressionsGivenColumn {
          *
          * For example:
          *
-         * `df.`{@get [OperationArg]}` { `[mean][DataColumn.mean]`(skipNA = true) }`
+         * `df.`{@get [OPERATION]}` { `[mean][DataColumn.mean]`(skipNA = true) }`
          *
-         * `df.`{@get [OperationArg]}` { `[count][DataColumn.count]` { it > 10 } }`
+         * `df.`{@get [OPERATION]}` { `[count][DataColumn.count]` { it > 10 } }`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenDataFrame.kt
@@ -4,7 +4,6 @@ package org.jetbrains.kotlinx.dataframe.documentation
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.select
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenDataFrame.DataFrameExpressionLink
 import org.jetbrains.kotlinx.dataframe.DataFrameExpression as DfDataFrameExpression
 
 /**
@@ -14,7 +13,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrameExpression as DfDataFrameExpress
  */
 internal interface ExpressionsGivenDataFrame {
 
-    interface OperationArg
+    interface OPERATION
 
     /** Provide a new value for every selected data frame using a [dataframe expression][DfDataFrameExpression]. */
     interface DataFrameExpression {
@@ -24,7 +23,7 @@ internal interface ExpressionsGivenDataFrame {
          *
          * For example:
          *
-         * {@get [OperationArg]}` { `[select][DataFrame.select]` { lastName } }`
+         * {@get [OPERATION]}` { `[select][DataFrame.select]` { lastName } }`
          */
         interface WithExample
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenRow.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenRow.kt
@@ -10,9 +10,6 @@ import org.jetbrains.kotlinx.dataframe.api.insert
 import org.jetbrains.kotlinx.dataframe.api.map
 import org.jetbrains.kotlinx.dataframe.api.notNull
 import org.jetbrains.kotlinx.dataframe.api.with
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.AddDataRowNote
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.RowExpressionLink
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRow.RowValueExpressionLink
 import org.jetbrains.kotlinx.dataframe.RowExpression as DfRowExpression
 import org.jetbrains.kotlinx.dataframe.RowValueExpression as DfRowValueExpression
 
@@ -41,11 +38,11 @@ internal interface ExpressionsGivenRow {
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface OperationArg
+    interface OPERATION
 
     // Using <code>` notation to not create double `` when including
 
-    /** {@set [OperationArg] <code>`operation`</code>} */
+    /** {@set [OPERATION] <code>`operation`</code>} */
     interface SetDefaultOperationArg
 
     /**
@@ -64,9 +61,9 @@ internal interface ExpressionsGivenRow {
          *
          * For example:
          *
-         * `df.`{@get [OperationArg]}` { name.firstName + " " + name.lastName }`
+         * `df.`{@get [OPERATION]}` { name.firstName + " " + name.lastName }`
          *
-         * `df.`{@get [OperationArg]}` { 2021 - age }`
+         * `df.`{@get [OPERATION]}` { 2021 - age }`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample
@@ -85,9 +82,9 @@ internal interface ExpressionsGivenRow {
          *
          * For example:
          *
-         * `df.`{@get [OperationArg]}` { name.firstName + " from " + it }`
+         * `df.`{@get [OPERATION]}` { name.firstName + " from " + it }`
          *
-         * `df.`{@get [OperationArg]}` { it.uppercase() }`
+         * `df.`{@get [OPERATION]}` { it.uppercase() }`
          * {@include [SetDefaultOperationArg]}
          */
         interface WithExample

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenRowAndColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/ExpressionsGivenRowAndColumn.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlinx.dataframe.documentation
 
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.mean
-import org.jetbrains.kotlinx.dataframe.documentation.ExpressionsGivenRowAndColumn.RowColumnExpressionLink
 import org.jetbrains.kotlinx.dataframe.RowColumnExpression as DfRowColumnExpression
 
 /**
@@ -16,11 +15,11 @@ internal interface ExpressionsGivenRowAndColumn {
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface OperationArg
+    interface OPERATION
 
     // Using <code>` notation to not create double `` when including
 
-    /** {@set [OperationArg] <code>`operation`</code>} */
+    /** {@set [OPERATION] <code>`operation`</code>} */
     interface SetDefaultOperationArg
 
     /** Provide a new value for every selected cell given both its row and column using a [row-column expression][DfRowColumnExpression]. */
@@ -31,7 +30,7 @@ internal interface ExpressionsGivenRowAndColumn {
          *
          * For example:
          *
-         * `df.`{@get [OperationArg]}` { row, col ->`
+         * `df.`{@get [OPERATION]}` { row, col ->`
          *
          * {@include [Indent]}`row.age / col.`[mean][DataColumn.mean]`(skipNA = true)`
          *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/SelectingColumns.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/SelectingColumns.kt
@@ -16,15 +16,6 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.ColumnAccessors
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.ColumnAccessorsLink
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.ColumnNames
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.ColumnNamesLink
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.Dsl
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.DslLink
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.DslSingleLink
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.KProperties
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns.KPropertiesLink
 import kotlin.reflect.KProperty
 
 /** [Selecting Columns][SelectingColumns] */
@@ -51,11 +42,11 @@ internal interface SelectingColumns {
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface OperationArg
+    interface OPERATION
 
     // Using <code>` notation to not create double `` when including
 
-    /** {@set [OperationArg] <code>`operation`</code>} */
+    /** {@set [OPERATION] <code>`operation`</code>} */
     interface SetDefaultOperationArg
 
     /**
@@ -85,11 +76,11 @@ internal interface SelectingColumns {
          *
          * #### For example:
          *
-         * `df.`{@get [OperationArg]}` { length `[and][ColumnsSelectionDsl.and]` age }`
+         * `df.`{@get [OPERATION]}` { length `[and][ColumnsSelectionDsl.and]` age }`
          *
-         * `df.`{@get [OperationArg]}`  {  `[cols][ColumnsSelectionDsl.cols]`(1..5) }`
+         * `df.`{@get [OPERATION]}`  {  `[cols][ColumnsSelectionDsl.cols]`(1..5) }`
          *
-         * `df.`{@get [OperationArg]}`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Double][Double]`>() }`
+         * `df.`{@get [OPERATION]}`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Double][Double]`>() }`
          *
          * @include [SetDefaultOperationArg]
          */
@@ -125,11 +116,11 @@ internal interface SelectingColumns {
          *
          * #### For example:
          *
-         * `df.`{@get [OperationArg]}` { length }`
+         * `df.`{@get [OPERATION]}` { length }`
          *
-         * `df.`{@get [OperationArg]}`  {  `[col][ColumnsSelectionDsl.col]`(1) }`
+         * `df.`{@get [OPERATION]}`  {  `[col][ColumnsSelectionDsl.col]`(1) }`
          *
-         * `df.`{@get [OperationArg]}`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Double][Double]`>().`[first][ColumnsSelectionDsl.first]`() }`
+         * `df.`{@get [OPERATION]}`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Double][Double]`>().`[first][ColumnsSelectionDsl.first]`() }`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample
@@ -149,7 +140,7 @@ internal interface SelectingColumns {
          *
          * #### For example:
          *
-         * `df.`{@get [OperationArg]}`("length", "age")`
+         * `df.`{@get [OPERATION]}`("length", "age")`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample
@@ -173,7 +164,7 @@ internal interface SelectingColumns {
          *
          * `val age by `[column][column]`<`[Double][Double]`>()`
          *
-         * `df.`{@get [OperationArg]}`(length, age)`
+         * `df.`{@get [OPERATION]}`(length, age)`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample
@@ -193,7 +184,7 @@ internal interface SelectingColumns {
          * data class Person(val length: Double, val age: Double)
          * ```
          *
-         * `df.`{@get [OperationArg]}`(Person::length, Person::age)`
+         * `df.`{@get [OPERATION]}`(Person::length, Person::age)`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/SelectingRows.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/SelectingRows.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ClassName")
+
 package org.jetbrains.kotlinx.dataframe.documentation
 
 import org.jetbrains.kotlinx.dataframe.RowFilter
@@ -11,8 +13,6 @@ import org.jetbrains.kotlinx.dataframe.api.first
 import org.jetbrains.kotlinx.dataframe.api.format
 import org.jetbrains.kotlinx.dataframe.api.gather
 import org.jetbrains.kotlinx.dataframe.api.update
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingRows.RowConditionLink
-import org.jetbrains.kotlinx.dataframe.documentation.SelectingRows.RowValueConditionLink
 import org.jetbrains.kotlinx.dataframe.index
 
 /**
@@ -33,15 +33,15 @@ internal interface SelectingRows {
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface FirstOperationArg
+    interface FIRST_OPERATION
 
     /*
      * The key for a @set that will define the operation name for the examples below.
      * Make sure to [alias][your examples].
      */
-    interface SecondOperationArg
+    interface SECOND_OPERATION
 
-    /** {@set [FirstOperationArg] operation}{@set [SecondOperationArg] where} */
+    /** {@set [FIRST_OPERATION] operation}{@set [SECOND_OPERATION] where} */
     interface SetDefaultOperationArg
 
     /** [Entire-Row Condition][EntireRowCondition.WithExample] */
@@ -55,9 +55,9 @@ internal interface SelectingRows {
          *
          * For example:
          *
-         * `df.`{@get [FirstOperationArg]}` { `[index][index]`() % 2 == 0 }`
+         * `df.`{@get [FIRST_OPERATION]}` { `[index][index]`() % 2 == 0 }`
          *
-         * `df.`{@get [FirstOperationArg]}` { `[diff][diff]` { age } == 0 }`
+         * `df.`{@get [FIRST_OPERATION]}` { `[diff][diff]` { age } == 0 }`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample
@@ -76,9 +76,9 @@ internal interface SelectingRows {
          *
          * For example:
          *
-         * `df.`{@get [FirstOperationArg]}` { length }.`{@get [SecondOperationArg]}` { it > 10.0 }`
+         * `df.`{@get [FIRST_OPERATION]}` { length }.`{@get [SECOND_OPERATION]}` { it > 10.0 }`
          *
-         * `df.`{@get [FirstOperationArg]}` { `[cols][ColumnsSelectionDsl.cols]`(1..5) }.`{@get [SecondOperationArg]}` { `[index][index]`() > 4 && city != "Paris" }`
+         * `df.`{@get [FIRST_OPERATION]}` { `[cols][ColumnsSelectionDsl.cols]`(1..5) }.`{@get [SECOND_OPERATION]}` { `[index][index]`() > 4 && city != "Paris" }`
          * @include [SetDefaultOperationArg]
          */
         interface WithExample

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/TakeAndDropColumnsSelectionDslGrammar.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/TakeAndDropColumnsSelectionDslGrammar.kt
@@ -5,10 +5,10 @@ package org.jetbrains.kotlinx.dataframe.documentation
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 
 /**
- * ## {@get [TitleArg]} (Last) (Cols) (While) Grammar
+ * ## {@get [TITLE]} (Last) (Cols) (While) Grammar
  *
  * @include [DslGrammarTemplate]
- * {@set [DslGrammarTemplate.DefinitionsArg]
+ * {@set [DslGrammarTemplate.DEFINITIONS]
  *  {@include [DslGrammarTemplate.ColumnSetDef]}
  *  {@include [LineBreak]}
  *  {@include [DslGrammarTemplate.ColumnGroupDef]}
@@ -18,19 +18,19 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
  *  {@include [DslGrammarTemplate.NumberDef]}
  * }
  *
- * {@set [DslGrammarTemplate.PlainDslFunctionsArg]
+ * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
  *  {@include [PlainDslName]}**`(`**{@include [DslGrammarTemplate.NumberRef]}**`)`**
  *
  *  `| `{@include [PlainDslWhileName]}**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**
  * }
  *
- * {@set [DslGrammarTemplate.ColumnSetFunctionsArg]
+ * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
  *  {@include [Indent]}{@include [ColumnSetName]}**`(`**{@include [DslGrammarTemplate.NumberRef]}**`)`**
  *
  *  {@include [Indent]}`| `{@include [ColumnSetWhileName]}**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**
  * }
  *
- * {@set [DslGrammarTemplate.ColumnGroupFunctionsArg]
+ * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
  *  {@include [Indent]}{@include [ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.NumberRef]}**`)`**
  *
  *  {@include [Indent]}`| `{@include [ColumnGroupWhileName]}**`  {  `**{@include [DslGrammarTemplate.ConditionRef]}**` \}`**
@@ -39,26 +39,26 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
 internal interface TakeAndDropColumnsSelectionDslGrammar {
 
     // Like "Take"/"Drop"
-    interface TitleArg
+    interface TITLE
 
     // Operation, like "take"/"drop"
-    interface OperationArg
+    interface OPERATION
 
-    /** [**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OperationArg]}Last]`)` */
+    /** [**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OPERATION]}Last]`)` */
     interface PlainDslName
 
-    /** __`.`__[**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}]`(`[**`Last`**][ColumnSet.{@get [OperationArg]}Last]`)` */
+    /** __`.`__[**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}]`(`[**`Last`**][ColumnSet.{@get [OPERATION]}Last]`)` */
     interface ColumnSetName
 
-    /** __`.`__[**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}Cols]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OperationArg]}LastCols]`)`[**`Cols`**][ColumnsSelectionDsl.{@get [OperationArg]}Cols] */
+    /** __`.`__[**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}Cols]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OPERATION]}LastCols]`)`[**`Cols`**][ColumnsSelectionDsl.{@get [OPERATION]}Cols] */
     interface ColumnGroupName
 
-    /** [**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}While]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OperationArg]}LastWhile]`)`[**`While`**][ColumnsSelectionDsl.{@get [OperationArg]}While] */
+    /** [**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}While]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OPERATION]}LastWhile]`)`[**`While`**][ColumnsSelectionDsl.{@get [OPERATION]}While] */
     interface PlainDslWhileName
 
-    /** __`.`__[**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}While]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OperationArg]}LastWhile]`)`[**`While`**][ColumnsSelectionDsl.{@get [OperationArg]}While] */
+    /** __`.`__[**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}While]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OPERATION]}LastWhile]`)`[**`While`**][ColumnsSelectionDsl.{@get [OPERATION]}While] */
     interface ColumnSetWhileName
 
-    /** __`.`__[**\`{@get [OperationArg]}\`**][ColumnsSelectionDsl.{@get [OperationArg]}ColsWhile]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OperationArg]}LastColsWhile]`)`[**`ColsWhile`**][ColumnsSelectionDsl.{@get [OperationArg]}ColsWhile] */
+    /** __`.`__[**\`{@get [OPERATION]}\`**][ColumnsSelectionDsl.{@get [OPERATION]}ColsWhile]`(`[**`Last`**][ColumnsSelectionDsl.{@get [OPERATION]}LastColsWhile]`)`[**`ColsWhile`**][ColumnsSelectionDsl.{@get [OPERATION]}ColsWhile] */
     interface ColumnGroupWhileName
 }

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonReadDelimDocs.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonReadDelimDocs.kt
@@ -9,9 +9,9 @@ import java.io.InputStream
 import java.net.URL
 
 /**
- * ### Read $[FileTypeTitleArg] $[DataTitleArg] to [DataFrame]
+ * ### Read $[FILE_TYPE_TITLE] $[DATA_TITLE] to [DataFrame]
  *
- * Reads any $[FileTypeArg] $[DataArg] to a [DataFrame][DataFrame].
+ * Reads any $[FILE_TYPE] $[DATA] to a [DataFrame][DataFrame].
  *
  * Parameters you can use to customize the reading process include, for instance, \[delimiter\],
  * \[header\], \[colTypes\], \[readLines\], and \[parserOptions\].
@@ -20,15 +20,15 @@ import java.net.URL
  * The integration is built upon {@include [DocumentationUrls.Deephaven]}.
  *
  * ##### Similar Functions
- * With the overloads of $[FunctionLinkArg]`()`, you can read any $[FileTypeArg] by [File][File],
+ * With the overloads of $[FUNCTION_LINK]`()`, you can read any $[FILE_TYPE] by [File][File],
  * [Path][java.nio.file.Path], [URL][URL], or [InputStream][InputStream].
  * Reading by file path or URL can also be done by passing a [String].
  *
- * For example, $[FunctionLinkArg]`("input.$[CommonReadDelimDocs.FileExtensionArg]")` or with some options:
+ * For example, $[FUNCTION_LINK]`("input.$[CommonReadDelimDocs.FILE_EXTENSION]")` or with some options:
  *
- * $[FunctionLinkArg]`(`
+ * $[FUNCTION_LINK]`(`
  *
- * {@include [Indent]}`file = `[File][File]`("input.$[CommonReadDelimDocs.FileExtensionArg]"),`
+ * {@include [Indent]}`file = `[File][File]`("input.$[CommonReadDelimDocs.FILE_EXTENSION]"),`
  *
  * {@include [Indent]}`parserOptions = `[ParserOptions][org.jetbrains.kotlinx.dataframe.api.ParserOptions]`(locale = `[Locale][java.util.Locale]`.`[US][java.util.Locale.US]`),`
  *
@@ -40,47 +40,48 @@ import java.net.URL
  *
  * ZIP (.zip) or GZIP (.gz) files are supported by default. \[compression\] is automatically detected.
  *
- * You can also read "raw" $[FileTypeArg] data from a [String] like this:
+ * You can also read "raw" $[FILE_TYPE] data from a [String] like this:
  *
- * $[StrFunctionLinkArg]`("a,b,c", delimiter = ",")`
+ * $[STR_FUNCTION_LINK]`("a,b,c", delimiter = ",")`
  *
- * _**NOTE EXPERIMENTAL**: This is a new set of functions, replacing the old $[OldFunctionLinkArg]`()` functions.
+ * _**NOTE EXPERIMENTAL**: This is a new set of functions, replacing the old $[OLD_FUNCTION_LINK]`()` functions.
  * They'll hopefully be faster and better._
  *
  * @comment Some helper arguments for the function links
- * @set [FunctionLinkArg] \[DataFrame.${[FunctionNameArg]}\]\[${[FunctionNameArg]}\]
- * @set [StrFunctionLinkArg] \[DataFrame.${[FunctionNameArg]}Str\]\[${[FunctionNameArg]}Str\]
- * @set [OldFunctionLinkArg] \[DataFrame.${[OldFunctionNameArg]}\]\[org.jetbrains.kotlinx.dataframe.io.${[OldFunctionNameArg]}\]
+ * @set [FUNCTION_LINK] \[DataFrame.${[FUNCTION_NAME]}\]\[${[FUNCTION_NAME]}\]
+ * @set [STR_FUNCTION_LINK] \[DataFrame.${[FUNCTION_NAME]}Str\]\[${[FUNCTION_NAME]}Str\]
+ * @set [OLD_FUNCTION_LINK] \[DataFrame.${[OLD_FUNCTION_NAME]}\]\[org.jetbrains.kotlinx.dataframe.io.${[OLD_FUNCTION_NAME]}\]
  */
+@Suppress("ClassName")
 internal interface CommonReadDelimDocs {
 
     /**
      * @include [CommonReadDelimDocs]
-     * @set [FileTypeTitleArg] CSV
-     * @set [FileTypeArg] CSV
-     * @set [FileExtensionArg] csv
-     * @set [FunctionNameArg] readCsv
-     * @set [OldFunctionNameArg] readCSV
+     * @set [FILE_TYPE_TITLE] CSV
+     * @set [FILE_TYPE] CSV
+     * @set [FILE_EXTENSION] csv
+     * @set [FUNCTION_NAME] readCsv
+     * @set [OLD_FUNCTION_NAME] readCSV
      */
     interface CsvDocs
 
     /**
      * @include [CommonReadDelimDocs]
-     * @set [FileTypeTitleArg] TSV
-     * @set [FileTypeArg] TSV
-     * @set [FileExtensionArg] tsv
-     * @set [FunctionNameArg] readTsv
-     * @set [OldFunctionNameArg] readTSV
+     * @set [FILE_TYPE_TITLE] TSV
+     * @set [FILE_TYPE] TSV
+     * @set [FILE_EXTENSION] tsv
+     * @set [FUNCTION_NAME] readTsv
+     * @set [OLD_FUNCTION_NAME] readTSV
      */
     interface TsvDocs
 
     /**
      * @include [CommonReadDelimDocs]
-     * @set [FileTypeTitleArg] Delimiter-Separated Text
-     * @set [FileTypeArg] delimiter-separated text
-     * @set [FileExtensionArg] txt
-     * @set [FunctionNameArg] readDelim
-     * @set [OldFunctionNameArg] readDelim{@comment cannot differentiate between old and new}
+     * @set [FILE_TYPE_TITLE] Delimiter-Separated Text
+     * @set [FILE_TYPE] delimiter-separated text
+     * @set [FILE_EXTENSION] txt
+     * @set [FUNCTION_NAME] readDelim
+     * @set [OLD_FUNCTION_NAME] readDelim{@comment cannot differentiate between old and new}
      */
     interface DelimDocs
 
@@ -103,32 +104,32 @@ internal interface CommonReadDelimDocs {
     interface CommonReadParams
 
     // something like "File" or "File/URL"
-    interface DataTitleArg
+    interface DATA_TITLE
 
     // something like "file" or "file or url"
-    interface DataArg
+    interface DATA
 
     // Like "CSV" or "TSV", capitalized
-    interface FileTypeTitleArg
+    interface FILE_TYPE_TITLE
 
     // Like "CSV" or "TSV"
-    interface FileTypeArg
+    interface FILE_TYPE
 
     // like "csv" or "txt"
-    interface FileExtensionArg
+    interface FILE_EXTENSION
 
     // Function name, like "readCsv"
-    interface FunctionNameArg
+    interface FUNCTION_NAME
 
     // Old function name, like "readCSV"
-    interface OldFunctionNameArg
+    interface OLD_FUNCTION_NAME
 
     // A link to the main function, set by ReadDelim itself
-    interface FunctionLinkArg
+    interface FUNCTION_LINK
 
     // A link to the str function, set by ReadDelim itself
-    interface StrFunctionLinkArg
+    interface STR_FUNCTION_LINK
 
     // A link to the old function, set by ReadDelim itself
-    interface OldFunctionLinkArg
+    interface OLD_FUNCTION_LINK
 }

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonWriteDelimDocs.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonWriteDelimDocs.kt
@@ -9,9 +9,9 @@ import org.jetbrains.kotlinx.dataframe.io.writeCSV
 import java.io.File
 
 /**
- * ### $[WriteOrConvertArg] [DataFrame] to $[FileTypeTitleArg] $[DataTitleArg]
+ * ### $[WRITE_OR_CONVERT] [DataFrame] to $[FILE_TYPE_TITLE] $[DATA_TITLE]
  *
- * ${[WriteOrConvertArg]}s \[this\]\[this\] [DataFrame][DataFrame] to a $[FileTypeArg] $[DataArg].
+ * ${[WRITE_OR_CONVERT]}s \[this\]\[this\] [DataFrame][DataFrame] to a $[FILE_TYPE] $[DATA].
  *
  * Parameters you can use to customize the process include, for instance, \[delimiter\],
  * \[includeHeader\], \[quoteMode\], and \[headerComments\].
@@ -20,54 +20,55 @@ import java.io.File
  * The integration is built upon {@include [DocumentationUrls.ApacheCsv]}.
  *
  * ##### Similar Functions
- * With overloads of $[FunctionLinkArg]`()`, you can write $[FileTypeArg] to [File][File], [Path][java.nio.file.Path],
+ * With overloads of $[FUNCTION_LINK]`()`, you can write $[FILE_TYPE] to [File][File], [Path][java.nio.file.Path],
  * [Appendable], or [String].
  *
- * For example, $[FunctionLinkArg]`("output.$[CommonWriteDelimDocs.FileExtensionArg]")`
+ * For example, $[FUNCTION_LINK]`("output.$[CommonWriteDelimDocs.FILE_EXTENSION]")`
  *
- * or $[FunctionLinkArg]`(`[File][File]`("output.$[CommonWriteDelimDocs.FileExtensionArg]"), quoteMode = `[QuoteMode.ALL][ALL]`)`
+ * or $[FUNCTION_LINK]`(`[File][File]`("output.$[CommonWriteDelimDocs.FILE_EXTENSION]"), quoteMode = `[QuoteMode.ALL][ALL]`)`
  *
  * Converting to a [String] can be done like this:
  *
- * $[ToStrFunctionLinkArg]`(delimiter = ",")`
+ * $[TO_STR_FUNCTION_LINK]`(delimiter = ",")`
  *
  * _**NOTE EXPERIMENTAL**: This is a new set of functions, replacing the old
  * [DataFrame.writeCSV][writeCSV]`()` and [DataFrame.toCsv][toCsv]`()` functions.
  * They'll hopefully be better._
  *
  * @comment Some helper arguments for the function links
- * @set [FunctionLinkArg] \[DataFrame.${[FunctionNameArg]}\]\[${[FunctionNameArg]}\]
- * @set [ToStrFunctionLinkArg] \[DataFrame.${[ToStrFunctionNameArg]}\]\[${[ToStrFunctionNameArg]}\]
+ * @set [FUNCTION_LINK] \[DataFrame.${[FUNCTION_NAME]}\]\[${[FUNCTION_NAME]}\]
+ * @set [TO_STR_FUNCTION_LINK] \[DataFrame.${[TO_STR_FUNCTION_NAME]}\]\[${[TO_STR_FUNCTION_NAME]}\]
  */
+@Suppress("ClassName")
 internal interface CommonWriteDelimDocs {
 
     /**
      * @include [CommonWriteDelimDocs]
-     * @set [FileTypeTitleArg] CSV
-     * @set [FileTypeArg] CSV
-     * @set [FileExtensionArg] csv
-     * @set [FunctionNameArg] writeCsv
-     * @set [ToStrFunctionNameArg] toCsvStr
+     * @set [FILE_TYPE_TITLE] CSV
+     * @set [FILE_TYPE] CSV
+     * @set [FILE_EXTENSION] csv
+     * @set [FUNCTION_NAME] writeCsv
+     * @set [TO_STR_FUNCTION_NAME] toCsvStr
      */
     interface CsvDocs
 
     /**
      * @include [CommonWriteDelimDocs]
-     * @set [FileTypeTitleArg] TSV
-     * @set [FileTypeArg] TSV
-     * @set [FileExtensionArg] tsv
-     * @set [FunctionNameArg] writeTsv
-     * @set [ToStrFunctionNameArg] toTsvStr
+     * @set [FILE_TYPE_TITLE] TSV
+     * @set [FILE_TYPE] TSV
+     * @set [FILE_EXTENSION] tsv
+     * @set [FUNCTION_NAME] writeTsv
+     * @set [TO_STR_FUNCTION_NAME] toTsvStr
      */
     interface TsvDocs
 
     /**
      * @include [CommonWriteDelimDocs]
-     * @set [FileTypeTitleArg] Delimiter-Separated Text
-     * @set [FileTypeArg] delimiter-separated text
-     * @set [FileExtensionArg] txt
-     * @set [FunctionNameArg] writeDelim
-     * @set [ToStrFunctionNameArg] toDelimStr
+     * @set [FILE_TYPE_TITLE] Delimiter-Separated Text
+     * @set [FILE_TYPE] delimiter-separated text
+     * @set [FILE_EXTENSION] txt
+     * @set [FUNCTION_NAME] writeDelim
+     * @set [TO_STR_FUNCTION_NAME] toDelimStr
      */
     interface DelimDocs
 
@@ -83,32 +84,32 @@ internal interface CommonWriteDelimDocs {
     interface CommonWriteParams
 
     // something like "Write" or "Convert"
-    interface WriteOrConvertArg
+    interface WRITE_OR_CONVERT
 
     // Like "CSV" or "TSV", capitalized
-    interface FileTypeTitleArg
+    interface FILE_TYPE_TITLE
 
     // something like "File" or "String"
-    interface DataTitleArg
+    interface DATA_TITLE
 
     // something like "file" or "text"
-    interface DataArg
+    interface DATA
 
     // Like "CSV" or "TSV"
-    interface FileTypeArg
+    interface FILE_TYPE
 
     // like "csv" or "txt"
-    interface FileExtensionArg
+    interface FILE_EXTENSION
 
     // Function name, like "readCsv"
-    interface FunctionNameArg
+    interface FUNCTION_NAME
 
     // Function name, like "toCsvStr"
-    interface ToStrFunctionNameArg
+    interface TO_STR_FUNCTION_NAME
 
     // A link to the main function, set by WriteDelim itself
-    interface FunctionLinkArg
+    interface FUNCTION_LINK
 
     // A link to the str function, set by WriteDelim itself
-    interface ToStrFunctionLinkArg
+    interface TO_STR_FUNCTION_LINK
 }

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DelimParams.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DelimParams.kt
@@ -85,7 +85,7 @@ internal object DelimParams {
      *   Columns widths are determined by the header in the data (if present), or manually by setting
      *   \[fixedColumnWidths\].
      */
-    val HAS_FIXED_WIDTH_COLUMNS: Boolean = false
+    const val HAS_FIXED_WIDTH_COLUMNS: Boolean = false
 
     /**
      * @param fixedColumnWidths The fixed column widths. Default: empty list.

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readCsv.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readCsv.kt
@@ -28,8 +28,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.READ_LINES
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.SKIP_LINES
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.TRIM_INSIDE_QUOTED
 import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
-import org.jetbrains.kotlinx.dataframe.io.Compression
-import org.jetbrains.kotlinx.dataframe.io.Compression.Companion
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -39,8 +37,8 @@ import kotlin.io.path.inputStream
 
 /**
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [PATH_READ]
  * @include [CSV_DELIMITER]
  * @include [COMPRESSION]
@@ -90,8 +88,8 @@ public fun DataFrame.Companion.readCsv(
 
 /**
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [FILE_READ]
  * @include [CSV_DELIMITER]
  * @include [COMPRESSION]
@@ -141,8 +139,8 @@ public fun DataFrame.Companion.readCsv(
 
 /**
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] Url
- * @set [CommonReadDelimDocs.DataArg] url
+ * @set [CommonReadDelimDocs.DATA_TITLE] Url
+ * @set [CommonReadDelimDocs.DATA] url
  * @include [DelimParams.URL_READ]
  * @include [CSV_DELIMITER]
  * @include [COMPRESSION]
@@ -192,8 +190,8 @@ public fun DataFrame.Companion.readCsv(
 
 /**
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File or URL
- * @set [CommonReadDelimDocs.DataArg] file or url
+ * @set [CommonReadDelimDocs.DATA_TITLE] File or URL
+ * @set [CommonReadDelimDocs.DATA] file or url
  * @include [FILE_OR_URL_READ]
  * @include [CSV_DELIMITER]
  * @include [COMPRESSION]
@@ -244,8 +242,8 @@ public fun DataFrame.Companion.readCsv(
 /**
  * {@comment the only one with adjustCsvSpecs}
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] InputStream
- * @set [CommonReadDelimDocs.DataArg] input stream
+ * @set [CommonReadDelimDocs.DATA_TITLE] InputStream
+ * @set [CommonReadDelimDocs.DATA] input stream
  * @include [INPUT_STREAM_READ]
  * @include [CSV_DELIMITER]
  * @include [COMPRESSION]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readCsvStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readCsvStr.kt
@@ -24,8 +24,8 @@ import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
 
 /**
  * @include [CommonReadDelimDocs.CsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] String
- * @set [CommonReadDelimDocs.DataArg] [String]
+ * @set [CommonReadDelimDocs.DATA_TITLE] String
+ * @set [CommonReadDelimDocs.DATA] [String]
  * @include [TEXT_READ]
  * @include [CSV_DELIMITER]
  * @include [CommonReadDelimDocs.CommonReadParams]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readDelim.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readDelim.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.READ_LINES
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.SKIP_LINES
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.TRIM_INSIDE_QUOTED
 import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
-import org.jetbrains.kotlinx.dataframe.io.Compression
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -44,8 +43,8 @@ import kotlin.io.path.inputStream
 
 /**
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [PATH_READ]
  * @include [DELIM_DELIMITER]
  * @include [COMPRESSION]
@@ -95,8 +94,8 @@ public fun DataFrame.Companion.readDelim(
 
 /**
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [FILE_READ]
  * @include [DELIM_DELIMITER]
  * @include [COMPRESSION]
@@ -146,8 +145,8 @@ public fun DataFrame.Companion.readDelim(
 
 /**
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] Url
- * @set [CommonReadDelimDocs.DataArg] url
+ * @set [CommonReadDelimDocs.DATA_TITLE] Url
+ * @set [CommonReadDelimDocs.DATA] url
  * @include [DelimParams.URL_READ]
  * @include [DELIM_DELIMITER]
  * @include [COMPRESSION]
@@ -197,8 +196,8 @@ public fun DataFrame.Companion.readDelim(
 
 /**
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File or URL
- * @set [CommonReadDelimDocs.DataArg] file or url
+ * @set [CommonReadDelimDocs.DATA_TITLE] File or URL
+ * @set [CommonReadDelimDocs.DATA] file or url
  * @include [FILE_OR_URL_READ]
  * @include [DELIM_DELIMITER]
  * @include [COMPRESSION]
@@ -249,8 +248,8 @@ public fun DataFrame.Companion.readDelim(
 /**
  * {@comment the only one with adjustCsvSpecs}
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] InputStream
- * @set [CommonReadDelimDocs.DataArg] input stream
+ * @set [CommonReadDelimDocs.DATA_TITLE] InputStream
+ * @set [CommonReadDelimDocs.DATA] input stream
  * @include [INPUT_STREAM_READ]
  * @include [DELIM_DELIMITER]
  * @include [COMPRESSION]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readDelimStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readDelimStr.kt
@@ -24,8 +24,8 @@ import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
 
 /**
  * @include [CommonReadDelimDocs.DelimDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] String
- * @set [CommonReadDelimDocs.DataArg] [String]
+ * @set [CommonReadDelimDocs.DATA_TITLE] String
+ * @set [CommonReadDelimDocs.DATA] [String]
  * @include [TEXT_READ]
  * @include [DELIM_DELIMITER]
  * @include [CommonReadDelimDocs.CommonReadParams]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readTsv.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readTsv.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.SKIP_LINES
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.TRIM_INSIDE_QUOTED
 import org.jetbrains.kotlinx.dataframe.documentation.DelimParams.TSV_DELIMITER
 import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
-import org.jetbrains.kotlinx.dataframe.io.Compression
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -38,8 +37,8 @@ import kotlin.io.path.inputStream
 
 /**
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [PATH_READ]
  * @include [TSV_DELIMITER]
  * @include [COMPRESSION]
@@ -89,8 +88,8 @@ public fun DataFrame.Companion.readTsv(
 
 /**
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File
- * @set [CommonReadDelimDocs.DataArg] file
+ * @set [CommonReadDelimDocs.DATA_TITLE] File
+ * @set [CommonReadDelimDocs.DATA] file
  * @include [FILE_READ]
  * @include [TSV_DELIMITER]
  * @include [COMPRESSION]
@@ -140,8 +139,8 @@ public fun DataFrame.Companion.readTsv(
 
 /**
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] Url
- * @set [CommonReadDelimDocs.DataArg] url
+ * @set [CommonReadDelimDocs.DATA_TITLE] Url
+ * @set [CommonReadDelimDocs.DATA] url
  * @include [DelimParams.URL_READ]
  * @include [TSV_DELIMITER]
  * @include [COMPRESSION]
@@ -191,8 +190,8 @@ public fun DataFrame.Companion.readTsv(
 
 /**
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] File or URL
- * @set [CommonReadDelimDocs.DataArg] file or url
+ * @set [CommonReadDelimDocs.DATA_TITLE] File or URL
+ * @set [CommonReadDelimDocs.DATA] file or url
  * @include [FILE_OR_URL_READ]
  * @include [TSV_DELIMITER]
  * @include [COMPRESSION]
@@ -243,8 +242,8 @@ public fun DataFrame.Companion.readTsv(
 /**
  * {@comment the only one with adjustCsvSpecs}
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] InputStream
- * @set [CommonReadDelimDocs.DataArg] input stream
+ * @set [CommonReadDelimDocs.DATA_TITLE] InputStream
+ * @set [CommonReadDelimDocs.DATA] input stream
  * @include [INPUT_STREAM_READ]
  * @include [TSV_DELIMITER]
  * @include [COMPRESSION]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readTsvStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readTsvStr.kt
@@ -24,8 +24,8 @@ import org.jetbrains.kotlinx.dataframe.impl.io.readDelimImpl
 
 /**
  * @include [CommonReadDelimDocs.TsvDocs]
- * @set [CommonReadDelimDocs.DataTitleArg] String
- * @set [CommonReadDelimDocs.DataArg] [String]
+ * @set [CommonReadDelimDocs.DATA_TITLE] String
+ * @set [CommonReadDelimDocs.DATA] [String]
  * @include [TEXT_READ]
  * @include [TSV_DELIMITER]
  * @include [CommonReadDelimDocs.CommonReadParams]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toCsvStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toCsvStr.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlinx.dataframe.impl.io.writeDelimImpl
 
 /**
  * @include [CommonWriteDelimDocs.CsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Convert
- * @set [CommonWriteDelimDocs.DataTitleArg] String
- * @set [CommonWriteDelimDocs.DataArg] [String]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Convert
+ * @set [CommonWriteDelimDocs.DATA_TITLE] String
+ * @set [CommonWriteDelimDocs.DATA] [String]
  * @include [CSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
  */

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toDelimStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toDelimStr.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlinx.dataframe.impl.io.writeDelimImpl
 
 /**
  * @include [CommonWriteDelimDocs.DelimDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Convert
- * @set [CommonWriteDelimDocs.DataTitleArg] String
- * @set [CommonWriteDelimDocs.DataArg] [String]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Convert
+ * @set [CommonWriteDelimDocs.DATA_TITLE] String
+ * @set [CommonWriteDelimDocs.DATA] [String]
  * @include [DELIM_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
  */

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toTsvStr.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/toTsvStr.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlinx.dataframe.impl.io.writeDelimImpl
 
 /**
  * @include [CommonWriteDelimDocs.TsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Convert
- * @set [CommonWriteDelimDocs.DataTitleArg] String
- * @set [CommonWriteDelimDocs.DataArg] [String]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Convert
+ * @set [CommonWriteDelimDocs.DATA_TITLE] String
+ * @set [CommonWriteDelimDocs.DATA] [String]
  * @include [TSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
  */

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeCsv.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeCsv.kt
@@ -24,9 +24,9 @@ import kotlin.io.path.writer
 
 /**
  * @include [CommonWriteDelimDocs.CsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [CSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -58,9 +58,9 @@ public fun AnyFrame.writeCsv(
 
 /**
  * @include [CommonWriteDelimDocs.CsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [FILE_WRITE]
  * @include [CSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -92,9 +92,9 @@ public fun AnyFrame.writeCsv(
 
 /**
  * @include [CommonWriteDelimDocs.CsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [CSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -127,9 +127,9 @@ public fun AnyFrame.writeCsv(
 /**
  * {@comment only one with adjustCsvFormat}
  * @include [CommonWriteDelimDocs.CsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] Appendable
- * @set [CommonWriteDelimDocs.DataArg] [Appendable]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] Appendable
+ * @set [CommonWriteDelimDocs.DATA] [Appendable]
  * @include [WRITER_WRITE]
  * @include [CSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeDelim.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeDelim.kt
@@ -24,9 +24,9 @@ import kotlin.io.path.writer
 
 /**
  * @include [CommonWriteDelimDocs.DelimDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [DELIM_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -58,9 +58,9 @@ public fun AnyFrame.writeDelim(
 
 /**
  * @include [CommonWriteDelimDocs.DelimDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [FILE_WRITE]
  * @include [DELIM_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -92,9 +92,9 @@ public fun AnyFrame.writeDelim(
 
 /**
  * @include [CommonWriteDelimDocs.DelimDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [DELIM_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -127,9 +127,9 @@ public fun AnyFrame.writeDelim(
 /**
  * {@comment only one with adjustCsvFormat}
  * @include [CommonWriteDelimDocs.DelimDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] Appendable
- * @set [CommonWriteDelimDocs.DataArg] [Appendable]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] Appendable
+ * @set [CommonWriteDelimDocs.DATA] [Appendable]
  * @include [WRITER_WRITE]
  * @include [DELIM_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]

--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeTsv.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/writeTsv.kt
@@ -24,9 +24,9 @@ import kotlin.io.path.writer
 
 /**
  * @include [CommonWriteDelimDocs.TsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [TSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -58,9 +58,9 @@ public fun AnyFrame.writeTsv(
 
 /**
  * @include [CommonWriteDelimDocs.TsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [FILE_WRITE]
  * @include [TSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -92,9 +92,9 @@ public fun AnyFrame.writeTsv(
 
 /**
  * @include [CommonWriteDelimDocs.TsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] File
- * @set [CommonWriteDelimDocs.DataArg] file
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] File
+ * @set [CommonWriteDelimDocs.DATA] file
  * @include [PATH_WRITE]
  * @include [TSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]
@@ -127,9 +127,9 @@ public fun AnyFrame.writeTsv(
 /**
  * {@comment only one with adjustCsvFormat}
  * @include [CommonWriteDelimDocs.TsvDocs]
- * @set [CommonWriteDelimDocs.WriteOrConvertArg] Write
- * @set [CommonWriteDelimDocs.DataTitleArg] Appendable
- * @set [CommonWriteDelimDocs.DataArg] [Appendable]
+ * @set [CommonWriteDelimDocs.WRITE_OR_CONVERT] Write
+ * @set [CommonWriteDelimDocs.DATA_TITLE] Appendable
+ * @set [CommonWriteDelimDocs.DATA] [Appendable]
  * @include [WRITER_WRITE]
  * @include [TSV_DELIMITER]
  * @include [CommonWriteDelimDocs.CommonWriteParams]


### PR DESCRIPTION
attempt to rename all KoDEx argument interfaces to screaming snake case for better readability.

For example "FirstNameArg" -> "FIRST_NAME".

This makes it easier to distinguish between `{@include [Something]}` and `{@get [SOMETHING]}`