### PR TITLE
Rename to camelCase support in compiler plugin

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -85,12 +85,8 @@ public fun <T, C> RenameClause<T, C>.into(transform: (ColumnWithPath<C>) -> Stri
  * Renames the selected columns to `camelCase` by replacing all [delimiters][DELIMITERS_REGEX]
  * and converting the first char to lowercase.
  */
-public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> =
-    into {
-        it.name()
-            .toCamelCaseByDelimiters(DELIMITERS_REGEX)
-            .replaceFirstChar { it.lowercaseChar() }
-    }
+@Refine
+@Interpretable("RenameToCamelCaseClause")
 public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> = into { it.renameToCamelCase().name() }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -91,10 +91,25 @@ public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> =
             .toCamelCaseByDelimiters(DELIMITERS_REGEX)
             .replaceFirstChar { it.lowercaseChar() }
     }
+public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> = into { it.renameToCamelCase().name() }
 
 // endregion
 
 // region DataColumn
+
+/**
+ * ## Rename to camelCase
+ *
+ * Renames this column to `camelCase` by replacing all [delimiters][DELIMITERS_REGEX]
+ * and converting the first char to lowercase.
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <T, C : ColumnReference<T>> C.renameToCamelCase(): C =
+    rename(
+        this.name()
+            .toCamelCaseByDelimiters(DELIMITERS_REGEX)
+            .replaceFirstChar { it.lowercaseChar() },
+    ) as C
 
 @Suppress("UNCHECKED_CAST")
 public fun <T, C : ColumnReference<T>> C.rename(column: KProperty<T>): C = rename(column.columnName) as C

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -52,6 +52,8 @@ public class RenameClause<T, C>(internal val df: DataFrame<T>, internal val colu
  * and converting the first char to lowercase.
  * Even [DataFrames][DataFrame] inside [FrameColumns][FrameColumn] are traversed recursively.
  */
+@Refine
+@Interpretable("RenameToCamelCase")
 public fun <T> DataFrame<T>.renameToCamelCase(): DataFrame<T> =
     // recursively rename all columns written with delimiters or starting with a capital to camel case
     rename {

--- a/plugins/expressions-converter/tests-gen/org/jetbrains/kotlinx/dataframe/ExplainerBlackBoxCodegenTestGenerated.java
+++ b/plugins/expressions-converter/tests-gen/org/jetbrains/kotlinx/dataframe/ExplainerBlackBoxCodegenTestGenerated.java
@@ -5,7 +5,6 @@ package org.jetbrains.kotlinx.dataframe;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TestMetadata;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -16,26 +15,26 @@ import java.util.regex.Pattern;
 @TestMetadata("testData/box")
 @TestDataPath("$PROJECT_ROOT")
 public class ExplainerBlackBoxCodegenTestGenerated extends AbstractExplainerBlackBoxCodegenTest {
-    @Test
-    public void testAllFilesPresentInBox() throws Exception {
-        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("testData/box"), Pattern.compile("^(.+)\\.kt$"), null, true);
-    }
+  @Test
+  public void testAllFilesPresentInBox() {
+    KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("testData/box"), Pattern.compile("^(.+)\\.kt$"), null, true);
+  }
 
-    @Test
-    @TestMetadata("any.kt")
-    public void testAny() throws Exception {
-        runTest("testData/box/any.kt");
-    }
+  @Test
+  @TestMetadata("any.kt")
+  public void testAny() {
+    runTest("testData/box/any.kt");
+  }
 
-    @Test
-    @TestMetadata("df.kt")
-    public void testDf() throws Exception {
-        runTest("testData/box/df.kt");
-    }
+  @Test
+  @TestMetadata("df.kt")
+  public void testDf() {
+    runTest("testData/box/df.kt");
+  }
 
-    @Test
-    @TestMetadata("test.kt")
-    public void testTest() throws Exception {
-        runTest("testData/box/test.kt");
-    }
+  @Test
+  @TestMetadata("test.kt")
+  public void testTest() {
+    runTest("testData/box/test.kt");
+  }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
-import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.renameToCamelCase
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
@@ -18,9 +17,8 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.toPluginDataFrameSchema
 class Rename : AbstractInterpreter<RenameClauseApproximation>() {
     private val Arguments.receiver by dataFrame()
     private val Arguments.columns: ColumnsResolver by arg()
-    override fun Arguments.interpret(): RenameClauseApproximation {
-        return RenameClauseApproximation(receiver, columns)
-    }
+
+    override fun Arguments.interpret(): RenameClauseApproximation = RenameClauseApproximation(receiver, columns)
 }
 
 class RenameClauseApproximation(val schema: PluginDataFrameSchema, val columns: ColumnsResolver)
@@ -33,36 +31,45 @@ class RenameInto : AbstractSchemaModificationInterpreter() {
         val columns = receiver.columns.resolve(receiver.schema)
         require(columns.size == newNames.size)
         var i = 0
-        return receiver.schema.map(columns.mapTo(mutableSetOf()) { it.path.path }, nextName = { newNames[i].also { i += 1 } })
+        return receiver.schema.map(
+            selected = columns.mapTo(mutableSetOf()) { it.path.path },
+            nextName = { newNames[i].also { i += 1 } },
+        )
     }
 }
 
-internal fun PluginDataFrameSchema.map(selected: ColumnsSet, nextName: () -> String): PluginDataFrameSchema {
-    return PluginDataFrameSchema(
-        f(columns(), nextName, selected, emptyList())
+internal fun PluginDataFrameSchema.map(selected: ColumnsSet, nextName: () -> String): PluginDataFrameSchema =
+    PluginDataFrameSchema(
+        f(columns(), nextName, selected, emptyList()),
     )
-}
 
-internal fun f(columns: List<SimpleCol>, nextName: () -> String, selected: ColumnsSet, path: List<String>): List<SimpleCol> {
-    return columns.map {
+internal fun f(
+    columns: List<SimpleCol>,
+    nextName: () -> String,
+    selected: ColumnsSet,
+    path: List<String>,
+): List<SimpleCol> =
+    columns.map {
         val fullPath = path + listOf(it.name)
         when (it) {
             is SimpleColumnGroup -> {
                 val group = if (fullPath in selected) {
                     it.rename(nextName())
-                }  else {
+                } else {
                     it
                 }
                 group.map(selected, fullPath, nextName)
             }
+
             is SimpleFrameColumn -> {
                 val frame = if (fullPath in selected) {
                     it.rename(nextName())
-                }  else {
+                } else {
                     it
                 }
                 frame.map(selected, fullPath, nextName)
             }
+
             is SimpleDataColumn -> if (fullPath in selected) {
                 it.rename(nextName())
             } else {
@@ -70,21 +77,26 @@ internal fun f(columns: List<SimpleCol>, nextName: () -> String, selected: Colum
             }
         }
     }
-}
 
-internal fun SimpleColumnGroup.map(selected: ColumnsSet, path: List<String>, nextName: () -> String): SimpleColumnGroup {
-    return SimpleColumnGroup(
-        name,
-        f(columns(), nextName, selected, path)
+internal fun SimpleColumnGroup.map(
+    selected: ColumnsSet,
+    path: List<String>,
+    nextName: () -> String,
+): SimpleColumnGroup =
+    SimpleColumnGroup(
+        name = name,
+        columns = f(columns(), nextName, selected, path),
     )
-}
 
-internal fun SimpleFrameColumn.map(selected: ColumnsSet, path: List<String>, nextName: () -> String): SimpleFrameColumn {
-    return SimpleFrameColumn(
-        name,
-        f(columns(), nextName, selected, path)
+internal fun SimpleFrameColumn.map(
+    selected: ColumnsSet,
+    path: List<String>,
+    nextName: () -> String,
+): SimpleFrameColumn =
+    SimpleFrameColumn(
+        name = name,
+        columns = f(columns(), nextName, selected, path),
     )
-}
 
 class RenameToCamelCase : AbstractSchemaModificationInterpreter() {
     val Arguments.receiver by dataFrame()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/rename.kt
@@ -9,6 +9,9 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleDataColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleColumnGroup
 import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleFrameColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.toPluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.api.renameToCamelCase
 
 class Rename : AbstractInterpreter<RenameClauseApproximation>() {
     private val Arguments.receiver by dataFrame()
@@ -79,4 +82,12 @@ internal fun SimpleFrameColumn.map(selected: ColumnsSet, path: List<String>, nex
         name,
         f(columns(), nextName, selected, path)
     )
+}
+
+class RenameToCamelCase : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver by dataFrame()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return receiver.asDataFrame().renameToCamelCase().toPluginDataFrameSchema()
+    }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -103,6 +103,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Update0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.UpdateWith0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ValueCounts
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCase
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCaseClause
 import org.jetbrains.kotlinx.dataframe.plugin.utils.Names
 
 internal fun FirFunctionCall.loadInterpreter(session: FirSession): Interpreter<*>? {
@@ -253,6 +254,7 @@ internal inline fun <reified T> String.load(): T {
         "DataFrameOf3" -> DataFrameOf3()
         "ValueCounts" -> ValueCounts()
         "RenameToCamelCase" -> RenameToCamelCase()
+        "RenameToCamelCaseClause" -> RenameToCamelCaseClause()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -102,6 +102,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.TrimMargin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Update0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.UpdateWith0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ValueCounts
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCase
 import org.jetbrains.kotlinx.dataframe.plugin.utils.Names
 
 internal fun FirFunctionCall.loadInterpreter(session: FirSession): Interpreter<*>? {
@@ -251,6 +252,7 @@ internal inline fun <reified T> String.load(): T {
         "Aggregate" -> Aggregate()
         "DataFrameOf3" -> DataFrameOf3()
         "ValueCounts" -> ValueCounts()
+        "RenameToCamelCase" -> RenameToCamelCase()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/testData/box/renameToCamelCase.kt
+++ b/plugins/kotlin-dataframe/testData/box/renameToCamelCase.kt
@@ -4,31 +4,46 @@ import org.jetbrains.kotlinx.dataframe.api.*
 import org.jetbrains.kotlinx.dataframe.io.*
 
 fun box(): String {
-    // Create DataFrame with snake_case column names
+    // Test DataFrame.renameToCamelCase()
     val df = dataFrameOf("first_name", "last_name", "user_age")(
         "John", "Doe", 30
     )
-
-    // Rename columns to camelCase
     val renamed = df.renameToCamelCase()
 
-    // Access columns through generated extension properties
-    if (renamed.firstName[0] != "John") return "Extension property 'firstName' failed"
-    if (renamed.lastName[0] != "Doe") return "Extension property 'lastName' failed"
-    if (renamed.userAge[0] != 30) return "Extension property 'userAge' failed"
+    // Verify extension properties
+    if (renamed.firstName[0] != "John") return "DataFrame.renameToCamelCase: 'firstName' failed"
+    if (renamed.lastName[0] != "Doe") return "DataFrame.renameToCamelCase: 'lastName' failed"
+    if (renamed.userAge[0] != 30) return "DataFrame.renameToCamelCase: 'userAge' failed"
 
-    // Test nested DataFrame renaming
+    // Test RenameClause.toCamelCase()
+    val df2 = dataFrameOf("first_name", "last_name", "user_age")(
+        "Jane", "Smith", 25
+    )
+    val renamed2 = df2.rename { first_name and last_name and user_age }.toCamelCase()
+
+    // Verify extension properties for RenameClause.toCamelCase
+    if (renamed2.firstName[0] != "Jane") return "RenameClause.toCamelCase: 'firstName' failed"
+    if (renamed2.lastName[0] != "Smith") return "RenameClause.toCamelCase: 'lastName' failed"
+    if (renamed2.userAge[0] != 25) return "RenameClause.toCamelCase: 'userAge' failed"
+
+    // Test nested DataFrame with both methods
     val nestedDf = dataFrameOf("user_info")(
         dataFrameOf("first_name", "last_name")(
             "John", "Doe"
         )
     )
-    val renamedNested = nestedDf.renameToCamelCase()
 
-    // Access nested columns through generated extension properties
+    // Test DataFrame.renameToCamelCase with nested
+    val renamedNested = nestedDf.renameToCamelCase()
     val nestedData = renamedNested.userInfo[0]
-    if (nestedData.firstName[0] != "John") return "Extension property 'firstName' failed"
-    if (nestedData.lastName[0] != "Doe") return "Extension property 'lastName' failed"
+    if (nestedData.firstName[0] != "John") return "Nested DataFrame.renameToCamelCase: 'firstName' failed"
+    if (nestedData.lastName[0] != "Doe") return "Nested DataFrame.renameToCamelCase: 'lastName' failed"
+
+    // Test RenameClause.toCamelCase with nested, only uses selection
+    val renamedNested2 = nestedDf.rename { all() }.toCamelCase()
+    val nestedData2 = renamedNested2.userInfo[0]
+    if (nestedData2.first_name[0] != "John") return "Nested RenameClause.toCamelCase: 'first_name' failed"
+    if (nestedData2.last_name[0] != "Doe") return "Nested RenameClause.toCamelCase: 'last_name' failed"
 
     return "OK"
 }

--- a/plugins/kotlin-dataframe/testData/box/renameToCamelCase.kt
+++ b/plugins/kotlin-dataframe/testData/box/renameToCamelCase.kt
@@ -1,0 +1,34 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    // Create DataFrame with snake_case column names
+    val df = dataFrameOf("first_name", "last_name", "user_age")(
+        "John", "Doe", 30
+    )
+
+    // Rename columns to camelCase
+    val renamed = df.renameToCamelCase()
+
+    // Access columns through generated extension properties
+    if (renamed.firstName[0] != "John") return "Extension property 'firstName' failed"
+    if (renamed.lastName[0] != "Doe") return "Extension property 'lastName' failed"
+    if (renamed.userAge[0] != 30) return "Extension property 'userAge' failed"
+
+    // Test nested DataFrame renaming
+    val nestedDf = dataFrameOf("user_info")(
+        dataFrameOf("first_name", "last_name")(
+            "John", "Doe"
+        )
+    )
+    val renamedNested = nestedDf.renameToCamelCase()
+
+    // Access nested columns through generated extension properties
+    val nestedData = renamedNested.userInfo[0]
+    if (nestedData.firstName[0] != "John") return "Extension property 'firstName' failed"
+    if (nestedData.lastName[0] != "Doe") return "Extension property 'lastName' failed"
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -407,6 +407,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("renameToCamelCase.kt")
+  public void testRenameToCamelCase() {
+    runTest("testData/box/renameToCamelCase.kt");
+  }
+
+  @Test
   @TestMetadata("Schema.kt")
   public void testSchema() {
     runTest("testData/box/Schema.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameDiagnosticTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameDiagnosticTestGenerated.java
@@ -33,6 +33,12 @@ public class DataFrameDiagnosticTestGenerated extends AbstractDataFrameDiagnosti
   }
 
   @Test
+  @TestMetadata("renameToCamelCase.kt")
+  public void testRenameToCamelCase() {
+    runTest("testData/diagnostics/renameToCamelCase.kt");
+  }
+
+  @Test
   @TestMetadata("selectDuringTyping.kt")
   public void testSelectDuringTyping() {
     runTest("testData/diagnostics/selectDuringTyping.kt");


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1025

Adds compiler plugin support for `DataFrame.renameToCamelCase()` and `DataFrame.rename {}.toCamelCase()`

Got some help from Junie :) The first function was almost entirely written by AI, the second one needed a more guiding hand from me.

See commit messages for more specifics