### PR TITLE
Add @CandidateForRemoval annotation

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/CandidateForRemoval.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/CandidateForRemoval.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.kotlinx.dataframe.annotations
+
+/**
+ * Functions that can be replaced with other API, such as shortcuts without clean value,
+ * or something not properly designed, and so will be considered to be removed from API.
+ * If you see a function marked with it and think it should be kept, please let us know in the GitHub issue:
+ * https://github.com/Kotlin/dataframe/issues/1028
+ */
+internal annotation class CandidateForRemoval

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.CandidateForRemoval
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.impl.columnName
@@ -20,8 +21,10 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
+@CandidateForRemoval
 public fun AnyRow.isEmpty(): Boolean = owner.columns().all { it[index] == null }
 
+@CandidateForRemoval
 public fun AnyRow.isNotEmpty(): Boolean = !isEmpty()
 
 public inline fun <reified R> AnyRow.valuesOf(): List<R> = values().filterIsInstance<R>()
@@ -166,12 +169,16 @@ public fun AnyRow.columnNames(): List<String> = df().columnNames()
 
 public fun AnyRow.columnTypes(): List<KType> = df().columnTypes()
 
+@CandidateForRemoval
 public fun <T> DataRow<T>.getRow(index: Int): DataRow<T> = getRowOrNull(index)!!
 
+@CandidateForRemoval
 public fun <T> DataRow<T>.getRows(indices: Iterable<Int>): DataFrame<T> = df().getRows(indices)
 
+@CandidateForRemoval
 public fun <T> DataRow<T>.getRows(indices: IntRange): DataFrame<T> = df().getRows(indices)
 
+@CandidateForRemoval
 public fun <T> DataRow<T>.getRowOrNull(index: Int): DataRow<T>? {
     val df = df()
     return if (index >= 0 && index < df.nrow) df[index] else null

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/copy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/copy.kt
@@ -1,9 +1,10 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
-
+import org.jetbrains.kotlinx.dataframe.annotations.CandidateForRemoval
 // region DataFrame
 
+@CandidateForRemoval
 public fun <T> DataFrame<T>.copy(): DataFrame<T> = columns().toDataFrame().cast()
 
 // endregion


### PR DESCRIPTION
https://github.com/Kotlin/dataframe/issues/1028

For `DataRow.isEmpty` and `DataRow.isNotEmpty` is hard to imagine situation where it'd be used
`DataFrame.copy` is useless 
`DataRow.getRows()` is a short cut that can be easily replaced, and also hard to imagine a usecase