### PR TITLE
Allow running Gradle tasks with -PskipKodex to publish locally faster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,10 @@ This library is built with Gradle.
   things up during development.
 * Make sure to pass the extra parameter `-Pkotlin.dataframe.debug=true` to enable debug mode. This flag will
   make sure some extra checks are run, which are important but too heavy for production.
+* The parameter `-PskipKodex` allows you to skip [kdoc processing](KDOC_PREPROCESSING.md),
+  making local publishing faster: `./gradlew publishToMavenLocal -PskipKodex`.
+  This, however, publishes the library with "broken" KDocs, 
+  so it's only meant for faster iterations during development.
 
 You can import this project into IDEA, but you have to delegate the build actions
 to Gradle (in Preferences -> Build, Execution, Deployment -> Build Tools -> Gradle -> Runner)

--- a/KDOC_PREPROCESSING.md
+++ b/KDOC_PREPROCESSING.md
@@ -57,6 +57,8 @@ This can be seen in action in the `core:processKDocsMain` and `core:changeJarTas
 `processKDocsMain` task is executed first, which processes the KDocs in the source files and writes them to the
 `generated-sources` folder. The `changeJarTask` task then makes sure that any `Jar` task in the `core` module uses the
 `generated-sources` folder as the source directory instead of the normal `src` folder.
+It's possible to optionally skip this step, for example, when you publish the library locally during development, 
+by providing the `-PskipKodex` project property: `./gradlew publishToMavenLocal -PskipKodex`
 
 `core:processKDocsMain` can also be run separately if you just want to see the result of the KDoc processing by KoDEx.
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -237,7 +237,7 @@ idea {
 // the target of `processKdocMain`, and they are returned to normal afterward.
 // This is usually only done when publishing
 val changeJarTask by tasks.creating {
-    outputs.upToDateWhen { false }
+    outputs.upToDateWhen { project.hasProperty("skipKodex") }
     doFirst {
         tasks.withType<Jar> {
             doFirst {
@@ -266,7 +266,7 @@ tasks.withType<Jar> {
 
 // modify all publishing tasks to depend on `changeJarTask` so the sources are swapped out with generated sources
 tasks.configureEach {
-    if (name.startsWith("publish")) {
+    if (!project.hasProperty("skipKodex") && name.startsWith("publish")) {
         dependsOn(processKDocsMain, changeJarTask)
     }
 }


### PR DESCRIPTION
So by default we will run everything, but with this extra parameter build will ignore configuration that changes jar and triggers processing
![image](https://github.com/user-attachments/assets/bae663b2-9c6c-4696-963c-adfb360785bc)
