### PR TITLE
All except simplification: Option 1

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9410,6 +9410,9 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$COLUMN_SET_PART {
 }
 
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumNameDef {
+}
+
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnDef {
 }
 
@@ -9437,10 +9440,13 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/Ds
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnKindRef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnNoAccessorDef {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnNameRef {
 }
 
-public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnNoAccessorRef {
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnNoPathDef {
+}
+
+public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnNoPathRef {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl$DslGrammarTemplate$ColumnOrColumnSetDef {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl.kt
@@ -128,7 +128,9 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
          *
          * {@include [DslGrammarTemplate.ColumnGroupDef]}
          *
-         * {@include [DslGrammarTemplate.ColumnNoAccessorDef]}
+         * {@include [DslGrammarTemplate.ColumNameDef]}
+         *
+         * {@include [DslGrammarTemplate.ColumnNoPathDef]}
          *
          * {@include [DslGrammarTemplate.ColumnOrColumnSetDef]}
          *
@@ -180,7 +182,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
          *
          * `| `{@include [AllExceptColumnsSelectionDsl.Grammar.PlainDslName]}**`  {  `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**` \}`**
          *
-         * `| `{@include [AllExceptColumnsSelectionDsl.Grammar.PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**` ..`**`)`**
+         * `| `{@include [AllExceptColumnsSelectionDsl.Grammar.PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnNoPathRef]}**`,`**` ..`**`)`**
          *
          * `| `{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}` `{@include [AndColumnsSelectionDsl.Grammar.InfixName]}`  [  `**`{`**`  ]  `{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}`  [  `**`\}`**`  ]  `
          *
@@ -307,7 +309,7 @@ public interface ColumnsSelectionDsl<out T> : // SingleColumn<DataRow<T>>
          *
          * {@include [Indent]}`| `{@include [AllExceptColumnsSelectionDsl.Grammar.ColumnGroupName]}**`  {  `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**`  \}  `**
          *
-         * {@include [Indent]}`| `{@include [AllExceptColumnsSelectionDsl.Grammar.ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnNoAccessorRef]}**`,`**` ..`**`)`**
+         * {@include [Indent]}`| `{@include [AllExceptColumnsSelectionDsl.Grammar.ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnNameRef]}**`,`**` ..`**`)`**
          *
          * {@include [Indent]}`| `{@include [AndColumnsSelectionDsl.Grammar.Name]}**` (`**`|`**`{ `**{@include [DslGrammarTemplate.ColumnOrColumnSetRef]}**` \}`**`|`**`)`**
          *

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
@@ -343,13 +343,7 @@ public interface AllExceptColumnsSelectionDsl {
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: KProperty<*>): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
 
-    /**
-     * @include [ColumnsSelectionDslDocs]
-     * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
-     *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(pathOf("age"), "userdata"["height"])`
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `("name"["firstName"], "name"["middleName"])`
-     */
+    @Deprecated(message = ALL_EXCEPT_COLUMN_PATH, level = DeprecationLevel.ERROR)
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: ColumnPath): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
 
@@ -436,15 +430,6 @@ public interface AllExceptColumnsSelectionDsl {
          * @set [ColumnGroupDocs.ARGUMENT_2] `(Person::firstName, Person::middleName)`
          */
         interface KPropertyArgs
-
-        /**
-         * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
-         *  the columns (relative to the column group) that need to be excluded from the current selection in [this\]
-         *  column group. The other columns will be included in the selection by default.
-         * @set [ColumnGroupDocs.ARGUMENT_1] `(pathOf("age"), "extraData"["item1"])`
-         * @set [ColumnGroupDocs.ARGUMENT_2] `(pathOf("firstName"), "middleNames"["first"])`
-         */
-        interface ColumnPathArgs
     }
 
     /**
@@ -487,11 +472,7 @@ public interface AllExceptColumnsSelectionDsl {
     public fun SingleColumn<DataRow<*>>.allColsExcept(vararg others: KProperty<*>): ColumnSet<*> =
         allColsExceptInternal(others.toColumnSet())
 
-    /**
-     * @include [ColumnGroupDocs]
-     * @include [ColumnGroupDocs.SingleColumnReceiverArgs]
-     * @include [ColumnGroupDocs.ColumnPathArgs]
-     */
+    @Deprecated(message = ALL_COLS_EXCEPT_COLUMN_PATH, level = DeprecationLevel.ERROR)
     public fun SingleColumn<DataRow<*>>.allColsExcept(vararg other: ColumnPath): ColumnSet<*> =
         allColsExceptInternal(other.toColumnSet())
 
@@ -539,11 +520,7 @@ public interface AllExceptColumnsSelectionDsl {
     public fun String.allColsExcept(vararg others: KProperty<*>): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 
-    /**
-     * @include [ColumnGroupDocs]
-     * @include [ColumnGroupDocs.StringReceiverArgs]
-     * @include [ColumnGroupDocs.ColumnPathArgs]
-     */
+    @Deprecated(message = ALL_COLS_EXCEPT_COLUMN_PATH, level = DeprecationLevel.ERROR)
     public fun String.allColsExcept(vararg others: ColumnPath): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 
@@ -591,11 +568,7 @@ public interface AllExceptColumnsSelectionDsl {
     public fun KProperty<*>.allColsExcept(vararg others: KProperty<*>): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 
-    /**
-     * @include [ColumnGroupDocs]
-     * @include [ColumnGroupDocs.KPropertyReceiverArgs]
-     * @include [ColumnGroupDocs.ColumnPathArgs]
-     */
+    @Deprecated(message = ALL_COLS_EXCEPT_COLUMN_PATH, level = DeprecationLevel.ERROR)
     public fun KProperty<*>.allColsExcept(vararg others: ColumnPath): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 
@@ -643,11 +616,7 @@ public interface AllExceptColumnsSelectionDsl {
     public fun ColumnPath.allColsExcept(vararg others: KProperty<*>): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 
-    /**
-     * @include [ColumnGroupDocs]
-     * @include [ColumnGroupDocs.ColumnPathReceiverArgs]
-     * @include [ColumnGroupDocs.ColumnPathArgs]
-     */
+    @Deprecated(message = ALL_COLS_EXCEPT_COLUMN_PATH, level = DeprecationLevel.ERROR)
     public fun ColumnPath.allColsExcept(vararg others: ColumnPath): ColumnSet<*> =
         columnGroup(this).allColsExceptInternal(others.toColumnSet())
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
@@ -18,8 +18,10 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.toColumns
 import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.columns.removeAll
 import org.jetbrains.kotlinx.dataframe.util.ALL_COLS_EXCEPT
+import org.jetbrains.kotlinx.dataframe.util.ALL_COLS_EXCEPT_COLUMN_PATH
 import org.jetbrains.kotlinx.dataframe.util.ALL_COLS_REPLACE
 import org.jetbrains.kotlinx.dataframe.util.ALL_COLS_REPLACE_VARARG
+import org.jetbrains.kotlinx.dataframe.util.ALL_EXCEPT_COLUMN_PATH
 import kotlin.reflect.KProperty
 
 // region ColumnsSelectionDsl
@@ -45,7 +47,9 @@ public interface AllExceptColumnsSelectionDsl {
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnDef]}
      *  {@include [LineBreak]}
-     *  {@include [DslGrammarTemplate.ColumnNoAccessorDef]}
+     *  {@include [DslGrammarTemplate.ColumNameDef]}
+     *  {@include [LineBreak]}
+     *  {@include [DslGrammarTemplate.ColumnNoPathDef]}
      *  {@include [LineBreak]}
      *  {@include [DslGrammarTemplate.ColumnsResolverDef]}
      * }
@@ -53,7 +57,7 @@ public interface AllExceptColumnsSelectionDsl {
      * {@set [DslGrammarTemplate.PLAIN_DSL_FUNCTIONS]
      *  {@include [PlainDslName]}**`   {   `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**` \}`**
      *
-     *  `| `{@include [PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnRef]}**`,`**` ..`**`)`**
+     *  `| `{@include [PlainDslName]}**`(`**{@include [DslGrammarTemplate.ColumnNoPathRef]}**`,`**` ..`**`)`**
      * }
      * {@set [DslGrammarTemplate.COLUMN_SET_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnSetName]}` [`**`  {  `**`] `{@include [DslGrammarTemplate.ColumnsResolverRef]}` [`**`  \}  `**`]`
@@ -65,7 +69,7 @@ public interface AllExceptColumnsSelectionDsl {
      * {@set [DslGrammarTemplate.COLUMN_GROUP_FUNCTIONS]
      *  {@include [Indent]}{@include [ColumnGroupName]}**`  {  `**{@include [DslGrammarTemplate.ColumnsSelectorRef]}**`  \}  `**
      *
-     *  {@include [Indent]}`| `{@include [ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnNoAccessorRef]}**`,`**` ..`**`)`**
+     *  {@include [Indent]}`| `{@include [ColumnGroupName]}**`(`**{@include [DslGrammarTemplate.ColumnNameRef]}**`,`**` ..`**`)`**
      * }
      */
     public interface Grammar {
@@ -170,9 +174,9 @@ public interface AllExceptColumnsSelectionDsl {
     /**
      * @include [CommonExceptDocs]
      * {@set [CommonExceptDocs.EXAMPLE]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>() `[except][ColumnSet.except]` `{@get [ARGUMENT_1]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>() `[except][ColumnSet.except]` {@get [ARGUMENT_1]} \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age) `[except][ColumnSet.except]` `{@get [ARGUMENT_2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age) `[except][ColumnSet.except]` {@get [ARGUMENT_2]} \}`
      * }
      */
     private interface ColumnSetInfixDocs {
@@ -187,9 +191,9 @@ public interface AllExceptColumnsSelectionDsl {
     /**
      * @include [CommonExceptDocs]
      * {@set [CommonExceptDocs.EXAMPLE]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>().`[except][ColumnSet.except]{@get [ARGUMENT_1]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[Number][Number]`>().`[except][ColumnSet.except]`{@get [ARGUMENT_1]} \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age).`[except][ColumnSet.except]{@get [ARGUMENT_2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[cols][ColumnsSelectionDsl.cols]`(name, age).`[except][ColumnSet.except]`{@get [ARGUMENT_2]} \}`
      * }
      */
     private interface ColumnSetVarargDocs {
@@ -205,8 +209,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetInfixDocs]
      * @set [CommonExceptDocs.PARAM] @param [selector\] A lambda in which you specify the columns that need to be
      *   excluded from the [ColumnSet]. The scope of the selector is the same as the outer scope.
-     * @set [ColumnSetInfixDocs.ARGUMENT_1] `{ "age" `[and][ColumnsSelectionDsl.and]` height }`
-     * @set [ColumnSetInfixDocs.ARGUMENT_2] `{ name.firstName }`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] { "age" `[and][ColumnsSelectionDsl.and]` height }
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] { name.firstName }
      */
     public infix fun <C> ColumnSet<C>.except(selector: () -> ColumnsResolver<*>): ColumnSet<C> = except(selector())
 
@@ -214,8 +218,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetInfixDocs]
      * @set [CommonExceptDocs.PARAM] @param [other\] A [ColumnsResolver] containing the columns that need to be
      *   excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"age" `[and][ColumnsSelectionDsl.and]` height`
-     * @set [ColumnSetInfixDocs.ARGUMENT_2] `name.firstName`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] "age" `[and][ColumnsSelectionDsl.and]` height
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] name.firstName
      */
     public infix fun <C> ColumnSet<C>.except(other: ColumnsResolver<*>): ColumnSet<C> = exceptInternal(other)
 
@@ -223,8 +227,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetVarargDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnsResolvers][ColumnsResolver] containing
      *  the columns that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(age, userData.height)`
-     * @set [ColumnSetVarargDocs.ARGUMENT_2] `(name.firstName, name.middleName)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] (age, userData.height)
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] (name.firstName, name.middleName)
      */
     public fun <C> ColumnSet<C>.except(vararg others: ColumnsResolver<*>): ColumnSet<C> = except(others.toColumnSet())
 
@@ -232,8 +236,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetInfixDocs]
      * @set [CommonExceptDocs.PARAM] @param [other\] A [String] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"age"`
-     * @set [ColumnSetInfixDocs.ARGUMENT_2] `"name"`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] "age"
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] "name"
      */
     public infix fun <C> ColumnSet<C>.except(other: String): ColumnSet<C> = except(column<Any?>(other))
 
@@ -241,8 +245,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetVarargDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [Strings][String] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ARGUMENT_1] `("age", "height")`
-     * @set [ColumnSetVarargDocs.ARGUMENT_2] `("name")`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] ("age", "height")
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] ("name")
      */
     public fun <C> ColumnSet<C>.except(vararg others: String): ColumnSet<C> = except(others.toColumnSet())
 
@@ -250,8 +254,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetInfixDocs]
      * @set [CommonExceptDocs.PARAM] @param [other\] A [KProperty] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ARGUMENT_1] `Person::age`
-     * @set [ColumnSetInfixDocs.ARGUMENT_2] `Person::name`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] Person::age
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] Person::name
      */
     public infix fun <C> ColumnSet<C>.except(other: KProperty<C>): ColumnSet<C> = except(column(other))
 
@@ -259,8 +263,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetVarargDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [KProperties][KProperty] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(Person::age, Person::height)`
-     * @set [ColumnSetVarargDocs.ARGUMENT_2] `(Person::name)`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] (Person::age, Person::height)
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] (Person::name)
      */
     public fun <C> ColumnSet<C>.except(vararg others: KProperty<C>): ColumnSet<C> = except(others.toColumnSet())
 
@@ -268,8 +272,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetInfixDocs]
      * @set [CommonExceptDocs.PARAM] @param [other\] A [ColumnPath] referring to
      *  the column (relative to the current scope) that needs to be excluded from the [ColumnSet].
-     * @set [ColumnSetInfixDocs.ARGUMENT_1] `"userdata"["age"]`
-     * @set [ColumnSetInfixDocs.ARGUMENT_2] `pathOf("name", "firstName")`
+     * @set [ColumnSetInfixDocs.ARGUMENT_1] "userdata"["age"]
+     * @set [ColumnSetInfixDocs.ARGUMENT_2] pathOf("name", "firstName")
      */
     public infix fun <C> ColumnSet<C>.except(other: ColumnPath): ColumnSet<C> = except(column<Any?>(other))
 
@@ -277,8 +281,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnSetVarargDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [ColumnPaths][ColumnPath] referring to
      *  the columns (relative to the current scope) that need to be excluded from the [ColumnSet].
-     * @set [ColumnSetVarargDocs.ARGUMENT_1] `(pathOf("age"), "userdata"["height"])`
-     * @set [ColumnSetVarargDocs.ARGUMENT_2] `("name"["firstName"], "name"["middleName"])`
+     * @set [ColumnSetVarargDocs.ARGUMENT_1] (pathOf("age"), "userdata"["height"])
+     * @set [ColumnSetVarargDocs.ARGUMENT_2] ("name"["firstName"], "name"["middleName"])
      */
     public fun <C> ColumnSet<C>.except(vararg others: ColumnPath): ColumnSet<C> = except(others.toColumnSet())
 
@@ -289,9 +293,9 @@ public interface AllExceptColumnsSelectionDsl {
     /**
      * @include [CommonExceptDocs]
      * @set [CommonExceptDocs.EXAMPLE]
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ARGUMENT_1]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]`{@get [ARGUMENT_1]} \}`
      *
-     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]{@get [ARGUMENT_2]}` \}`
+     *  `df.`[select][ColumnsSelectionDsl.select]`  {  `[allExcept][ColumnsSelectionDsl.allExcept]`{@get [ARGUMENT_2]} \}`
      */
     private interface ColumnsSelectionDslDocs {
 
@@ -306,8 +310,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnsSelectionDslDocs]
      * @set [CommonExceptDocs.PARAM] @param [selector\] A lambda in which you specify the columns that need to be
      *  excluded from the current selection. The scope of the selector is the same as the outer scope.
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `  { "age"  `[and][ColumnsSelectionDsl.and]` height }`
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] ` { name.firstName }`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] \ { "age"  `[and][ColumnsSelectionDsl.and]` height }
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] \ { name.firstName }
      */
     public fun <C> ColumnsSelectionDsl<C>.allExcept(selector: ColumnsSelector<C, *>): ColumnSet<*> =
         this.asSingleColumn().allColsExcept(selector)
@@ -317,8 +321,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnsSelectionDslDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] A [ColumnsResolver] containing the columns that need to be
      *  excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(age, height)`
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `(name.firstName, name.middleName)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] (age, height)
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] (name.firstName, name.middleName)
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: ColumnsResolver<*>): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
@@ -327,8 +331,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnsSelectionDslDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [Strings][String] referring to
      *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `("age", "height")`
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `("name")`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] ("age", "height")
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] ("name")
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: String): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())
@@ -337,8 +341,8 @@ public interface AllExceptColumnsSelectionDsl {
      * @include [ColumnsSelectionDslDocs]
      * @set [CommonExceptDocs.PARAM] @param [others\] Any number of [KProperties][KProperty] referring to
      *  the columns (relative to the current scope) that need to be excluded from the current selection.
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] `(Person::age, Person::height)`
-     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] `(Person::name)`
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_1] (Person::age, Person::height)
+     * @set [ColumnsSelectionDslDocs.ARGUMENT_2] (Person::name)
      */
     public fun ColumnsSelectionDsl<*>.allExcept(vararg others: KProperty<*>): ColumnSet<*> =
         asSingleColumn().allColsExceptInternal(others.toColumnSet())

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -61,7 +61,9 @@ public fun <T> Pivot<T>.groupBy(vararg columns: KProperty<*>): PivotGroupBy<T> =
 public fun <T> Pivot<T>.groupByOther(): PivotGroupBy<T> {
     val impl = this as PivotImpl<T>
     val pivotColumns = df.getPivotColumnPaths(columns).toColumnSet()
-    return impl.toGroupedPivot(moveToTop = false) { allExcept(pivotColumns) }
+    return impl.toGroupedPivot(moveToTop = false) {
+        (this as DataFrame<T>).remove { pivotColumns }.columns().toColumnSet()
+    }
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ColumnSet.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ColumnSet.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.api.asSingleColumn
  * ## ColumnSet
  *
  * Entity that can be resolved into a list of [columns][DataColumn].
+ * Unlike an actual "set", repeated columns are allowed.
  * Just like [SingleColumn], this is a [ColumnsResolver].
  *
  * @see [SingleColumn]

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DslGrammarTemplateColumnsSelectionDsl.kt
@@ -115,8 +115,11 @@ public interface DslGrammarTemplateColumnsSelectionDsl {
          */
         public interface ColumnGroupDef
 
-        /** `columnNoAccessor: `[`String`][String]`  |  `[`KProperty`][kotlin.reflect.KProperty]`<*> | `[`ColumnPath`][org.jetbrains.kotlinx.dataframe.columns.ColumnPath] */
-        public interface ColumnNoAccessorDef
+        /** `columnName: `[`String`][String]`  |  `[`KProperty`][kotlin.reflect.KProperty]`<*>` */
+        public interface ColumNameDef
+
+        /** `columnNoPath: `[`ColumnAccessor`][org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor]`  |  `[`String`][String]`  | `[`KProperty`][kotlin.reflect.KProperty]`<*>` */
+        public interface ColumnNoPathDef
 
         /** `columnOrSet: `{@include [ColumnRef]}`  |  `{@include [ColumnSetRef]} */
         public interface ColumnOrColumnSetDef
@@ -190,8 +193,11 @@ public interface DslGrammarTemplateColumnsSelectionDsl {
         /** [`columnGroup`][ColumnGroupDef] */
         public interface ColumnGroupRef
 
-        /** [`columnNoAccessor`][ColumnNoAccessorDef] */
-        public interface ColumnNoAccessorRef
+        /** [`columnName`][ColumNameDef] */
+        public interface ColumnNameRef
+
+        /** [`columnNoPath`][ColumnNoPathDef] */
+        public interface ColumnNoPathRef
 
         /** [`columnOrSet`][ColumnOrColumnSetDef] */
         public interface ColumnOrColumnSetRef

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/PivotGroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/PivotGroupByImpl.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation
 
+import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.aggregation.AggregateBody
@@ -9,6 +10,7 @@ import org.jetbrains.kotlinx.dataframe.api.PivotGroupBy
 import org.jetbrains.kotlinx.dataframe.api.aggregate
 import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.firstOrNull
+import org.jetbrains.kotlinx.dataframe.api.remove
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.GroupByImpl
 import org.jetbrains.kotlinx.dataframe.impl.api.aggregatePivot
@@ -33,10 +35,11 @@ internal data class PivotGroupByImpl<T>(
         df.groups.firstOrNull()
             ?.getPivotColumnPaths(columns).orEmpty()
             .let { pivotPaths ->
-                {
-                    all().except(
-                        pivotPaths.toColumnSet() and (df as GroupByImpl).keyColumnsInGroups.toColumnSet(),
-                    )
+                return@let {
+                    (this as AnyFrame)
+                        .remove { pivotPaths.toColumnSet() and (df as GroupByImpl).keyColumnsInGroups.toColumnSet() }
+                        .columns()
+                        .toColumnSet()
                 }
             }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/implode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/implode.kt
@@ -8,16 +8,20 @@ import org.jetbrains.kotlinx.dataframe.api.concat
 import org.jetbrains.kotlinx.dataframe.api.dropNA
 import org.jetbrains.kotlinx.dataframe.api.groupBy
 import org.jetbrains.kotlinx.dataframe.api.map
+import org.jetbrains.kotlinx.dataframe.api.remove
 import org.jetbrains.kotlinx.dataframe.api.replace
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.extractDataFrame
 import org.jetbrains.kotlinx.dataframe.impl.getListType
 import kotlin.reflect.typeOf
 
 internal fun <T, C> DataFrame<T>.implodeImpl(dropNA: Boolean = false, columns: ColumnsSelector<T, C>): DataFrame<T> =
-    groupBy { allExcept(columns) }.updateGroups {
+    groupBy {
+        (this as DataFrame<T>).remove(columns).columns().toColumnSet()
+    }.updateGroups {
         replace(columns).with { column ->
             val (value, type) = when (column.kind()) {
                 ColumnKind.Value -> (if (dropNA) column.dropNA() else column).toList() to getListType(column.type())

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnAccessorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnAccessorImpl.kt
@@ -24,8 +24,8 @@ internal class ColumnAccessorImpl<T>(val path: ColumnPath) : ColumnAccessor<T> {
             val col = df.getColumn<Any?>(colName, context.unresolvedColumnsPolicy) ?: return null
             if (!col.isColumnGroup()) {
                 error(
-                    "Cannot resolve column '${path.subList(0, i + 2).joinToString(".")}': " +
-                        "Column '${path.subList(0, i + 1).joinToString(".")}' is not a column group.",
+                    "Cannot resolve column '${path.subList(0, i + 2).joinToString("/")}': " +
+                        "Column '${path.subList(0, i + 1).joinToString("/")}' is not a column group.",
                 )
             } else {
                 col

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/Utils.kt
@@ -381,6 +381,16 @@ internal fun <T> List<ColumnWithPath<T>>.simplify(): List<ColumnWithPath<T>> {
     return root.topmostChildren { it.data != null }.map { it.data!! }
 }
 
+
+private fun ColumnWithPath<*>.renderName(): String =
+    if (isColumnGroup()) {
+        "${path.joinToString()}/{${
+            columns().map { it.addPath() }.joinToString { it.renderName() }
+        }}"
+    } else {
+        path.joinToString()
+    }
+
 /**
  * Returns a new list of distinct column paths, except the ones inside [columns].
  * NOTE: There are no structural changes as removing nested columns is not allowed.
@@ -408,9 +418,9 @@ internal fun List<ColumnWithPath<*>>.removeAll(columnsToRemove: Iterable<ColumnW
         if (nestedColumns.isNotEmpty()) {
             throw IllegalArgumentException(
                 "Cannot exclude the nested columns '[${
-                    nestedColumns.joinToString { it.path.joinToString() }
+                    nestedColumns.joinToString { it.joinToString() }
                 }]' from the column set '[${
-                    this.joinToString { it.path.joinToString() }
+                    this.joinToString { it.renderName() }
                 }]' with the except-functions. Use the `DataFrame<*>.remove { }` operation instead.",
             )
         }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/tree/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/tree/Utils.kt
@@ -31,6 +31,17 @@ internal fun <T> TreeNode<T>.getOrPut(path: ColumnPath, createData: (ColumnPath)
 }
 
 /**
+ * Checks if a given column path exists from the current tree node.
+ *
+ * @param path The sequence of column path parts to check from the tree node.
+ * @return True if the specified path exists from the tree node, false otherwise.
+ */
+internal operator fun <T> TreeNode<T>.contains(path: ColumnPath): Boolean =
+    path.fold(this as TreeNode<T>?) { node, pathPart ->
+        node?.get(pathPart)
+    } != null
+
+/**
  * Traverses all children in the tree in depth-first order and returns the top-most nodes that satisfy
  * [yieldCondition]. This means that if a node satisfies [yieldCondition], its children are not traversed, regardless of
  * whether they satisfy [yieldCondition] or not.

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -79,4 +79,12 @@ internal const val ALL_COLS_EXCEPT =
 internal const val ALL_COLS_REPLACE = "allColsExcept { other }"
 internal const val ALL_COLS_REPLACE_VARARG = "allColsExcept { others.toColumnSet() }"
 
+internal const val ALL_COLS_EXCEPT_COLUMN_PATH =
+    "This overload is blocked because you cannot use `allColsExcept` for columns nested in this column group. " +
+        "Use a String to refer to a column instead, or use DataFrame.remove {} to remove nested columns."
+
+internal const val ALL_EXCEPT_COLUMN_PATH =
+    "This overload is blocked because you cannot use `allExcept` for nested columns. " +
+        "Use a String to refer to a column instead, or use DataFrame.remove {} to remove nested columns."
+
 // endregion

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -2482,17 +2482,6 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `except in columns selector`() {
         typed.select { allExcept { age and weight } } shouldBe typed.select { name and city }
-
-        typed
-            .group { age and weight and city }.into("info")
-            .alsoDebug()
-            .select { allExcept { "info"["age"] } }
-            .alsoDebug()
-            .let {
-                it.name shouldBe typed.name
-                it["info"]["weight"] shouldBe typed.weight
-                it["info"]["city"] shouldBe typed.city
-            }
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/761

This PR rewrites `except` to disallow pointing to nested columns. The columns selection DSL should only be allowed to "select" columns, not restructure it; we have `move`, `remove`, etc. for that.

When a user now calls, say 
```kt
df.select { all() except userData.age }
```
they will receive an `IllegalArgumentException`: 
`` Cannot exclude the nested columns '[userData/age]' from the column set '[userData/{age, name}, otherCol1, otherCol2]' with the except-functions. Use the `DataFrame<*>.remove { }` operation instead. ``
because `userData.age` is not directly selected by `all()`, only its parent, `userdata`, is.

TODO: 
- [ ] Documentation website

----

Some internal struggle: It seems like `except` was used internally in a couple places and it relied on the old behavior.

[Rewriting this](https://github.com/Kotlin/dataframe/pull/1036/commits/21c6a370318081a1cc1475432bc5713836da6474) now pushes me to this horrible notation:

Before:
```kt
df.groupBy { allExcept(columnSetWithNestedCols) }...
```

After:
```kt
df.groupBy {
    (this as DataFrame<*>)
        .remove(columnSetWithNestedCols)
        .columns()
        .toColumnSet()
}...
```

(something like `df.remove {}.groupBy {}` wouldn't not work, because you still want the columns inside the group)

Having to write something like this makes me rethink what we should do about this. Clearly there's a need for _selecting the top-level columns of a version of the current dataframe where a (set of) column(s) and their parents are removed._ Though, it seems out of the scope for `except` (and the 0.15 version of `except` even [breaks](https://github.com/Kotlin/dataframe/issues/761) in some cases). We could:
- Fix the bugs in `except` and keep it as is 
  - (there are likely quite a few more we don't know about yet)
  - The ones we know can be fixed: https://github.com/Kotlin/dataframe/pull/1038
- introduce a new function that has the old behavior with a good name
- Create a way to access the original DF in the selection dsl and promote the idea that you can use functions like `remove` on it. Probably also needs a `df.toColumnSet()` function.
- Merge this as is and just block except with nested columns
  - (We only use the concept 3 times after all)
- Something else

@zaleslaw @koperagen @nikitinas @belovrv WDYT?