### PR TITLE
generalize toListImpl to support conversions into lists and sequences

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9808,8 +9808,8 @@ public final class org/jetbrains/kotlinx/dataframe/impl/api/ToDataFrameKt {
 	public static final fun createDataFrameImpl (Ljava/lang/Iterable;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 }
 
-public final class org/jetbrains/kotlinx/dataframe/impl/api/ToListKt {
-	public static final fun toListImpl (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/reflect/KType;)Ljava/util/List;
+public final class org/jetbrains/kotlinx/dataframe/impl/api/ToSequenceKt {
+	public static final fun toSequenceImpl (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/reflect/KType;)Ljava/lang/Iterable;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/UpdateKt {

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toList.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toList.kt
@@ -2,13 +2,13 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.impl.api.toListImpl
+import org.jetbrains.kotlinx.dataframe.impl.api.toSequenceImpl
 import kotlin.reflect.typeOf
 
 // region DataFrame
 
-public inline fun <reified T> DataFrame<T>.toList(): List<T> = toListImpl(typeOf<T>()) as List<T>
+public inline fun <reified T> DataFrame<T>.toList(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
 
-public inline fun <reified T> AnyFrame.toListOf(): List<T> = toListImpl(typeOf<T>()) as List<T>
+public inline fun <reified T> AnyFrame.toListOf(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
 
 // endregion

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.typeOf
 
 // region DataFrame
 
-public inline fun <reified T> DataFrame<T>.toList(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
+public inline fun <reified T> DataFrame<T>.toSequence(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
-public inline fun <reified T> AnyFrame.toListOf(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
+public inline fun <reified T> AnyFrame.toSequenceOf(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.typeOf
 
 // region DataFrame
 
-public inline fun <reified T> DataFrame<T>.toList(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
+public inline fun <reified T> DataFrame<T>.toSequence(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
-public inline fun <reified T> AnyFrame.toListOf(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
+public inline fun <reified T> AnyFrame.toSequenceOf(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
 // endregion

--- a/docs/StardustDocs/topics/collectionsInterop.md
+++ b/docs/StardustDocs/topics/collectionsInterop.md
@@ -82,7 +82,7 @@ for Gradle or the [Kotlin Jupyter kernel](gettingStartedJupyterNotebook.md)
 
 </tip>
 
-After your data is transformed, [`DataFrame`](DataFrame.md) instances can be exported 
+After your data is transformed, [`DataFrame`](DataFrame.md) instances can be exported eagerly
 into [`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/) of another data class using [toList](toList.md) or [toListOf](toList.md#tolistof) extensions:
 
 <!---FUN listInterop4-->
@@ -91,6 +91,17 @@ into [`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-l
 data class Output(val a: Int, val b: Int, val c: Int)
 
 val result = df2.toListOf<Output>()
+```
+
+Alternatively, one can create lazy [`Sequence`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-sequence/) objects.
+This avoids holding the entire list of objects in memory as objects are created on the fly as needed.
+
+<!---FUN listInterop5-->
+
+```kotlin
+data class Output(val a: Int, val b: Int, val c: Int)
+
+val result = df2.toSequenceOf<Output>()
 ```
 
 <!---END-->


### PR DESCRIPTION
The previous implementation already was based on iterating over rows, with this generalization, the user can now decide whether to eagerly convert a Dataframe into a list, or use lazy transformations via a sequence.

Resolves: #1045 