### PR TITLE
Add more operation to compiler plugin

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6003,16 +6003,23 @@ public final class org/jetbrains/kotlinx/dataframe/api/Merge {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/MergeKt {
-	public static final fun asStrings (Lorg/jetbrains/kotlinx/dataframe/api/Merge;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
-	public static final fun by (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;ILjava/lang/CharSequence;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
-	public static synthetic fun by$default (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;ILjava/lang/CharSequence;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
+	public static final fun asStrings (Lorg/jetbrains/kotlinx/dataframe/api/Merge;)Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;
+	public static final fun by (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;ILjava/lang/CharSequence;)Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;
+	public static synthetic fun by$default (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;ILjava/lang/CharSequence;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;
 	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnAccessor;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/Merge;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun intoList (Lorg/jetbrains/kotlinx/dataframe/api/Merge;)Ljava/util/List;
+	public static final fun intoList (Lorg/jetbrains/kotlinx/dataframe/api/MergeWithTransform;)Ljava/util/List;
 	public static final fun merge (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
 	public static final fun merge (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
 	public static final fun notNull (Lorg/jetbrains/kotlinx/dataframe/api/Merge;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
+	public static final fun notNullList (Lorg/jetbrains/kotlinx/dataframe/api/Merge;)Lorg/jetbrains/kotlinx/dataframe/api/Merge;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/api/MergeWithTransform {
+	public fun <init> (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function2;Lkotlin/reflect/KType;Lorg/jetbrains/kotlinx/dataframe/api/Infer;)V
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/MinKt {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/AggregateDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/AggregateDsl.kt
@@ -17,7 +17,7 @@ public abstract class AggregateDsl<out T> :
     DataFrame<T>,
     ColumnSelectionDsl<T> {
 
-    @Interpretable("GroupByInto")
+    @Interpretable("AggregateDslInto")
     public inline infix fun <reified R> R.into(name: String): NamedValue =
         internal().yield(pathOf(name), this, typeOf<R>())
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -127,6 +127,8 @@ public fun <T, C, R> Convert<T, DataRow<C>>.asFrame(
     body: ColumnsContainer<T>.(ColumnGroup<C>) -> DataFrame<R>,
 ): DataFrame<T> = to { body(this, it.asColumnGroup()).asColumnGroup(it.name()) }
 
+@Refine
+@Interpretable("PerRowCol")
 public inline fun <T, C, reified R> Convert<T, C>.perRowCol(
     infer: Infer = Infer.Nulls,
     noinline expression: RowColumnExpression<T, C, R>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -110,6 +110,7 @@ public fun <T> Convert<T, *>.to(type: KType): DataFrame<T> = to { it.convertTo(t
 public fun <T, C> Convert<T, C>.to(columnConverter: DataFrame<T>.(DataColumn<C>) -> AnyBaseCol): DataFrame<T> =
     df.replace(columns).with { columnConverter(df, it) }
 
+@Refine
 @Interpretable("With0")
 public inline fun <T, C, reified R> Convert<T, C>.with(
     infer: Infer = Infer.Nulls,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -74,6 +74,7 @@ public data class Gather<T, C, K, R>(
 public fun <T, C, K, R> Gather<T, C, K, R>.into(keyColumn: String, valueColumn: String): DataFrame<T> =
     gatherImpl(keyColumn, valueColumn)
 
+@AccessApiOverload
 public fun <T, C, K, R> Gather<T, C, K, R>.into(
     keyColumn: ColumnAccessor<K>,
     valueColumn: ColumnAccessor<R>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
@@ -5,6 +5,8 @@ import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.internal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.withExpr
@@ -14,6 +16,8 @@ import kotlin.reflect.typeOf
 
 // region GroupBy
 
+@Refine
+@Interpretable("GroupByInto")
 public fun <T, G> GroupBy<T, G>.into(column: String): DataFrame<T> = toDataFrame(column)
 
 @AccessApiOverload

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
@@ -56,7 +56,11 @@ public fun <T, C, R> Merge<T, C, R>.intoList(): List<R> =
 
 public fun <T, C, R> Merge<T, C, R>.into(path: ColumnPath): DataFrame<T> {
     // If target path exists, merge into temp path
-    val mergePath = if (df.getColumnOrNull(path) != null) pathOf(nameGenerator().addUnique("temp")) else path
+    val mergePath = if (df.getColumnOrNull(path) != null) {
+        pathOf(df.nameGenerator().addUnique("temp"))
+    } else {
+        path
+    }
 
     // move columns into group
     val grouped = df.move(selector).under { mergePath }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
@@ -5,6 +5,8 @@ import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -16,6 +18,7 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
+@Interpretable("Merge0")
 public fun <T, C> DataFrame<T>.merge(selector: ColumnsSelector<T, C>): Merge<T, C, List<C>> =
     Merge(this, selector, false, { it }, typeOf<Any?>(), Infer.Type)
 
@@ -53,14 +56,20 @@ public class MergeWithTransform<T, C, R>(
     internal val infer: Infer,
 )
 
+@Interpretable("MergeId")
 public fun <T, C, R> Merge<T, C, R>.notNull(): Merge<T, C & Any, R> = copy(notNull = true) as Merge<T, C & Any, R>
 
 @JvmName("notNullList")
+@Interpretable("MergeId")
 public fun <T, C, R> Merge<T, C, List<R>>.notNull(): Merge<T, C & Any, List<R & Any>> =
     copy(notNull = true) as Merge<T, C & Any, List<R & Any>>
 
+@Refine
+@Interpretable("MergeInto0")
 public fun <T, C, R> MergeWithTransform<T, C, R>.into(columnName: String): DataFrame<T> = into(pathOf(columnName))
 
+@Refine
+@Interpretable("MergeInto0")
 public fun <T, C, R> Merge<T, C, R>.into(columnName: String): DataFrame<T> = into(pathOf(columnName))
 
 @AccessApiOverload
@@ -111,8 +120,10 @@ public fun <T, C, R> MergeWithTransform<T, C, R>.into(path: ColumnPath): DataFra
 public fun <T, C, R> Merge<T, C, R>.into(path: ColumnPath): DataFrame<T> =
     MergeWithTransform(df, selector, notNull, transform, resultType, infer).into(path)
 
+@Interpretable("MergeId")
 public fun <T, C, R> Merge<T, C, R>.asStrings(): MergeWithTransform<T, C, String> = by(", ")
 
+@Interpretable("MergeBy0")
 public fun <T, C, R> Merge<T, C, R>.by(
     separator: CharSequence = ", ",
     prefix: CharSequence = "",
@@ -137,6 +148,7 @@ public fun <T, C, R> Merge<T, C, R>.by(
         infer = Infer.Nulls,
     )
 
+@Interpretable("MergeBy1")
 public inline fun <T, C, R, reified V> Merge<T, C, R>.by(
     infer: Infer = Infer.Nulls,
     crossinline transform: DataRow<T>.(R) -> V,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -24,6 +24,8 @@ import kotlin.reflect.KProperty
 
 // region DataFrame
 
+@Refine
+@Interpretable("RenameMapping")
 public fun <T> DataFrame<T>.rename(vararg mappings: Pair<String, String>): DataFrame<T> =
     rename { mappings.map { it.first.toColumnAccessor() }.toColumnSet() }
         .into(*mappings.map { it.second }.toTypedArray())

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reorder.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reorder.kt
@@ -6,6 +6,8 @@ import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.Selector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.reorderImpl
@@ -52,6 +54,8 @@ public fun <T, V : Comparable<V>> DataFrame<T>.reorderColumnsBy(
         inFrameColumns = atAnyDepth,
     ).reorderImpl(desc, expression)
 
+@Refine
+@Interpretable("ReorderColumnsByName")
 public fun <T> DataFrame<T>.reorderColumnsByName(atAnyDepth: Boolean = true, desc: Boolean = false): DataFrame<T> =
     reorderColumnsBy(atAnyDepth, desc) { name() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.api.GroupBy
 import org.jetbrains.kotlinx.dataframe.api.GroupClause
 import org.jetbrains.kotlinx.dataframe.api.InsertClause
 import org.jetbrains.kotlinx.dataframe.api.Merge
+import org.jetbrains.kotlinx.dataframe.api.MergeWithTransform
 import org.jetbrains.kotlinx.dataframe.api.MoveClause
 import org.jetbrains.kotlinx.dataframe.api.Pivot
 import org.jetbrains.kotlinx.dataframe.api.PivotGroupBy
@@ -165,6 +166,7 @@ public object KotlinNotebookPluginUtils {
             is SplitWithTransform<*, *, *>,
             is Split<*, *>,
             is Merge<*, *, *>,
+            is MergeWithTransform<*, *, *>,
             is Gather<*, *, *, *>,
             is Update<*, *>,
             is Convert<*, *>,
@@ -207,6 +209,13 @@ public object KotlinNotebookPluginUtils {
             is Split<*, *> -> dataframeLike.toDataFrame()
 
             is Merge<*, *, *> -> dataframeLike.into(
+                generateRandomVariationOfColumnName(
+                    "merged",
+                    dataframeLike.df.columnNames(),
+                ),
+            )
+
+            is MergeWithTransform<*, *, *> -> dataframeLike.into(
                 generateRandomVariationOfColumnName(
                     "merged",
                     dataframeLike.df.columnNames(),

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -1398,6 +1398,11 @@ class DataFrameTests : BaseTest() {
     }
 
     @Test
+    fun `merge into temp`() {
+        dataFrameOf("a", "b", "temp")(1, null, 3)
+            .merge { cols("a", "b") }.into("b")
+    }
+    @Test
     fun `generic column type`() {
         val d = typed.convert { city }.with { it?.toCharArray()?.toList() ?: emptyList() }
         println(d.city.type())

--- a/docs/StardustDocs/topics/reorder.md
+++ b/docs/StardustDocs/topics/reorder.md
@@ -7,7 +7,7 @@ Returns [`DataFrame`](DataFrame.md) with a new order of selected columns.
 ```text
 reorder { columns }
   [.cast<ColumnType>() ]
-   .by { columnExpression } | .byDesc { columnExpression } | .byName(desc = false) { columnExpression } 
+   .by { columnExpression } | .byDesc { columnExpression } | .byName(desc = false)
     
 columnExpression: DataColumn.(DataColumn) -> Value
 ```
@@ -74,19 +74,19 @@ df.reorder { name }.byName(desc = true) // [name.lastName, name.firstName]
 Reorders all columns
 
 ```text
-reorderColumnsBy(dfs = true, desc = false) { columnExpression }
+reorderColumnsBy(atAnyDepth = true, desc = false) { columnExpression }
 ```
 
 **Parameters:**
-* `dfs` — reorder columns inside [`ColumnGroups`](DataColumn.md#columngroup) and [`FrameColumn`](DataColumn.md#framecolumn) recursively
+* `atAnyDepth` — reorder columns inside [`ColumnGroups`](DataColumn.md#columngroup) and [`FrameColumn`](DataColumn.md#framecolumn) recursively
 * `desc` — apply descending order
 
 ## reorderColumnsByName
 
 ```text
-reorderColumnsByName(dfs = true, desc = false)
+reorderColumnsByName(atAnyDepth = true, desc = false)
 ```
 
 **Parameters:**
-* `dfs` — reorder columns inside [`ColumnGroups`](DataColumn.md#columngroup) and [`FrameColumn`](DataColumn.md#framecolumn) recursively
+* `atAnyDepth` — reorder columns inside [`ColumnGroups`](DataColumn.md#columngroup) and [`FrameColumn`](DataColumn.md#framecolumn) recursively
 * `desc` — apply descending order

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/DataFrameAdapter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/DataFrameAdapter.kt
@@ -1,15 +1,13 @@
-@file:Suppress("INVISIBLE_REFERENCE")
-
 package org.jetbrains.kotlinx.dataframe.plugin.impl
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.asDataColumn
 import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
-import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnGroupImpl
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.TypeApproximation
 
 fun PluginDataFrameSchema.asDataFrame(): DataFrame<ConeTypesAdapter> {
@@ -28,11 +26,10 @@ private fun List<SimpleCol>.map(): DataFrame<ConeTypesAdapter> {
     return dataFrameOf(columns).cast()
 }
 
-@Suppress("INVISIBLE_REFERENCE")
 fun SimpleCol.asDataColumn(): DataColumn<*> {
     val column = when (this) {
         is SimpleDataColumn -> DataColumn.createByType(this.name, listOf(this.type))
-        is SimpleColumnGroup -> DataColumn.createColumnGroup(this.name, this.columns().map()) as ColumnGroupImpl<*>
+        is SimpleColumnGroup -> DataColumn.createColumnGroup(this.name, this.columns().map()).asDataColumn()
         is SimpleFrameColumn -> DataColumn.createFrameColumn(this.name, listOf(this.columns().map()))
     }
     return column

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/add.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/add.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleColumnGroup
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.simpleColumnOf
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dsl
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
 import org.jetbrains.kotlinx.dataframe.plugin.impl.type
 
 typealias TypeApproximation = Marker
@@ -17,6 +18,7 @@ typealias TypeApproximation = Marker
 class Add : AbstractSchemaModificationInterpreter() {
     val Arguments.receiver: PluginDataFrameSchema by dataFrame()
     val Arguments.name: String by arg()
+    val Arguments.infer by ignore()
     val Arguments.type: TypeApproximation by type(name("expression"))
 
     override fun Arguments.interpret(): PluginDataFrameSchema {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/convert.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/convert.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleDataColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleFrameColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.enum
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
 import org.jetbrains.kotlinx.dataframe.plugin.impl.simpleColumnOf
 import org.jetbrains.kotlinx.dataframe.plugin.impl.type
 
@@ -54,6 +55,7 @@ internal class Convert6 : AbstractInterpreter<PluginDataFrameSchema>() {
 
 class With0 : AbstractSchemaModificationInterpreter() {
     val Arguments.receiver: ConvertApproximation by arg()
+    val Arguments.infer by ignore()
     val Arguments.type: TypeApproximation by type(name("rowConverter"))
 
     override fun Arguments.interpret(): PluginDataFrameSchema {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/convert.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/convert.kt
@@ -63,6 +63,16 @@ class With0 : AbstractSchemaModificationInterpreter() {
     }
 }
 
+class PerRowCol : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver: ConvertApproximation by arg()
+    val Arguments.infer by ignore()
+    val Arguments.type: TypeApproximation by type(name("expression"))
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return convertImpl(receiver.schema, receiver.columns, type)
+    }
+}
+
 internal fun KotlinTypeFacade.convertImpl(
     pluginDataFrameSchema: PluginDataFrameSchema,
     columns: List<List<String>>,

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/groupBy.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/groupBy.kt
@@ -44,7 +44,7 @@ class GroupByDsl {
     val columns = mutableListOf<NamedValue>()
 }
 
-class GroupByInto : AbstractInterpreter<Unit>() {
+class AggregateDslInto : AbstractInterpreter<Unit>() {
     val Arguments.dsl: GroupByDsl by arg()
     val Arguments.receiver: FirExpression by arg(lens = Interpreter.Id)
     val Arguments.name: String by arg()
@@ -144,6 +144,18 @@ fun KotlinTypeFacade.createPluginDataFrameSchema(keys: List<ColumnWithPathApprox
 
 
     return PluginDataFrameSchema(rootColumns)
+}
+
+class GroupByInto : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver: GroupBy by groupBy()
+    val Arguments.column: String by arg()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        val grouped = listOf(SimpleFrameColumn(column, receiver.groups.columns()))
+        return PluginDataFrameSchema(
+            receiver.keys.columns() + grouped
+        )
+    }
 }
 
 class GroupByToDataFrame : AbstractSchemaModificationInterpreter() {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/insert.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/insert.kt
@@ -1,5 +1,3 @@
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/join.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/join.kt
@@ -1,5 +1,3 @@
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/merge.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/merge.kt
@@ -1,0 +1,104 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.api.into
+import org.jetbrains.kotlinx.dataframe.api.move
+import org.jetbrains.kotlinx.dataframe.api.pathOf
+import org.jetbrains.kotlinx.dataframe.api.remove
+import org.jetbrains.kotlinx.dataframe.api.replace
+import org.jetbrains.kotlinx.dataframe.api.toPath
+import org.jetbrains.kotlinx.dataframe.api.under
+import org.jetbrains.kotlinx.dataframe.api.with
+import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
+import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
+import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleCol
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataColumn
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
+import org.jetbrains.kotlinx.dataframe.plugin.impl.simpleColumnOf
+import org.jetbrains.kotlinx.dataframe.plugin.impl.toPluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.type
+
+class MergeApproximation(
+    val df: PluginDataFrameSchema,
+    val columns: ColumnsResolver,
+)
+
+class Merge0 : AbstractInterpreter<MergeApproximation>() {
+    val Arguments.receiver: PluginDataFrameSchema by dataFrame()
+    val Arguments.selector: ColumnsResolver by arg()
+
+    override fun Arguments.interpret(): MergeApproximation {
+        return MergeApproximation(receiver, selector)
+    }
+}
+
+class MergeInto0 : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver: MergeApproximation by arg()
+    val Arguments.columnName: String by arg()
+    val Arguments.typeArg2 by type()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        val columns = receiver.columns.resolve(receiver.df).map { it.path.toPath() }
+        return merge(receiver.df, columns, pathOf(columnName), simpleColumnOf(columnName, typeArg2.type))
+    }
+}
+
+class MergeId : AbstractInterpreter<MergeApproximation>() {
+    val Arguments.receiver: MergeApproximation by arg()
+
+    override fun Arguments.interpret(): MergeApproximation {
+        return receiver
+    }
+}
+
+class MergeBy0 : AbstractInterpreter<MergeApproximation>() {
+    val Arguments.receiver: MergeApproximation by arg()
+    val Arguments.separator by ignore()
+    val Arguments.prefix by ignore()
+    val Arguments.postfix by ignore()
+    val Arguments.limit by ignore()
+    val Arguments.truncated by ignore()
+
+    override fun Arguments.interpret(): MergeApproximation {
+        return receiver
+    }
+}
+
+class MergeBy1 : AbstractInterpreter<MergeApproximation>() {
+    val Arguments.receiver: MergeApproximation by arg()
+    val Arguments.infer by ignore()
+    val Arguments.transform by ignore()
+
+    override fun Arguments.interpret(): MergeApproximation {
+        return receiver
+    }
+}
+
+fun merge(
+    schema: PluginDataFrameSchema,
+    columns: List<ColumnPath>,
+    path: ColumnPath,
+    result: SimpleCol
+): PluginDataFrameSchema {
+    val df = schema.asDataFrame()
+    val mergedPath = if (df.getColumnOrNull(path) != null) {
+        val temp = ColumnNameGenerator(df.columnNames()).addUnique("temp")
+        pathOf(temp)
+    } else {
+        path
+    }
+
+    val grouped = df.move { columns.toColumnSet() }.under { mergedPath }
+
+    var res = grouped.replace { mergedPath }.with { result.rename(mergedPath.columnName).asDataColumn() }
+    if (mergedPath != path) {
+        res = res.remove { path }.move { mergedPath }.into { path }
+    }
+    return res.toPluginDataFrameSchema()
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/reorder.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/reorder.kt
@@ -1,0 +1,20 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.api.reorderColumnsByName
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Present
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.toPluginDataFrameSchema
+
+class ReorderColumnsByName : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver by dataFrame()
+    val Arguments.atAnyDepth: Boolean by arg(defaultValue = Present(true))
+    val Arguments.desc: Boolean by arg(defaultValue = Present(false))
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return receiver.asDataFrame().reorderColumnsByName(atAnyDepth, desc).toPluginDataFrameSchema()
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/select.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/select.kt
@@ -28,7 +28,7 @@ internal class Select0 : AbstractInterpreter<PluginDataFrameSchema>() {
 internal class Expr0 : AbstractInterpreter<ColumnsResolver>() {
     val Arguments.receiver by ignore()
     val Arguments.name: String by arg(defaultValue = Present("untitled"))
-    val Arguments.infer: Infer by enum(defaultValue = Present(Infer.Nulls))
+    val Arguments.infer by ignore()
     val Arguments.expression: TypeApproximation by type()
 
     override fun Arguments.interpret(): ColumnsResolver {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/valueCounts.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/valueCounts.kt
@@ -1,8 +1,7 @@
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
 import org.jetbrains.kotlinx.dataframe.api.ValueCount
+import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
 import org.jetbrains.kotlinx.dataframe.plugin.extensions.wrap
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
@@ -22,7 +21,7 @@ class ValueCounts : AbstractSchemaModificationInterpreter() {
 
     override fun Arguments.interpret(): PluginDataFrameSchema {
         val res = columns?.resolve(receiver)?.map { it.column } ?: receiver.columns()
-        val generator = org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator(res.map { it.name })
+        val generator = ColumnNameGenerator(res.map { it.name })
         val count = SimpleDataColumn(generator.addUnique(resultColumn), session.builtinTypes.intType.type.wrap())
         return PluginDataFrameSchema(res + count)
     }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -105,6 +105,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MoveUnder0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MoveUnder1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PairConstructor
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PairToConstructor
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PerRowCol
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReadExcel
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.StringColumnsConstructor
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrame
@@ -206,6 +207,7 @@ internal inline fun <reified T> String.load(): T {
         "Convert6" -> Convert6()
         "To0" -> To0()
         "With0" -> With0()
+        "PerRowCol" -> PerRowCol()
         "Explode0" -> Explode0()
         "Read0" -> Read0()
         "Insert0" -> Insert0()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -107,6 +107,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PairConstructor
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PairToConstructor
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.PerRowCol
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReadExcel
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameMapping
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.StringColumnsConstructor
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToDataFrameColumn
@@ -224,6 +225,7 @@ internal inline fun <reified T> String.load(): T {
         "ReadJson0" -> ReadJson0()
         "ReadCSV0" -> ReadCSV0()
         "Rename" -> Rename()
+        "RenameMapping" -> RenameMapping()
         "Select0" -> Select0()
         "Expr0" -> Expr0()
         "And0" -> And0()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -90,6 +90,11 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FlattenDefault
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MapToFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Merge0
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeId
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeBy0
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeBy1
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeInto0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Move0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MoveAfter0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MoveInto0
@@ -277,6 +282,11 @@ internal inline fun <reified T> String.load(): T {
         "MoveToRight0" -> MoveToRight0()
         "MoveAfter0" -> MoveAfter0()
         "GroupByAdd" -> GroupByAdd()
+        "Merge0" -> Merge0()
+        "MergeInto0" -> MergeInto0()
+        "MergeId" -> MergeId()
+        "MergeBy0" -> MergeBy0()
+        "MergeBy1" -> MergeBy1()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -123,6 +123,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.UpdateWith0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ValueCounts
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCase
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCaseClause
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.plugin.utils.Names
 
 internal fun FirFunctionCall.loadInterpreter(session: FirSession): Interpreter<*>? {
@@ -293,6 +294,7 @@ internal inline fun <reified T> String.load(): T {
         "MergeId" -> MergeId()
         "MergeBy0" -> MergeBy0()
         "MergeBy1" -> MergeBy1()
+        "ReorderColumnsByName" -> ReorderColumnsByName()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Explode0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Expr0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.From
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Group0
-import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.AggregateDslInto
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByToDataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Insert0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Insert1
@@ -89,6 +89,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Flatten0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FlattenDefault
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MapToFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Merge0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeId
@@ -242,11 +243,12 @@ internal inline fun <reified T> String.load(): T {
         "Exclude1" -> Exclude1()
         "RenameInto" -> RenameInto()
         "DataFrameGroupBy" -> DataFrameGroupBy()
-        "GroupByInto" -> GroupByInto()
+        "AggregateDslInto" -> AggregateDslInto()
         "ReadJsonStr" -> ReadJsonStr()
         "DataRowReadJsonStr" -> DataRowReadJsonStr()
         "ReadDelimStr" -> ReadDelimStr()
         "GroupByToDataFrame" -> GroupByToDataFrame()
+        "GroupByInto" -> GroupByInto()
         "ToDataFrameFrom0" -> ToDataFrameFrom()
         "All0" -> All0()
         "ColsOf0" -> ColsOf0()

--- a/plugins/kotlin-dataframe/testData/box/groupBy_toDataFrame.kt
+++ b/plugins/kotlin-dataframe/testData/box/groupBy_toDataFrame.kt
@@ -11,5 +11,9 @@ fun box(): String {
     val df1 = df.groupBy { b }.toDataFrame()
     df1.group[0].a
     df1.group[0].b
+
+    val df2 = df.groupBy { b }.into("gr")
+    df2.gr[0].a
+    df2.gr[0].b
     return "OK"
 }

--- a/plugins/kotlin-dataframe/testData/box/infer.kt
+++ b/plugins/kotlin-dataframe/testData/box/infer.kt
@@ -1,0 +1,15 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("a")(123)
+        .add("b", infer = Infer.Nulls) { 123 }
+        .convert { b }.with(infer = Infer.None) { it.toString() }
+        .select { a and b and expr(infer = Infer.Nulls) { 42 } }
+
+    val b: String = df.b[0]
+    val untitled: Int = df.untitled[0]
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/merge.kt
+++ b/plugins/kotlin-dataframe/testData/box/merge.kt
@@ -1,0 +1,15 @@
+x
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val merge = dataFrameOf("a", "b")(1, null).merge { a and b }
+    merge.into("b").compareSchemas(strict = true)
+    merge.by { it }.into("b").compareSchemas(strict = true)
+    merge.notNull().into("b").compareSchemas(strict = true)
+    merge.notNull().by { it }.into("b").compareSchemas(strict = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/perRowCol.kt
+++ b/plugins/kotlin-dataframe/testData/box/perRowCol.kt
@@ -1,0 +1,10 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("a")(123).convert { a }.perRowCol { row, col -> "" }
+    val value: String = df.a[0]
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/renameMapping.kt
+++ b/plugins/kotlin-dataframe/testData/box/renameMapping.kt
@@ -1,0 +1,10 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("a")(123).rename("a" to "c")
+    val value: Int = df.c[0]
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/reorder.fir.txt
+++ b/plugins/kotlin-dataframe/testData/box/reorder.fir.txt
@@ -1,0 +1,912 @@
+FILE: reorder.kt
+    public final fun box(): R|kotlin/String| {
+        lval df: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>| = R|org/jetbrains/kotlinx/dataframe/api/dataFrameOf|(vararg(String(name), String(age), String(city), String(weight))).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/api/DataFrameBuilder|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/DataFrameBuilder|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Invoke_09I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/Invoke_09I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_09I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_09I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_09I>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_09I>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_09I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_09I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_09I>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_09I>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Invoke_09 : R|<local>/Invoke_09I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                public constructor(): R|<local>/Invoke_09|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/DataFrameBuilder.invoke|(vararg(String(Alice), Int(15), String(London), Int(54), String(Bob), Int(45), String(Dubai), Int(87), String(Charlie), Int(20), String(Moscow), Null(null), String(Charlie), Int(40), String(Milan), Null(null), String(Bob), Int(30), String(Tokyo), Int(68), String(Alice), Int(20), Null(null), Int(55), String(Charlie), Int(30), String(Moscow), Int(90)))
+        }
+        )
+        lval sorted1: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_48>| = R|<local>/df|.R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_48>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_48>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Invoke_48I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/Invoke_48I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_48I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_48I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_48I>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_48I>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_48I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_48I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Invoke_48I>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Invoke_48I>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Invoke_48 : R|<local>/Invoke_48I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                public constructor(): R|<local>/Invoke_48|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/reorderColumnsByName|<R|<local>/Invoke_09|>()
+        }
+        )
+        lval sorted2: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_48>| = R|<local>/df|.R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|, R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Group_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/Group_32I|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public constructor(): R|<local>/Key_32I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Key_32 : R|<local>/Key_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                public constructor(): R|<local>/Key_32|
+
+            }
+
+            local abstract class Group_32 : R|<local>/Group_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Group_32|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/groupBy|<R|<local>/Invoke_09|>(<L> = groupBy@fun R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|.<anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/columns/ColumnsResolver<*>| <inline=NoInline>  {
+                ^ (this@R|/box|, this@R|special/anonymous|).R|<local>/Scope0.city|
+            }
+            )
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_92I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public constructor(): R|<local>/Key_92I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_351 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_351|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_92 : R|<local>/Key_92I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_92|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/into|<R|<local>/Key_32|, R|<local>/Group_32|>(String(a))
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_48>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_48>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_48I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>|
+
+                public constructor(): R|<local>/Key_48I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_48I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_48I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_48I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_48I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_421>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_421 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_421|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_421>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_421>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_421>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_421>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_421>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_421>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_421>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_421>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_48 : R|<local>/Key_48I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_48|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/reorderColumnsByName|<R|<local>/Key_92|>()
+        }
+        )
+        lval sorted3: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_87>| = R|<local>/df|.R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|, R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Group_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/Group_32I|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public constructor(): R|<local>/Key_32I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Key_32 : R|<local>/Key_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                public constructor(): R|<local>/Key_32|
+
+            }
+
+            local abstract class Group_32 : R|<local>/Group_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Group_32|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/groupBy|<R|<local>/Invoke_09|>(<L> = groupBy@fun R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|.<anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/columns/ColumnsResolver<*>| <inline=NoInline>  {
+                ^ (this@R|/box|, this@R|special/anonymous|).R|<local>/Scope0.city|
+            }
+            )
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_92I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public constructor(): R|<local>/Key_92I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_351 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_351|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_92 : R|<local>/Key_92I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_92|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/into|<R|<local>/Key_32|, R|<local>/Group_32|>(String(a))
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_87>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_87>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_87I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>|
+
+                public constructor(): R|<local>/Key_87I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_87I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_87I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_87I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_87I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_461>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_461 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_461|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_461>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_461>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_461>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_461>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_461>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_461>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_461>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_461>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_87 : R|<local>/Key_87I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_87|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/reorderColumnsByName|<R|<local>/Key_92|>(Boolean(true), Boolean(false))
+        }
+        )
+        lval sorted4: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_96>| = R|<local>/df|.R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|, R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Group_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/Group_32I|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Group_32I>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Group_32I>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_32I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public constructor(): R|<local>/Key_32I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_32I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_32I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class Key_32 : R|<local>/Key_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                public constructor(): R|<local>/Key_32|
+
+            }
+
+            local abstract class Group_32 : R|<local>/Group_32I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Group_32|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/groupBy|<R|<local>/Invoke_09|>(<L> = groupBy@fun R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|.<anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl<<local>/Invoke_09>|): R|org/jetbrains/kotlinx/dataframe/columns/ColumnsResolver<*>| <inline=NoInline>  {
+                ^ (this@R|/box|, this@R|special/anonymous|).R|<local>/Scope0.city|
+            }
+            )
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/api/GroupBy<<local>/Key_32, <local>/Group_32>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_92I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public constructor(): R|<local>/Key_92I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_92I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_351>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_351 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_351|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_351>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_351>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_92 : R|<local>/Key_92I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_92|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/into|<R|<local>/Key_32|, R|<local>/Group_32|>(String(a))
+        }
+        ).R|kotlin/let|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|, R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_96>|>(<L> = fun <anonymous>(it: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_92>|): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/Key_96>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class Key_96I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>|
+
+                public constructor(): R|<local>/Key_96I|
+
+            }
+
+            local final class Scope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_96I>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_96I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/Key_96I>|.a: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/Key_96I>|.a: R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<org/jetbrains/kotlinx/dataframe/DataFrame<<local>/A_921>>|
+
+                public constructor(): R|<local>/Scope0|
+
+            }
+
+            local abstract class A_921 : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public constructor(): R|<local>/A_921|
+
+            }
+
+            local final class Scope1 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_921>|.city: R|kotlin/String?|
+                    public get(): R|kotlin/String?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_921>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String?>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_921>|.age: R|kotlin/Int|
+                    public get(): R|kotlin/Int|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_921>|.age: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_921>|.name: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_921>|.name: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/A_921>|.weight: R|kotlin/Int?|
+                    public get(): R|kotlin/Int?|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/A_921>|.weight: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/Int?>|
+
+                public constructor(): R|<local>/Scope1|
+
+            }
+
+            local abstract class Key_96 : R|<local>/Key_96I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope0: R|<local>/Scope0|
+                    public get(): R|<local>/Scope0|
+
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val scope1: R|<local>/Scope1|
+                    public get(): R|<local>/Scope1|
+
+                public constructor(): R|<local>/Key_96|
+
+            }
+
+            ^ R|<local>/it|.R|org/jetbrains/kotlinx/dataframe/api/reorderColumnsByName|<R|<local>/Key_92|>(Boolean(true), Boolean(true))
+        }
+        )
+        ^box String(OK)
+    }

--- a/plugins/kotlin-dataframe/testData/box/reorder.kt
+++ b/plugins/kotlin-dataframe/testData/box/reorder.kt
@@ -1,0 +1,27 @@
+// FIR_DUMP
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val sorted1 = df.reorderColumnsByName()
+
+    val sorted2 = df.groupBy { city }.into("a").reorderColumnsByName()
+
+    val sorted3 = df.groupBy { city }.into("a").reorderColumnsByName(desc = true, atAnyDepth = false)
+
+    val sorted4 = df.groupBy { city }.into("a").reorderColumnsByName(desc = true, atAnyDepth = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/diagnostics/schemaInfo.fir.txt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/schemaInfo.fir.txt
@@ -167,16 +167,16 @@ FILE: schemaInfo.kt
             }
 
             local abstract class Participants_181 : R|kotlin/Any| {
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val city: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val firstName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val firstName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val lastName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val lastName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val age: R|kotlin/Int|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val age: R|kotlin/Int|
                     public get(): R|kotlin/Int|
 
                 public constructor(): R|<local>/Participants_181|
@@ -261,16 +261,16 @@ FILE: schemaInfo.kt
             }
 
             local abstract class Participants_181 : R|kotlin/Any| {
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val city: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val firstName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val firstName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val lastName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val lastName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val age: R|kotlin/Int|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val age: R|kotlin/Int|
                     public get(): R|kotlin/Int|
 
                 public constructor(): R|<local>/Participants_181|
@@ -352,16 +352,16 @@ FILE: schemaInfo.kt
             }
 
             local abstract class GroupParticipants_461 : R|kotlin/Any| {
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val city: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val firstName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val firstName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val lastName: R|kotlin/String|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(1)) public abstract val lastName: R|kotlin/String|
                     public get(): R|kotlin/String|
 
-                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(3)) public abstract val age: R|kotlin/Int|
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(2)) public abstract val age: R|kotlin/Int|
                     public get(): R|kotlin/Int|
 
                 public constructor(): R|<local>/GroupParticipants_461|

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -245,6 +245,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("infer.kt")
+  public void testInfer() {
+    runTest("testData/box/infer.kt");
+  }
+
+  @Test
   @TestMetadata("injectAccessors.kt")
   public void testInjectAccessors() {
     runTest("testData/box/injectAccessors.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -479,6 +479,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("renameMapping.kt")
+  public void testRenameMapping() {
+    runTest("testData/box/renameMapping.kt");
+  }
+
+  @Test
   @TestMetadata("renameToCamelCase.kt")
   public void testRenameToCamelCase() {
     runTest("testData/box/renameToCamelCase.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -491,6 +491,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("reorder.kt")
+  public void testReorder() {
+    runTest("testData/box/reorder.kt");
+  }
+
+  @Test
   @TestMetadata("Schema.kt")
   public void testSchema() {
     runTest("testData/box/Schema.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -311,6 +311,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("merge.kt")
+  public void testMerge() {
+    runTest("testData/box/merge.kt");
+  }
+
+  @Test
   @TestMetadata("modifySchemaInAggregate.kt")
   public void testModifySchemaInAggregate() {
     runTest("testData/box/modifySchemaInAggregate.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -377,6 +377,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("perRowCol.kt")
+  public void testPerRowCol() {
+    runTest("testData/box/perRowCol.kt");
+  }
+
+  @Test
   @TestMetadata("platformType.kt")
   public void testPlatformType() {
     runTest("testData/box/platformType.kt");


### PR DESCRIPTION
- merge
- rename(Pair<String, String>)
- convert.perRowCol
- reorderColumnsByName
- GroupBy.into (alt toDataFrame)
And related fixes: bugfix in merge, change in merge grammar (see related test for explanation), making sure displayed "info diagnostic" schemas are ordered according to columns order, update to reorder.md 