### PR TITLE
[Compiler plugin] Support more GroupBy shortcuts

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3530,6 +3530,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConcatKt {
 	public static final fun concat (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lorg/jetbrains/kotlinx/dataframe/DataFrame;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun concat (Lorg/jetbrains/kotlinx/dataframe/DataRow;[Lorg/jetbrains/kotlinx/dataframe/DataRow;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun concat (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun concat (Lorg/jetbrains/kotlinx/dataframe/api/ReducedGroupBy;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun concatRows (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun concatT (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 }
@@ -4831,7 +4832,6 @@ public final class org/jetbrains/kotlinx/dataframe/api/InsertKt {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/IntoKt {
-	public static final fun concat (Lorg/jetbrains/kotlinx/dataframe/api/ReducedGroupBy;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun into (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnAccessor;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/concat.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/concat.kt
@@ -42,6 +42,15 @@ public fun <T, G> GroupBy<T, G>.concat(): DataFrame<G> = groups.concat()
 
 // endregion
 
+// region ReducedGroupBy
+
+public fun <T, G> ReducedGroupBy<T, G>.concat(): DataFrame<G> =
+    groupBy.groups.values()
+        .map { reducer(it, it) }
+        .concat()
+
+// endregion
+
 // region Iterable
 
 public fun <T> Iterable<DataFrame<T>>.concat(): DataFrame<T> = concatImpl(asList())

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/count.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/count.kt
@@ -6,6 +6,8 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
 import org.jetbrains.kotlinx.dataframe.RowFilter
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateValue
 
 // region DataColumn
@@ -37,9 +39,13 @@ public fun <T> DataFrame<T>.count(predicate: RowFilter<T>): Int = rows().count {
 
 // region GroupBy
 
+@Refine
+@Interpretable("GroupByCount0")
 public fun <T> Grouped<T>.count(resultName: String = "count"): DataFrame<T> =
     aggregateValue(resultName) { count() default 0 }
 
+@Refine
+@Interpretable("GroupByCount0")
 public fun <T> Grouped<T>.count(resultName: String = "count", predicate: RowFilter<T>): DataFrame<T> =
     aggregateValue(resultName) { count(predicate) default 0 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -55,8 +56,10 @@ public fun <T> DataFrame<T>.firstOrNull(predicate: RowFilter<T>): DataRow<T>? = 
 
 // region GroupBy
 
+@Interpretable("GroupByReducePredicate")
 public fun <T, G> GroupBy<T, G>.first(): ReducedGroupBy<T, G> = reduce { firstOrNull() }
 
+@Interpretable("GroupByReducePredicate")
 public fun <T, G> GroupBy<T, G>.first(predicate: RowFilter<G>): ReducedGroupBy<T, G> = reduce { firstOrNull(predicate) }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
@@ -79,6 +79,8 @@ public inline fun <T, G, reified V> ReducedGroupBy<T, G>.into(
     noinline expression: RowExpression<G, V>,
 ): DataFrame<G> = into(column.columnName, expression)
 
+@Refine
+@Interpretable("GroupByReduceInto")
 public fun <T, G> ReducedGroupBy<T, G>.into(columnName: String): DataFrame<G> = into(columnName) { this }
 
 @AccessApiOverload

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
@@ -89,9 +89,4 @@ public fun <T, G> ReducedGroupBy<T, G>.into(column: ColumnAccessor<AnyRow>): Dat
 @AccessApiOverload
 public fun <T, G> ReducedGroupBy<T, G>.into(column: KProperty<AnyRow>): DataFrame<G> = into(column) { this }
 
-public fun <T, G> ReducedGroupBy<T, G>.concat(): DataFrame<G> =
-    groupBy.groups.values()
-        .map { reducer(it, it) }
-        .concat()
-
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -56,8 +57,10 @@ public fun <T> DataFrame<T>.last(): DataRow<T> {
 
 // region GroupBy
 
+@Interpretable("GroupByReducePredicate")
 public fun <T, G> GroupBy<T, G>.last(): ReducedGroupBy<T, G> = reduce { lastOrNull() }
 
+@Interpretable("GroupByReducePredicate")
 public fun <T, G> GroupBy<T, G>.last(predicate: RowFilter<G>): ReducedGroupBy<T, G> = reduce { lastOrNull(predicate) }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.values
@@ -164,6 +165,8 @@ public fun <T, C : Comparable<C>> Grouped<T>.max(
 public fun <T, C : Comparable<C>> Grouped<T>.max(vararg columns: KProperty<C?>, name: String? = null): DataFrame<T> =
     max(name) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("GroupByMaxOf")
 public fun <T, C : Comparable<C>> Grouped<T>.maxOf(
     name: String? = null,
     expression: RowExpression<T, C>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.values
@@ -168,6 +169,7 @@ public fun <T, C : Comparable<C>> Grouped<T>.maxOf(
     expression: RowExpression<T, C>,
 ): DataFrame<T> = Aggregators.max.aggregateOfDelegated(this, name) { maxOfOrNull(expression) }
 
+@Interpretable("GroupByReduceExpression")
 public fun <T, G, R : Comparable<R>> GroupBy<T, G>.maxBy(rowExpression: RowExpression<G, R?>): ReducedGroupBy<T, G> =
     reduce { maxByOrNull(rowExpression) }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.values
@@ -164,6 +165,8 @@ public fun <T, C : Comparable<C>> Grouped<T>.min(
 public fun <T, C : Comparable<C>> Grouped<T>.min(vararg columns: KProperty<C?>, name: String? = null): DataFrame<T> =
     min(name) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("GroupByMinOf")
 public fun <T, C : Comparable<C>> Grouped<T>.minOf(
     name: String? = null,
     expression: RowExpression<T, C>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.values
@@ -168,6 +169,7 @@ public fun <T, C : Comparable<C>> Grouped<T>.minOf(
     expression: RowExpression<T, C>,
 ): DataFrame<T> = Aggregators.min.aggregateOfDelegated(this, name) { minOfOrNull(expression) }
 
+@Interpretable("GroupByReduceExpression")
 public fun <T, G, R : Comparable<R>> GroupBy<T, G>.minBy(rowExpression: RowExpression<G, R?>): ReducedGroupBy<T, G> =
     reduce { minByOrNull(rowExpression) }
 

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/SimpleCol.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/SimpleCol.kt
@@ -125,7 +125,7 @@ fun KotlinTypeFacade.simpleColumnOf(name: String, type: ConeKotlinType): SimpleC
     }
 }
 
-private fun KotlinTypeFacade.makeNullable(column: SimpleCol): SimpleCol {
+internal fun KotlinTypeFacade.makeNullable(column: SimpleCol): SimpleCol {
     return when (column) {
         is SimpleColumnGroup -> {
             SimpleColumnGroup(column.name, column.columns().map { makeNullable(it) })

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/ReducedGroupBy.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/ReducedGroupBy.kt
@@ -1,0 +1,35 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleColumnGroup
+import org.jetbrains.kotlinx.dataframe.plugin.impl.groupBy
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
+import org.jetbrains.kotlinx.dataframe.plugin.impl.makeNullable
+
+class GroupByReducePredicate : AbstractInterpreter<GroupBy>() {
+    val Arguments.receiver by groupBy()
+    val Arguments.predicate by ignore()
+    override fun Arguments.interpret(): GroupBy {
+        return receiver
+    }
+}
+
+class GroupByReduceExpression : AbstractInterpreter<GroupBy>() {
+    val Arguments.receiver by groupBy()
+    val Arguments.rowExpression by ignore()
+    override fun Arguments.interpret(): GroupBy {
+        return receiver
+    }
+}
+
+class GroupByReduceInto : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver by groupBy()
+    val Arguments.columnName: String by arg()
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        val group = makeNullable(SimpleColumnGroup(columnName, receiver.groups.columns()))
+        return PluginDataFrameSchema(receiver.keys.columns() + group)
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/count.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/count.kt
@@ -1,0 +1,19 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Present
+import org.jetbrains.kotlinx.dataframe.plugin.impl.add
+import org.jetbrains.kotlinx.dataframe.plugin.impl.groupBy
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
+
+class GroupByCount0 : AbstractSchemaModificationInterpreter() {
+    val Arguments.receiver by groupBy()
+    val Arguments.resultName: String by arg(defaultValue = Present("count"))
+    val Arguments.predicate by ignore()
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return receiver.keys.add(resultName, session.builtinTypes.intType.type, context = this)
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/groupBy.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/groupBy.kt
@@ -1,14 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
-import org.jetbrains.kotlinx.dataframe.plugin.InterpretationErrorReporter
-import org.jetbrains.kotlinx.dataframe.plugin.interpret
-import org.jetbrains.kotlinx.dataframe.plugin.loadInterpreter
 import org.jetbrains.kotlin.fir.expressions.FirAnonymousFunctionExpression
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlinx.dataframe.plugin.InterpretationErrorReporter
 import org.jetbrains.kotlinx.dataframe.plugin.extensions.KotlinTypeFacade
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractSchemaModificationInterpreter
@@ -23,8 +21,11 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.add
 import org.jetbrains.kotlinx.dataframe.plugin.impl.data.ColumnWithPathApproximation
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.groupBy
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
 import org.jetbrains.kotlinx.dataframe.plugin.impl.simpleColumnOf
 import org.jetbrains.kotlinx.dataframe.plugin.impl.type
+import org.jetbrains.kotlinx.dataframe.plugin.interpret
+import org.jetbrains.kotlinx.dataframe.plugin.loadInterpreter
 
 class GroupBy(val keys: PluginDataFrameSchema, val groups: PluginDataFrameSchema)
 
@@ -173,6 +174,7 @@ class GroupByToDataFrame : AbstractSchemaModificationInterpreter() {
 class GroupByAdd : AbstractInterpreter<GroupBy>() {
     val Arguments.receiver: GroupBy by groupBy()
     val Arguments.name: String by arg()
+    val Arguments.infer by ignore()
     val Arguments.type: TypeApproximation by type(name("expression"))
 
     override fun Arguments.interpret(): GroupBy {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -192,7 +192,7 @@ fun <T> KotlinTypeFacade.interpret(
                 assert(expectedReturnType.toString() == GroupBy::class.qualifiedName!!) {
                     "'$name' should be ${GroupBy::class.qualifiedName!!}, but plugin expect $expectedReturnType"
                 }
-
+                // ok for ReducedGroupBy too
                 val resolvedType = it.expression.resolvedType.fullyExpandedType(session)
                 val keys = pluginDataFrameSchema(resolvedType.typeArguments[0])
                 val groups = pluginDataFrameSchema(resolvedType.typeArguments[1])

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -91,6 +91,9 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByCount0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceExpression
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceInto
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReducePredicate
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MapToFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Merge0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeId
@@ -297,6 +300,9 @@ internal inline fun <reified T> String.load(): T {
         "MergeBy1" -> MergeBy1()
         "ReorderColumnsByName" -> ReorderColumnsByName()
         "GroupByCount0" -> GroupByCount0()
+        "GroupByReducePredicate" -> GroupByReducePredicate()
+        "GroupByReduceExpression" -> GroupByReduceExpression()
+        "GroupByReduceInto" -> GroupByReduceInto()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -91,6 +91,8 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByCount0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByMaxOf
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByMinOf
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceExpression
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceInto
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReducePredicate
@@ -303,6 +305,8 @@ internal inline fun <reified T> String.load(): T {
         "GroupByReducePredicate" -> GroupByReducePredicate()
         "GroupByReduceExpression" -> GroupByReduceExpression()
         "GroupByReduceInto" -> GroupByReduceInto()
+        "GroupByMaxOf" -> GroupByMaxOf()
+        "GroupByMinOf" -> GroupByMinOf()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -89,6 +89,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Flatten0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FlattenDefault
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByCount0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MapToFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Merge0
@@ -295,6 +296,7 @@ internal inline fun <reified T> String.load(): T {
         "MergeBy0" -> MergeBy0()
         "MergeBy1" -> MergeBy1()
         "ReorderColumnsByName" -> ReorderColumnsByName()
+        "GroupByCount0" -> GroupByCount0()
         else -> error("$this")
     } as T
 }

--- a/plugins/kotlin-dataframe/testData/box/groupBy_count.kt
+++ b/plugins/kotlin-dataframe/testData/box/groupBy_count.kt
@@ -1,0 +1,16 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.count()
+    val i: Int = df.count[0]
+
+    val df1 = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.count { a > 1 }
+    val i1: Int = df1.count[0]
+
+    val df2 = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.count("myCol") { a > 1 }
+    val i2: Int = df2.myCol[0]
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/groupBy_maxOfMinOf.kt
+++ b/plugins/kotlin-dataframe/testData/box/groupBy_maxOfMinOf.kt
@@ -1,0 +1,22 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.add("id") { index() }.maxOf { 123 }
+    val df1 = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.add("id") { index() }.minOf { 123 }
+
+    val max = df.max[0]
+    val min = df1.min[0]
+
+    df.compareSchemas()
+    df1.compareSchemas()
+
+    val df2 = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.add("id") { index() }.maxOf("myMax") { 123 }
+    val df3 = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.add("id") { index() }.minOf("myMin") { 123 }
+
+    df2.myMax
+    df3.myMin
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/reducedGroupBy.kt
+++ b/plugins/kotlin-dataframe/testData/box/reducedGroupBy.kt
@@ -1,0 +1,16 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val groupBy = dataFrameOf("a")(1, 1, 2, 3, 3).groupBy { a }.add("id") { index() }
+    groupBy.maxBy { id }.into("group").compareSchemas()
+    groupBy.maxBy { id }.into("group").compareSchemas()
+    groupBy.first { id == 1 }.into("group").compareSchemas()
+    groupBy.first().into("group").compareSchemas()
+    groupBy.last { id == 1 }.into("group").compareSchemas()
+    groupBy.last().into("group").compareSchemas()
+    groupBy.minBy { id == 1 }.into("group").compareSchemas()
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -239,6 +239,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("groupBy_maxOfMinOf.kt")
+  public void testGroupBy_maxOfMinOf() {
+    runTest("testData/box/groupBy_maxOfMinOf.kt");
+  }
+
+  @Test
   @TestMetadata("groupBy_refine.kt")
   public void testGroupBy_refine() {
     runTest("testData/box/groupBy_refine.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -227,6 +227,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("groupBy_count.kt")
+  public void testGroupBy_count() {
+    runTest("testData/box/groupBy_count.kt");
+  }
+
+  @Test
   @TestMetadata("groupBy_extractSchema.kt")
   public void testGroupBy_extractSchema() {
     runTest("testData/box/groupBy_extractSchema.kt");

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -473,6 +473,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("reducedGroupBy.kt")
+  public void testReducedGroupBy() {
+    runTest("testData/box/reducedGroupBy.kt");
+  }
+
+  @Test
   @TestMetadata("remove.kt")
   public void testRemove() {
     runTest("testData/box/remove.kt");


### PR DESCRIPTION
Now these are supported:
```
GroupBy.[minOf | maxOf]
GroupBy.[first | last | maxBy | minBy].into(columName) 
GroupBy.count 
```