### PR TITLE
Suggest removing some group.into { } overloads to simplify the primary use case

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.AnyColumnReference
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.CandidateForRemoval
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -40,10 +41,12 @@ public class GroupClause<T, C>(internal val df: DataFrame<T>, internal val colum
 @JvmName("intoString")
 @OverloadResolutionByLambdaReturnType
 @OptIn(ExperimentalTypeInference::class)
+@CandidateForRemoval
 public fun <T, C> GroupClause<T, C>.into(column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> String): DataFrame<T> =
     df.move(columns).under { column(it).toColumnAccessor() }
 
 @JvmName("intoColumn")
+@CandidateForRemoval
 public fun <T, C> GroupClause<T, C>.into(
     column: ColumnsSelectionDsl<T>.(ColumnWithPath<C>) -> AnyColumnReference,
 ): DataFrame<T> = df.move(columns).under(column)


### PR DESCRIPTION
What mostly concerns me here is that in order to create a simple grouping, which i believe is a main usage of this function, you have many options:
![image](https://github.com/user-attachments/assets/a4a0009d-0d59-4f21-abba-13e8fb812a8d)

Both function have a replacement: `move { }.under { }` 