### PR TITLE
Unified number types

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.dataframe.impl.zero
 import org.jetbrains.kotlinx.dataframe.math.sum
 import org.jetbrains.kotlinx.dataframe.math.sumOf
 import kotlin.reflect.KProperty
+import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
 
 // region DataColumn
@@ -42,7 +43,11 @@ public inline fun <T, reified R : Number> DataColumn<T>.sumOf(crossinline expres
 
 // region DataRow
 
-public fun AnyRow.rowSum(): Number = Aggregators.sum.aggregateMixed(values().filterIsInstance<Number>()) ?: 0
+public fun AnyRow.rowSum(): Number =
+    Aggregators.sum.aggregateMixed(
+        values = values().filterIsInstance<Number>(),
+        types = columnTypes().filter { it.isSubtypeOf(typeOf<Number?>()) }.toSet(),
+    ) ?: 0
 
 public inline fun <reified T : Number> AnyRow.rowSumOf(): T = values().filterIsInstance<T>().sum(typeOf<T>())
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/UnifyingNumbers.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/UnifyingNumbers.kt
@@ -1,0 +1,37 @@
+package org.jetbrains.kotlinx.dataframe.documentation
+
+/**
+ * ## Unifying Numbers
+ *
+ * The concept of unifying numbers is converting them to a common number type without losing information.
+ *
+ * The following graph shows the hierarchy of number types in Kotlin DataFrame.
+ * The order is top-down from the most complex type to the simplest one.
+ *
+ * {@include [Graph]}
+ * For each number type in the graph, it holds that a number of that type can be expressed lossless by
+ * a number of a more complex type (any of its parents).
+ * This is either because the more complex type has a larger range or higher precision (in terms of bits).
+ */
+internal interface UnifyingNumbers {
+
+    /**
+     * ```
+     *            BigDecimal
+     *            /      \\
+     *      BigInteger    \\
+     *        /   \\        \\
+     *    ULong   Long    Double
+     * ..   |    /   |   /   |  \\..
+     *   \\  |   /    |  /    |
+     *     UInt     Int    Float
+     * ..   |    /   |   /      \\..
+     *   \\  |   /    |  /
+     *    UShort   Short
+     *      |    /   |
+     *      |   /    |
+     *    UByte     Byte
+     * ```
+     */
+    interface Graph
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DirectedAcyclicGraph.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DirectedAcyclicGraph.kt
@@ -1,0 +1,176 @@
+package org.jetbrains.kotlinx.dataframe.impl
+
+import kotlin.experimental.ExperimentalTypeInference
+
+/**
+ * Represents a directed acyclic graph (DAG) of generic type [T].
+ *
+ * This class is immutable and guarantees that the graph does not contain any cycles.
+ * It provides functionality to find the nearest common ancestor of two vertices
+ * in the graph ([findNearestCommonVertex]).
+ *
+ * Use the [Builder] class or [buildDag] function to create a new instance of this class.
+ *
+ * @param T The type of items in the graph.
+ * @property adjacencyList A map representing directed edges, where the keys are source vertices
+ * and the values are sets of destination vertices.
+ * @property vertices A set of all vertices in the graph.
+ */
+internal class DirectedAcyclicGraph<T> private constructor(
+    private val adjacencyList: Map<T, Set<T>>,
+    private val vertices: Set<T>,
+) {
+    class Builder<T> {
+        private val edges = mutableListOf<Pair<T, T>>()
+        private val vertices = mutableSetOf<T>()
+
+        fun addEdge(from: T, to: T): Builder<T> {
+            edges.add(from to to)
+            vertices.add(from)
+            vertices.add(to)
+            return this
+        }
+
+        fun addEdges(vararg edges: Pair<T, T>): Builder<T> {
+            edges.forEach { (from, to) -> addEdge(from, to) }
+            return this
+        }
+
+        fun build(): DirectedAcyclicGraph<T> {
+            val adjacencyList = edges.groupBy({ it.first }, { it.second })
+                .mapValues { it.value.toSet() }
+
+            if (hasCycle(adjacencyList)) {
+                throw IllegalStateException("Graph contains cycle")
+            }
+
+            return DirectedAcyclicGraph(adjacencyList, vertices)
+        }
+
+        private fun hasCycle(adjacencyList: Map<T, Set<T>>): Boolean {
+            val visited = mutableSetOf<T>()
+            val recursionStack = mutableSetOf<T>()
+
+            fun dfs(vertex: T): Boolean {
+                if (vertex in recursionStack) return true
+                if (vertex in visited) return false
+
+                visited.add(vertex)
+                recursionStack.add(vertex)
+
+                adjacencyList[vertex]?.forEach { neighbor ->
+                    if (dfs(neighbor)) return true
+                }
+
+                recursionStack.remove(vertex)
+                return false
+            }
+
+            return adjacencyList.keys.any { vertex ->
+                if (vertex !in visited && dfs(vertex)) return true
+                false
+            }
+        }
+    }
+
+    fun findNearestCommonVertex(vertex1: T, vertex2: T): T? {
+        if (vertex1 !in vertices || vertex2 !in vertices) return null
+        if (vertex1 == vertex2) return vertex1
+
+        // Get all ancestors for both vertices
+        val ancestors1 = getAllAncestors(vertex1)
+        val ancestors2 = getAllAncestors(vertex2)
+
+        // If one vertex is an ancestor of another, return that vertex
+        if (vertex1 in ancestors2) return vertex1
+        if (vertex2 in ancestors1) return vertex2
+
+        // Find common ancestors
+        val commonAncestors = ancestors1.intersect(ancestors2)
+        if (commonAncestors.isEmpty()) return null
+
+        // Find the nearest common ancestor by checking distance from both vertices
+        return commonAncestors.minByOrNull { ancestor ->
+            getDistance(ancestor, vertex1) + getDistance(ancestor, vertex2)
+        }
+    }
+
+    private fun getAllAncestors(vertex: T): Set<T> {
+        val ancestors = mutableSetOf<T>()
+        val visited = mutableSetOf<T>()
+
+        fun dfs(current: T) {
+            if (current in visited) return
+            visited.add(current)
+
+            adjacencyList.forEach { (parent, children) ->
+                if (current in children) {
+                    ancestors.add(parent)
+                    dfs(parent)
+                }
+            }
+        }
+
+        dfs(vertex)
+        return ancestors
+    }
+
+    private fun getDistance(from: T, to: T): Int {
+        if (from == to) return 0
+
+        val distances = mutableMapOf<T, Int>()
+        val queue = ArrayDeque<T>()
+
+        queue.add(from)
+        distances[from] = 0
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val currentDistance = distances[current] ?: continue
+
+            adjacencyList[current]?.forEach { neighbor ->
+                if (neighbor !in distances) {
+                    distances[neighbor] = currentDistance + 1
+                    queue.add(neighbor)
+                    if (neighbor == to) return currentDistance + 1
+                }
+            }
+        }
+
+        return Int.MAX_VALUE
+    }
+
+    fun <R> map(conversion: (T) -> R): DirectedAcyclicGraph<R> {
+        val cache = mutableMapOf<T, R>()
+        val cachedConversion: (T) -> R = { cache.getOrPut(it) { conversion(it) } }
+
+        return Builder<R>().apply {
+            for ((from, to) in adjacencyList) {
+                for (to in to) {
+                    addEdge(from = cachedConversion(from), to = cachedConversion(to))
+                }
+            }
+        }.build()
+    }
+
+    companion object {
+        fun <T> builder(): Builder<T> = Builder()
+    }
+}
+
+/**
+ * Builds a new [DirectedAcyclicGraph] using the provided [builder] function.
+ *
+ * @see DirectedAcyclicGraph
+ */
+@OptIn(ExperimentalTypeInference::class)
+internal fun <T> buildDag(
+    @BuilderInference builder: DirectedAcyclicGraph.Builder<T>.() -> Unit,
+): DirectedAcyclicGraph<T> = DirectedAcyclicGraph.builder<T>().apply(builder).build()
+
+/**
+ * Builds a new [DirectedAcyclicGraph] using the provided [edges].
+ *
+ * @see DirectedAcyclicGraph
+ */
+internal fun <T> dagOf(vararg edges: Pair<T, T>): DirectedAcyclicGraph<T> = buildDag { addEdges(*edges) }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/NumberTypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/NumberTypeUtils.kt
@@ -1,0 +1,143 @@
+package org.jetbrains.kotlinx.dataframe.impl
+
+import org.jetbrains.kotlinx.dataframe.impl.api.createConverter
+import org.jetbrains.kotlinx.dataframe.impl.commonNumberType
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.withNullability
+import kotlin.reflect.typeOf
+
+/**
+ * Number type graph, structured in terms of number complexity.
+ * A number can always be expressed lossless by a number of a more complex type (any of its parents).
+ *
+ * ```
+ *         BigDecimal
+ *         /      \\
+ *   BigInteger    |
+ *         |       |
+ *       ULong     |
+ *         |       |
+ *       Long    Double
+ *          \\   /    |
+ *           UInt    |
+ *            |      |
+ *           Int   Float
+ *            |   /
+ *           UShort
+ *             |
+ *           Short
+ *             |
+ *           UByte
+ *            |
+ *           Byte
+ * ```
+ *
+ * For any two numbers, we can find the nearest common ancestor in this graph
+ * by calling [DirectedAcyclicGraph.findNearestCommonVertex].
+ * @see getCommonNumberClass
+ * @see commonNumberClass
+ */
+internal val numberTypeGraph: DirectedAcyclicGraph<KType> by lazy {
+    dagOf(
+        typeOf<BigDecimal>() to typeOf<BigInteger>(),
+        typeOf<BigDecimal>() to typeOf<Double>(),
+        typeOf<BigInteger>() to typeOf<ULong>(),
+        typeOf<ULong>() to typeOf<Long>(),
+        typeOf<Long>() to typeOf<UInt>(),
+        typeOf<Double>() to typeOf<UInt>(),
+        typeOf<Double>() to typeOf<Float>(),
+        typeOf<UInt>() to typeOf<Int>(),
+        typeOf<Int>() to typeOf<UShort>(),
+        typeOf<Float>() to typeOf<UShort>(),
+        typeOf<UShort>() to typeOf<Short>(),
+        typeOf<Short>() to typeOf<UByte>(),
+        typeOf<UByte>() to typeOf<Byte>(),
+    )
+}
+
+/** @include [numberTypeGraph] */
+internal val numberClassGraph: DirectedAcyclicGraph<KClass<*>> by lazy {
+    numberTypeGraph.map { it.classifier as KClass<*> }
+}
+
+/**
+ * Determines the nearest common numeric type, in terms of complexity, between two given classes/types.
+ *
+ * Unsigned types are supported too even though they are not a [Number] instance,
+ * but unless an unsigned type is provided in the input, it will never be returned.
+ * Meaning, given two [Number] inputs, the output will always be a [Number].
+ *
+ * @param first The first numeric type to compare. Can be null, in which case the second to is returned.
+ * @param second The second numeric to compare. Cannot be null.
+ * @return The nearest common numeric type between the two input classes.
+ *   If no common class is found, [IllegalStateException] is thrown.
+ * @see numberTypeGraph
+ */
+internal fun getCommonNumberType(first: KType?, second: KType): KType {
+    if (first == null) return second
+
+    val firstWithoutNullability = first.withNullability(false)
+    val secondWithoutNullability = second.withNullability(false)
+
+    val result = if (firstWithoutNullability == secondWithoutNullability) {
+        firstWithoutNullability
+    } else {
+        numberTypeGraph.findNearestCommonVertex(firstWithoutNullability, secondWithoutNullability)
+            ?: error("Can not find common number type for $first and $second")
+    }
+
+    return if (first.isMarkedNullable || second.isMarkedNullable) result.withNullability(true) else result
+}
+
+/** @include [getCommonNumberType] */
+@Suppress("IntroduceWhenSubject")
+internal fun getCommonNumberClass(first: KClass<*>?, second: KClass<*>): KClass<*> =
+    when {
+        first == null -> second
+
+        first == second -> first
+
+        else -> numberClassGraph.findNearestCommonVertex(first, second)
+            ?: error("Can not find common number type for $first and $second")
+    }
+
+/**
+ * Determines the nearest common numeric type, in terms of complexity, all types in [this].
+ *
+ * Unsigned types are supported too even though they are not a [Number] instance,
+ * but unless an unsigned type is provided in the input, it will never be returned.
+ * Meaning, given just [Number] inputs, the output will always be a [Number].
+ *
+ * @return The nearest common numeric type between the input types.
+ *   If no common type is found, it returns [Number].
+ * @see numberTypeGraph
+ */
+internal fun Iterable<KType>.commonNumberType(): KType = fold(null as KType?, ::getCommonNumberType) ?: typeOf<Number>()
+
+/** @include [commonNumberType] */
+internal fun Iterable<KClass<*>>.commonNumberClass(): KClass<*> =
+    fold(null as KClass<*>?, ::getCommonNumberClass) ?: Number::class
+
+/**
+ * Converts the elements of the given iterable of numbers into a common numeric type based on complexity.
+ * The common numeric type is determined using the provided [commonNumberType] parameter
+ * or calculated with [Iterable.commonNumberType] from the iterable's elements if not explicitly specified.
+ *
+ * @param commonNumberType The desired common numeric type to convert the elements to.
+ *   This is determined by default using the types of the elements in the iterable.
+ * @return A new iterable of numbers where each element is converted to the specified or inferred common number type.
+ * @throws IllegalStateException if an element cannot be converted to the common number type.
+ * @see Iterable.commonNumberType
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun Iterable<Number>.convertToCommonNumberType(
+    commonNumberType: KType = this.types().commonNumberType(),
+): Iterable<Number> {
+    val converter = createConverter(typeOf<Number>(), commonNumberType)!! as (Number) -> Number?
+    return map {
+        converter(it) ?: error("Can not convert $it to $commonNumberType")
+    }
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/NumberTypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/NumberTypeUtils.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.impl
 
+import org.jetbrains.kotlinx.dataframe.documentation.UnifyingNumbers
 import org.jetbrains.kotlinx.dataframe.impl.api.createConverter
-import org.jetbrains.kotlinx.dataframe.impl.commonNumberType
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.reflect.KClass
@@ -13,70 +13,65 @@ import kotlin.reflect.typeOf
  * Number type graph, structured in terms of number complexity.
  * A number can always be expressed lossless by a number of a more complex type (any of its parents).
  *
- * ```
- *         BigDecimal
- *         /      \\
- *   BigInteger    |
- *         |       |
- *       ULong     |
- *         |       |
- *       Long    Double
- *          \\   /    |
- *           UInt    |
- *            |      |
- *           Int   Float
- *            |   /
- *           UShort
- *             |
- *           Short
- *             |
- *           UByte
- *            |
- *           Byte
- * ```
+ * {@include [UnifyingNumbers.Graph]}
  *
  * For any two numbers, we can find the nearest common ancestor in this graph
  * by calling [DirectedAcyclicGraph.findNearestCommonVertex].
- * @see getCommonNumberClass
- * @see commonNumberClass
+ * @see getUnifiedNumberClass
+ * @see unifiedNumberClass
+ * @see UnifyingNumbers
  */
-internal val numberTypeGraph: DirectedAcyclicGraph<KType> by lazy {
-    dagOf(
-        typeOf<BigDecimal>() to typeOf<BigInteger>(),
-        typeOf<BigDecimal>() to typeOf<Double>(),
-        typeOf<BigInteger>() to typeOf<ULong>(),
-        typeOf<ULong>() to typeOf<Long>(),
-        typeOf<Long>() to typeOf<UInt>(),
-        typeOf<Double>() to typeOf<UInt>(),
-        typeOf<Double>() to typeOf<Float>(),
-        typeOf<UInt>() to typeOf<Int>(),
-        typeOf<Int>() to typeOf<UShort>(),
-        typeOf<Float>() to typeOf<UShort>(),
-        typeOf<UShort>() to typeOf<Short>(),
-        typeOf<Short>() to typeOf<UByte>(),
-        typeOf<UByte>() to typeOf<Byte>(),
-    )
+internal val unifiedNumberTypeGraph: DirectedAcyclicGraph<KType> by lazy {
+    buildDag {
+        addEdge(typeOf<BigDecimal>(), typeOf<BigInteger>())
+        addEdge(typeOf<BigDecimal>(), typeOf<Double>())
+
+        addEdge(typeOf<BigInteger>(), typeOf<ULong>())
+        addEdge(typeOf<BigInteger>(), typeOf<Long>())
+
+        addEdge(typeOf<ULong>(), typeOf<UInt>())
+
+        addEdge(typeOf<Long>(), typeOf<UInt>())
+        addEdge(typeOf<Long>(), typeOf<Int>())
+
+        addEdge(typeOf<Double>(), typeOf<Int>())
+        addEdge(typeOf<Double>(), typeOf<Float>())
+        addEdge(typeOf<Double>(), typeOf<UInt>())
+
+        addEdge(typeOf<UInt>(), typeOf<UShort>())
+
+        addEdge(typeOf<Int>(), typeOf<UShort>())
+        addEdge(typeOf<Int>(), typeOf<Short>())
+
+        addEdge(typeOf<Float>(), typeOf<Short>())
+        addEdge(typeOf<Float>(), typeOf<UShort>())
+
+        addEdge(typeOf<UShort>(), typeOf<UByte>())
+
+        addEdge(typeOf<Short>(), typeOf<UByte>())
+        addEdge(typeOf<Short>(), typeOf<Byte>())
+    }
 }
 
-/** @include [numberTypeGraph] */
-internal val numberClassGraph: DirectedAcyclicGraph<KClass<*>> by lazy {
-    numberTypeGraph.map { it.classifier as KClass<*> }
+/** @include [unifiedNumberTypeGraph] */
+internal val unifiedNumberClassGraph: DirectedAcyclicGraph<KClass<*>> by lazy {
+    unifiedNumberTypeGraph.map { it.classifier as KClass<*> }
 }
 
 /**
  * Determines the nearest common numeric type, in terms of complexity, between two given classes/types.
  *
  * Unsigned types are supported too even though they are not a [Number] instance,
- * but unless an unsigned type is provided in the input, it will never be returned.
- * Meaning, given two [Number] inputs, the output will always be a [Number].
+ * but unless two unsigned types are provided in the input, it will never be returned.
+ * Meaning, a single [Number] input, the output will always be a [Number].
  *
  * @param first The first numeric type to compare. Can be null, in which case the second to is returned.
  * @param second The second numeric to compare. Cannot be null.
  * @return The nearest common numeric type between the two input classes.
  *   If no common class is found, [IllegalStateException] is thrown.
- * @see numberTypeGraph
+ * @see UnifyingNumbers
  */
-internal fun getCommonNumberType(first: KType?, second: KType): KType {
+internal fun getUnifiedNumberType(first: KType?, second: KType): KType {
     if (first == null) return second
 
     val firstWithoutNullability = first.withNullability(false)
@@ -85,22 +80,22 @@ internal fun getCommonNumberType(first: KType?, second: KType): KType {
     val result = if (firstWithoutNullability == secondWithoutNullability) {
         firstWithoutNullability
     } else {
-        numberTypeGraph.findNearestCommonVertex(firstWithoutNullability, secondWithoutNullability)
+        unifiedNumberTypeGraph.findNearestCommonVertex(firstWithoutNullability, secondWithoutNullability)
             ?: error("Can not find common number type for $first and $second")
     }
 
     return if (first.isMarkedNullable || second.isMarkedNullable) result.withNullability(true) else result
 }
 
-/** @include [getCommonNumberType] */
+/** @include [getUnifiedNumberType] */
 @Suppress("IntroduceWhenSubject")
-internal fun getCommonNumberClass(first: KClass<*>?, second: KClass<*>): KClass<*> =
+internal fun getUnifiedNumberClass(first: KClass<*>?, second: KClass<*>): KClass<*> =
     when {
         first == null -> second
 
         first == second -> first
 
-        else -> numberClassGraph.findNearestCommonVertex(first, second)
+        else -> unifiedNumberClassGraph.findNearestCommonVertex(first, second)
             ?: error("Can not find common number type for $first and $second")
     }
 
@@ -108,33 +103,34 @@ internal fun getCommonNumberClass(first: KClass<*>?, second: KClass<*>): KClass<
  * Determines the nearest common numeric type, in terms of complexity, all types in [this].
  *
  * Unsigned types are supported too even though they are not a [Number] instance,
- * but unless an unsigned type is provided in the input, it will never be returned.
- * Meaning, given just [Number] inputs, the output will always be a [Number].
+ * but unless the input solely exists of unsigned numbers, it will never be returned.
+ * Meaning, given a [Number] in the input, the output will always be a [Number].
  *
  * @return The nearest common numeric type between the input types.
  *   If no common type is found, it returns [Number].
- * @see numberTypeGraph
+ * @see UnifyingNumbers
  */
-internal fun Iterable<KType>.commonNumberType(): KType = fold(null as KType?, ::getCommonNumberType) ?: typeOf<Number>()
+internal fun Iterable<KType>.unifiedNumberType(): KType =
+    fold(null as KType?, ::getUnifiedNumberType) ?: typeOf<Number>()
 
-/** @include [commonNumberType] */
-internal fun Iterable<KClass<*>>.commonNumberClass(): KClass<*> =
-    fold(null as KClass<*>?, ::getCommonNumberClass) ?: Number::class
+/** @include [unifiedNumberType] */
+internal fun Iterable<KClass<*>>.unifiedNumberClass(): KClass<*> =
+    fold(null as KClass<*>?, ::getUnifiedNumberClass) ?: Number::class
 
 /**
  * Converts the elements of the given iterable of numbers into a common numeric type based on complexity.
  * The common numeric type is determined using the provided [commonNumberType] parameter
- * or calculated with [Iterable.commonNumberType] from the iterable's elements if not explicitly specified.
+ * or calculated with [Iterable.unifiedNumberType] from the iterable's elements if not explicitly specified.
  *
  * @param commonNumberType The desired common numeric type to convert the elements to.
  *   This is determined by default using the types of the elements in the iterable.
  * @return A new iterable of numbers where each element is converted to the specified or inferred common number type.
  * @throws IllegalStateException if an element cannot be converted to the common number type.
- * @see Iterable.commonNumberType
+ * @see UnifyingNumbers
  */
 @Suppress("UNCHECKED_CAST")
-internal fun Iterable<Number>.convertToCommonNumberType(
-    commonNumberType: KType = this.types().commonNumberType(),
+internal fun Iterable<Number>.convertToUnifiedNumberType(
+    commonNumberType: KType = this.types().unifiedNumberType(),
 ): Iterable<Number> {
     val converter = createConverter(typeOf<Number>(), commonNumberType)!! as (Number) -> Number?
     return map {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators
 
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators.std
 import org.jetbrains.kotlinx.dataframe.math.mean
 import org.jetbrains.kotlinx.dataframe.math.median
 import org.jetbrains.kotlinx.dataframe.math.std

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/NumbersAggregator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/NumbersAggregator.kt
@@ -1,9 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators
 
 import org.jetbrains.kotlinx.dataframe.DataColumn
-import org.jetbrains.kotlinx.dataframe.impl.commonNumberType
-import org.jetbrains.kotlinx.dataframe.impl.convertToCommonNumberType
-import org.jetbrains.kotlinx.dataframe.impl.types
+import org.jetbrains.kotlinx.dataframe.impl.convertToUnifiedNumberType
+import org.jetbrains.kotlinx.dataframe.impl.unifiedNumberType
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
@@ -27,9 +26,9 @@ internal class NumbersAggregator(name: String, aggregate: (Iterable<Number>, KTy
      */
     @Suppress("UNCHECKED_CAST")
     fun aggregateMixed(values: Iterable<Number>, types: Set<KType>): Number? {
-        val commonType = types.commonNumberType()
+        val commonType = types.unifiedNumberType()
         return aggregate(
-            values = values.convertToCommonNumberType(commonType),
+            values = values.convertToUnifiedNumberType(commonType),
             type = commonType,
         )
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/NumbersAggregator.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/NumbersAggregator.kt
@@ -1,26 +1,37 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators
 
 import org.jetbrains.kotlinx.dataframe.DataColumn
-import org.jetbrains.kotlinx.dataframe.impl.commonNumberClass
-import org.jetbrains.kotlinx.dataframe.impl.createStarProjectedType
+import org.jetbrains.kotlinx.dataframe.impl.commonNumberType
+import org.jetbrains.kotlinx.dataframe.impl.convertToCommonNumberType
+import org.jetbrains.kotlinx.dataframe.impl.types
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
-internal class NumbersAggregator<C : Number>(name: String, aggregate: (Iterable<C>, KType) -> C?) :
-    AggregatorBase<C, C>(name, aggregate) {
+internal class NumbersAggregator(name: String, aggregate: (Iterable<Number>, KType) -> Number?) :
+    AggregatorBase<Number, Number>(name, aggregate) {
 
-    override fun aggregate(columns: Iterable<DataColumn<C?>>): C? = aggregateMixed(columns.mapNotNull { aggregate(it) })
+    override fun aggregate(columns: Iterable<DataColumn<Number?>>): Number? =
+        aggregateMixed(
+            values = columns.mapNotNull { aggregate(it) },
+            types = columns.map { it.type() }.toSet(),
+        )
 
     class Factory(private val aggregate: Iterable<Number>.(KType) -> Number?) : AggregatorProvider<Number, Number> {
         override fun create(name: String) = NumbersAggregator(name, aggregate)
 
-        override operator fun getValue(obj: Any?, property: KProperty<*>): NumbersAggregator<Number> =
-            create(property.name)
+        override operator fun getValue(obj: Any?, property: KProperty<*>): NumbersAggregator = create(property.name)
     }
 
-    fun aggregateMixed(values: Iterable<C>): C? {
-        val classes = values.map { it.javaClass.kotlin }
-        return aggregate(values, classes.commonNumberClass().createStarProjectedType(false))
+    /**
+     * Can aggregate numbers with different types by first converting them to a compatible type.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun aggregateMixed(values: Iterable<Number>, types: Set<KType>): Number? {
+        val commonType = types.commonNumberType()
+        return aggregate(
+            values = values.convertToCommonNumberType(commonType),
+            type = commonType,
+        )
     }
 
     override val preservesType = false

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/impl/DirectedAcyclicGraphTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/impl/DirectedAcyclicGraphTest.kt
@@ -1,0 +1,89 @@
+package org.jetbrains.kotlinx.dataframe.impl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class DirectedAcyclicGraphTest {
+
+    @Test
+    fun `basic graph building`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("B", "C")
+        }
+
+        graph.findNearestCommonVertex("B", "C") shouldBe "B"
+        graph.findNearestCommonVertex("A", "C") shouldBe "A"
+    }
+
+    @Test
+    fun `cycle detection`() {
+        shouldThrow<IllegalStateException> {
+            buildDag {
+                addEdge("A", "B")
+                addEdge("B", "C")
+                addEdge("C", "A")
+            }
+        }
+    }
+
+    @Test
+    fun `nearest common vertex - same vertex`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("B", "C")
+        }
+
+        graph.findNearestCommonVertex("B", "B") shouldBe "B"
+    }
+
+    @Test
+    fun `nearest common vertex - one is ancestor`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("B", "C")
+            addEdge("B", "D")
+        }
+
+        graph.findNearestCommonVertex("B", "D") shouldBe "B"
+        graph.findNearestCommonVertex("D", "B") shouldBe "B"
+    }
+
+    @Test
+    fun `nearest common vertex - common ancestor exists`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("A", "C")
+            addEdge("B", "D")
+            addEdge("C", "E")
+        }
+
+        graph.findNearestCommonVertex("D", "E") shouldBe "A"
+    }
+
+    @Test
+    fun `nearest common vertex - no common ancestor`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("C", "D")
+        }
+
+        graph.findNearestCommonVertex("B", "D").shouldBeNull()
+    }
+
+    @Test
+    fun `nearest common vertex - complex case`() {
+        val graph = buildDag {
+            addEdge("A", "B")
+            addEdge("B", "C")
+            addEdge("A", "D")
+            addEdge("D", "E")
+            addEdge("B", "E")
+        }
+
+        // B is closer to E than A
+        graph.findNearestCommonVertex("C", "E") shouldBe "B"
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/sum.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/sum.kt
@@ -64,7 +64,7 @@ class SumTests {
         df.sum { value3 } shouldBe expected3
     }
 
-    // Issue #1068
+    /** [Issue #1068](https://github.com/Kotlin/dataframe/issues/1068) */
     @Test
     fun `rowSum mixed number types`() {
         dataFrameOf("a", "b")(1, 2f)[0].rowSum().let {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/sum.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/sum.kt
@@ -4,9 +4,11 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.rowSum
 import org.jetbrains.kotlinx.dataframe.api.sum
 import org.jetbrains.kotlinx.dataframe.api.sumOf
 import org.junit.Test
+import java.math.BigDecimal
 
 class SumTests {
 
@@ -60,5 +62,25 @@ class SumTests {
         df.sum { value1 } shouldBe expected1
         df.sum { value2 } shouldBe expected2
         df.sum { value3 } shouldBe expected3
+    }
+
+    // Issue #1068
+    @Test
+    fun `rowSum mixed number types`() {
+        dataFrameOf("a", "b")(1, 2f)[0].rowSum().let {
+            it shouldBe 3.0
+            it::class shouldBe Double::class
+        }
+
+        // NOTE! unsigned numbers are not Number, they are skipped for now
+        dataFrameOf("a", "b")(1, 2u)[0].rowSum().let {
+            it shouldBe 1
+            it::class shouldBe Int::class
+        }
+
+        dataFrameOf("a", "b")(1.0, 2L)[0].rowSum().let {
+            it shouldBe (3.0.toBigDecimal())
+            it::class shouldBe BigDecimal::class
+        }
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
@@ -4,13 +4,14 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.api.columnOf
+import org.jetbrains.kotlinx.dataframe.documentation.UnifyingNumbers
 import org.jetbrains.kotlinx.dataframe.impl.asArrayAsListOrNull
 import org.jetbrains.kotlinx.dataframe.impl.commonParent
 import org.jetbrains.kotlinx.dataframe.impl.commonParents
 import org.jetbrains.kotlinx.dataframe.impl.commonType
 import org.jetbrains.kotlinx.dataframe.impl.commonTypeListifyValues
 import org.jetbrains.kotlinx.dataframe.impl.createType
-import org.jetbrains.kotlinx.dataframe.impl.getCommonNumberClass
+import org.jetbrains.kotlinx.dataframe.impl.getUnifiedNumberClass
 import org.jetbrains.kotlinx.dataframe.impl.guessValueType
 import org.jetbrains.kotlinx.dataframe.impl.isArray
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveArray
@@ -418,43 +419,47 @@ class UtilTests {
         ).commonTypeListifyValues() shouldBe typeOf<Collection<out Nothing?>?>()
     }
 
+    /**
+     * See [UnifyingNumbers] for more information.
+     * {@include [UnifyingNumbers.Graph]}
+     */
     @Test
     fun `common number types`() {
         // Same type
-        getCommonNumberClass(Int::class, Int::class) shouldBe Int::class
-        getCommonNumberClass(Double::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClass(Int::class, Int::class) shouldBe Int::class
+        getUnifiedNumberClass(Double::class, Double::class) shouldBe Double::class
 
         // Direct parent-child relationships
-        getCommonNumberClass(Int::class, UShort::class) shouldBe Int::class
-        getCommonNumberClass(UInt::class, Int::class) shouldBe UInt::class
-        getCommonNumberClass(Long::class, UInt::class) shouldBe Long::class
-        getCommonNumberClass(Double::class, Float::class) shouldBe Double::class
+        getUnifiedNumberClass(Int::class, UShort::class) shouldBe Int::class
+        getUnifiedNumberClass(Long::class, UInt::class) shouldBe Long::class
+        getUnifiedNumberClass(Double::class, Float::class) shouldBe Double::class
+        getUnifiedNumberClass(UShort::class, Short::class) shouldBe Int::class
+        getUnifiedNumberClass(UByte::class, Byte::class) shouldBe Short::class
 
-        // Parent-child relationships for signed/unsigned types
-        getCommonNumberClass(UShort::class, Short::class) shouldBe UShort::class
-        getCommonNumberClass(UByte::class, Byte::class) shouldBe UByte::class
+        getUnifiedNumberClass(UByte::class, UShort::class) shouldBe UShort::class
 
         // Multi-level relationships
-        getCommonNumberClass(Byte::class, Int::class) shouldBe Int::class
-        getCommonNumberClass(UByte::class, Long::class) shouldBe Long::class
-        getCommonNumberClass(Short::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClass(Byte::class, Int::class) shouldBe Int::class
+        getUnifiedNumberClass(UByte::class, Long::class) shouldBe Long::class
+        getUnifiedNumberClass(Short::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClass(UInt::class, Int::class) shouldBe Long::class
 
         // Top-level types
-        getCommonNumberClass(BigDecimal::class, Double::class) shouldBe BigDecimal::class
-        getCommonNumberClass(BigInteger::class, Long::class) shouldBe BigInteger::class
-        getCommonNumberClass(BigDecimal::class, BigInteger::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(BigDecimal::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(BigInteger::class, Long::class) shouldBe BigInteger::class
+        getUnifiedNumberClass(BigDecimal::class, BigInteger::class) shouldBe BigDecimal::class
 
         // Distant relationships
-        getCommonNumberClass(Byte::class, BigDecimal::class) shouldBe BigDecimal::class
-        getCommonNumberClass(UByte::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClass(Byte::class, BigDecimal::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(UByte::class, Double::class) shouldBe Double::class
 
         // Complex type promotions
-        getCommonNumberClass(Int::class, Float::class) shouldBe Double::class
-        getCommonNumberClass(Long::class, Double::class) shouldBe BigDecimal::class
-        getCommonNumberClass(ULong::class, Double::class) shouldBe BigDecimal::class
-        getCommonNumberClass(BigInteger::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(Int::class, Float::class) shouldBe Double::class
+        getUnifiedNumberClass(Long::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(ULong::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClass(BigInteger::class, Double::class) shouldBe BigDecimal::class
 
         // Edge case with null
-        getCommonNumberClass(null, Int::class) shouldBe Int::class
+        getUnifiedNumberClass(null, Int::class) shouldBe Int::class
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1068
Helps https://github.com/Kotlin/dataframe/issues/961

Fixed `getCommonNumberType` and `commonNumberClass` functions that are used solely by `sum` at the moment.

I introduced a future-proof rewrite of the function and added support for unsigned- and big numbers. Moved it to a separate file and added tests. We will reuse this logic in more places later. I created a small DAG implementation for this, as it's smaller than yet another dependency.

```
           BigDecimal
           /       \
     BigInteger     \
       /    \        \
   ULong   Long    Double
..   |    /   |   /   |  \..
  \  |   /    |  /    |
    UInt     Int    Float
..   |    /   |   /      \..
  \  |   /    |  /
   UShort   Short
     |    /   |
     |   /    |
   UByte     Byte
```
The idea of this is that numbers can be converted lossless to a higher number type, so providing, say `UInt` and `Float` can be auto-converted to `Double` at runtime safely. The only place it's currently done is when collecting numbers across multiple columns and summing them, but I intend to reuse this logic in other statistical functions when needed, in parsing, or [in JSON](https://github.com/Kotlin/dataframe/issues/557).

`NumbersAggregator` now converts numbers in its input to a common number type first, before aggregating, not relying on smart-casts anymore. 
To avoid heavy reflection calls, types can be supplied to aggregateMixed() if you're aware of them.