### PR TITLE
add SXSS writing

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10077,7 +10077,7 @@ public final class org/jetbrains/kotlinx/dataframe/impl/api/ToDataFrameKt {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/ToSequenceKt {
-	public static final fun toSequenceImpl (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/reflect/KType;)Ljava/lang/Iterable;
+	public static final fun toSequenceImpl (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/reflect/KType;)Lkotlin/sequences/Sequence;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/UpdateKt {

--- a/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
+++ b/core/generated-sources/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
@@ -18,8 +18,6 @@ import org.jetbrains.kotlinx.dataframe.samples.api.city
 import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
-import org.jetbrains.kotlinx.dataframe.samples.api.secondName
-import org.jetbrains.kotlinx.dataframe.samples.api.thirdName
 import org.jetbrains.kotlinx.dataframe.samples.api.weight
 import org.junit.Test
 import kotlin.reflect.typeOf

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
@@ -18,8 +18,6 @@ import org.jetbrains.kotlinx.dataframe.samples.api.city
 import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
-import org.jetbrains.kotlinx.dataframe.samples.api.secondName
-import org.jetbrains.kotlinx.dataframe.samples.api.thirdName
 import org.jetbrains.kotlinx.dataframe.samples.api.weight
 import org.junit.Test
 import kotlin.reflect.typeOf

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -281,8 +281,8 @@ public fun DataFrame.Companion.readExcel(
  */
 @JvmInline
 public value class StringColumns
-    @Interpretable("StringColumns")
-    constructor(public val range: String)
+@Interpretable("StringColumns")
+constructor(public val range: String)
 
 public fun StringColumns.toFormattingOptions(formatter: DataFormatter = DataFormatter()): FormattingOptions =
     FormattingOptions(range, formatter)
@@ -496,16 +496,14 @@ public fun <T> DataFrame<T>.writeExcel(
     val factory =
         // Write to an existing file with `keepFile` flag
         if (keepFile && file.exists() && file.length() > 0L) {
-            file.inputStream().use { fis ->
-                when (workBookType) {
-                    WorkBookType.XLS -> HSSFWorkbook(fis)
-                    WorkBookType.XLSX -> XSSFWorkbook(fis)
-                }
+            val fis = file.inputStream()
+            when (workBookType) {
+                WorkBookType.XLS -> HSSFWorkbook(fis)
+                WorkBookType.XLSX -> XSSFWorkbook(fis)
             }
         } else {
             when (workBookType) {
                 WorkBookType.XLS -> HSSFWorkbook()
-
                 // Use streaming mode for a new XLSX file
                 WorkBookType.XLSX -> SXSSFWorkbook()
             }

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -505,6 +505,7 @@ public fun <T> DataFrame<T>.writeExcel(
         } else {
             when (workBookType) {
                 WorkBookType.XLS -> HSSFWorkbook()
+
                 // Use streaming mode for a new XLSX file
                 WorkBookType.XLSX -> SXSSFWorkbook()
             }

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -490,6 +490,8 @@ public enum class WorkBookType {
  * @param keepFile If `true` and the file already exists, a new sheet will be appended instead of overwriting the file.
  * This may result in higher memory usage and slower performance compared to creating a new file.
  * Defaults to `false`.
+ *
+ * @throws [IllegalArgumentException] if the [sheetName] is invalid or workbook already contains a sheet with this name.
  */
 public fun <T> DataFrame<T>.writeExcel(
     path: String,
@@ -515,6 +517,8 @@ public fun <T> DataFrame<T>.writeExcel(
  * @param keepFile If `true` and the file already exists, a new sheet will be appended instead of overwriting the file.
  * This may result in higher memory usage and slower performance compared to creating a new file.
  * Defaults to `false`.
+ *
+ * @throws [IllegalArgumentException] if the [sheetName] is invalid or workbook already contains a sheet with this name.
  */
 public fun <T> DataFrame<T>.writeExcel(
     file: File,
@@ -557,6 +561,8 @@ public fun <T> DataFrame<T>.writeExcel(
  * @param sheetName The name of the sheet in the Excel file. If null, the default name will be used.
  * @param writeHeader A flag indicating whether to write the header row in the Excel file. Defaults to true.
  * @param factory The [Workbook] instance, allowing integration with an existing workbook.
+ *
+ * @throws [IllegalArgumentException] if the [sheetName] is invalid or workbook already contains a sheet with this name.
  */
 public fun <T> DataFrame<T>.writeExcel(
     outputStream: OutputStream,
@@ -585,7 +591,10 @@ public fun <T> DataFrame<T>.writeExcel(
  * @param columnsSelector A [selector][ColumnsSelector] to determine which columns to include. Defaults to all columns.
  * @param sheetName The name of the sheet. If null, a default sheet name is used.
  * @param writeHeader Whether to include a header row with column names. Defaults to true.
+ *
  * @return The created [Sheet] instance containing the DataFrame data.
+ *
+ * @throws [IllegalArgumentException] if the [sheetName] is invalid or workbook already contains a sheet with this name.
  */
 public fun <T> DataFrame<T>.writeExcel(
     wb: Workbook,

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -471,6 +471,26 @@ private fun Cell?.cellValue(sheetName: String): Any? {
     return getValueFromType(cellType)
 }
 
+public enum class WorkBookType {
+    XLS,
+    XLSX,
+}
+
+/**
+ * Writes this DataFrame to an Excel file as a single sheet.
+ *
+ * Implemented with [Apache POI](https://poi.apache.org) using `HSSFWorkbook` for XLS files,
+ * `XSSFWorkbook` for standard XLSX files, and `SXSSFWorkbook` for memory-efficient streaming when creating new XLSX files.
+ *
+ * @param path The path to the file where the data will be written.
+ * @param columnsSelector A [selector][ColumnsSelector] to determine which columns to include in the file. The default is all columns.
+ * @param sheetName The name of the sheet in the Excel file. If null, the default name will be used.
+ * @param writeHeader A flag indicating whether to write the header row in the Excel file. Defaults to true.
+ * @param workBookType The [type of workbook][WorkBookType] to create (e.g., XLS or XLSX). Defaults to XLSX.
+ * @param keepFile If `true` and the file already exists, a new sheet will be appended instead of overwriting the file.
+ * This may result in higher memory usage and slower performance compared to creating a new file.
+ * Defaults to `false`.
+ */
 public fun <T> DataFrame<T>.writeExcel(
     path: String,
     columnsSelector: ColumnsSelector<T, *> = { all() },
@@ -480,11 +500,22 @@ public fun <T> DataFrame<T>.writeExcel(
     keepFile: Boolean = false,
 ): Unit = writeExcel(File(path), columnsSelector, sheetName, writeHeader, workBookType, keepFile)
 
-public enum class WorkBookType {
-    XLS,
-    XLSX,
-}
-
+/**
+ * Writes this DataFrame to an Excel file as a single sheet.
+ *
+ * Implemented with [Apache POI](https://poi.apache.org) using `HSSFWorkbook` for XLS files,
+ * `XSSFWorkbook` for standard XLSX files,
+ * and `SXSSFWorkbook` for memory-efficient streaming when creating new XLSX files.
+ *
+ * @param file The file where the data will be written.
+ * @param columnsSelector A [selector][ColumnsSelector] to determine which columns to include in the file. The default is all columns.
+ * @param sheetName The name of the sheet in the Excel file. If null, the default name will be used.
+ * @param writeHeader A flag indicating whether to write the header row in the Excel file. Defaults to true.
+ * @param workBookType The [type of workbook][WorkBookType] to create (e.g., XLS or XLSX). Defaults to XLSX.
+ * @param keepFile If `true` and the file already exists, a new sheet will be appended instead of overwriting the file.
+ * This may result in higher memory usage and slower performance compared to creating a new file.
+ * Defaults to `false`.
+ */
 public fun <T> DataFrame<T>.writeExcel(
     file: File,
     columnsSelector: ColumnsSelector<T, *> = { all() },
@@ -514,6 +545,19 @@ public fun <T> DataFrame<T>.writeExcel(
     }
 }
 
+/**
+ * Writes this DataFrame to an Excel file using an existing [Workbook] instance into given [OutputStream].
+ *
+ * Uses [Apache POI](https://poi.apache.org).
+ * Supports [XSSFWorkbook] and [SXSSFWorkbook] for XLSX and [HSSFWorkbook] for XLS,
+ * and allows users to manage the workbook externally.
+ *
+ * @param outputStream The output stream where the Excel data will be written.
+ * @param columnsSelector A [selector][ColumnsSelector] to determine which columns to include in the file. The default is all columns.
+ * @param sheetName The name of the sheet in the Excel file. If null, the default name will be used.
+ * @param writeHeader A flag indicating whether to write the header row in the Excel file. Defaults to true.
+ * @param factory The [Workbook] instance, allowing integration with an existing workbook.
+ */
 public fun <T> DataFrame<T>.writeExcel(
     outputStream: OutputStream,
     columnsSelector: ColumnsSelector<T, *> = { all() },
@@ -527,6 +571,22 @@ public fun <T> DataFrame<T>.writeExcel(
     wb.close()
 }
 
+/**
+ * Creates a new [Sheet] in the given [Workbook] and writes this DataFrame content into it.
+ *
+ * Uses [Apache POI](https://poi.apache.org).
+ * Supports [XSSFWorkbook] and [SXSSFWorkbook] for XLSX and [HSSFWorkbook] for XLS,
+ * and allows users to manage the workbook externally.
+ *
+ * Automatically handles datetime types.
+ * Skips null values to prevent Apache POI from treating empty cells incorrectly.
+ *
+ * @param wb The [Workbook] where the sheet will be created.
+ * @param columnsSelector A [selector][ColumnsSelector] to determine which columns to include. Defaults to all columns.
+ * @param sheetName The name of the sheet. If null, a default sheet name is used.
+ * @param writeHeader Whether to include a header row with column names. Defaults to true.
+ * @return The created [Sheet] instance containing the DataFrame data.
+ */
 public fun <T> DataFrame<T>.writeExcel(
     wb: Workbook,
     columnsSelector: ColumnsSelector<T, *> = { all() },

--- a/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
+++ b/dataframe-excel/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/xlsx.kt
@@ -281,8 +281,8 @@ public fun DataFrame.Companion.readExcel(
  */
 @JvmInline
 public value class StringColumns
-@Interpretable("StringColumns")
-constructor(public val range: String)
+    @Interpretable("StringColumns")
+    constructor(public val range: String)
 
 public fun StringColumns.toFormattingOptions(formatter: DataFormatter = DataFormatter()): FormattingOptions =
     FormattingOptions(range, formatter)
@@ -504,6 +504,7 @@ public fun <T> DataFrame<T>.writeExcel(
         } else {
             when (workBookType) {
                 WorkBookType.XLS -> HSSFWorkbook()
+
                 // Use streaming mode for a new XLSX file
                 WorkBookType.XLSX -> SXSSFWorkbook()
             }


### PR DESCRIPTION
Fixes #1016.
Tested with profiler on big datasets - works great :).
Looks like `SXSSFWorkbook` restrictions don't affect on DF writing into Excel (except for the case for writing into existing file - in this case it can't just be used and `XSSFWorkbook` is used).