### PR TITLE
Add util classes for custom java type renderers

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DebugUtil.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/DebugUtil.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.kotlinx.dataframe.impl
+
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.api.ValueCount
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.jetbrains.kotlinx.dataframe.api.map
+
+// Needed to attach an expanded node with lazily evaluated expressions to DataFrame debug view
+@Suppress("unused")
+internal class Info(val df: AnyFrame)
+
+internal class Counts(val value: Any?, val count: Int) {
+    override fun toString(): String = "$value -> $count"
+}
+
+internal fun DataFrame<ValueCount>.render(): List<Counts> = map { Counts(it[0], it.count) }


### PR DESCRIPTION
With addition of these internal classes / functions we can have something like this:
![image](https://github.com/user-attachments/assets/8ad85030-0939-4ee5-ae43-c4489cff037f)

I'd like to test the idea more, so i need to have it in the core. But this doesn't affect users of the library in any way
