### PR TITLE
Sum statistics and aggregator improvements

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1781,8 +1781,10 @@ public final class org/jetbrains/kotlinx/dataframe/api/DataColumnTypeKt {
 	public static final fun isComparable (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun isFrameColumn (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun isList (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
+	public static final fun isMixedNumber (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun isNumber (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun isPrimitiveNumber (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
+	public static final fun isPrimitiveOrMixedNumber (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun isSubtypeOf (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/reflect/KType;)Z
 	public static final fun isValueColumn (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
 	public static final fun valuesAreComparable (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Z
@@ -5116,6 +5118,9 @@ public final class org/jetbrains/kotlinx/dataframe/impl/ExceptionUtilsKt {
 
 public final class org/jetbrains/kotlinx/dataframe/impl/NumberTypeUtilsKt {
 	public static final fun getPrimitiveNumberTypes ()Ljava/util/Set;
+	public static final fun isMixedNumber (Lkotlin/reflect/KType;)Z
+	public static final fun isPrimitiveNumber (Lkotlin/reflect/KType;)Z
+	public static final fun isPrimitiveOrMixedNumber (Lkotlin/reflect/KType;)Z
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/TypeUtilsKt {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3816,6 +3816,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/StdKt {
 
 public final class org/jetbrains/kotlinx/dataframe/api/SumKt {
 	public static final fun rowSum (Lorg/jetbrains/kotlinx/dataframe/DataRow;)Ljava/lang/Number;
+	public static final fun rowSumOf (Lorg/jetbrains/kotlinx/dataframe/DataRow;Lkotlin/reflect/KType;)Ljava/lang/Number;
 	public static final fun sum (Lorg/jetbrains/kotlinx/dataframe/DataFrame;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
 	public static final fun sum (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Ljava/lang/Number;
 	public static final fun sum (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
@@ -3839,6 +3840,10 @@ public final class org/jetbrains/kotlinx/dataframe/api/SumKt {
 	public static synthetic fun sum$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun sum$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
 	public static synthetic fun sum$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun sumByte (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)I
+	public static final fun sumByte (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)I
+	public static final fun sumByte (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lkotlin/reflect/KProperty;)I
+	public static final fun sumByte (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)I
 	public static final fun sumFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
 	public static final fun sumFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
 	public static final fun sumFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
@@ -3863,8 +3868,15 @@ public final class org/jetbrains/kotlinx/dataframe/api/SumKt {
 	public static synthetic fun sumFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun sumFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun sumFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun sumT (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Ljava/lang/Number;
-	public static final fun sumTNullable (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Ljava/lang/Number;
+	public static final fun sumNumber (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Ljava/lang/Number;
+	public static final fun sumOfByte (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/jvm/functions/Function1;)I
+	public static final fun sumOfByte (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)I
+	public static final fun sumOfShort (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/jvm/functions/Function1;)I
+	public static final fun sumOfShort (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)I
+	public static final fun sumShort (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)I
+	public static final fun sumShort (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)I
+	public static final fun sumShort (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lkotlin/reflect/KProperty;)I
+	public static final fun sumShort (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)I
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/TailKt {
@@ -6153,13 +6165,7 @@ public final class org/jetbrains/kotlinx/dataframe/math/StdKt {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/math/SumKt {
-	public static final fun sum (Ljava/lang/Iterable;)Ljava/math/BigDecimal;
-	public static final fun sum (Ljava/lang/Iterable;)Ljava/math/BigInteger;
-	public static final fun sum (Ljava/lang/Iterable;Lkotlin/reflect/KType;)Ljava/lang/Number;
-	public static final fun sum (Lkotlin/sequences/Sequence;)Ljava/math/BigDecimal;
-	public static final fun sum (Lkotlin/sequences/Sequence;)Ljava/math/BigInteger;
-	public static final fun sumNullableT (Ljava/lang/Iterable;Lkotlin/reflect/KType;)Ljava/lang/Number;
-	public static final fun sumOf (Ljava/lang/Iterable;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Ljava/lang/Number;
+	public static final fun sumNullableT (Lkotlin/sequences/Sequence;Lkotlin/reflect/KType;)Ljava/lang/Number;
 }
 
 public abstract class org/jetbrains/kotlinx/dataframe/schema/ColumnSchema {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataColumnType.kt
@@ -7,7 +7,9 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
-import org.jetbrains.kotlinx.dataframe.impl.primitiveNumberTypes
+import org.jetbrains.kotlinx.dataframe.impl.isMixedNumber
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveOrMixedNumber
 import org.jetbrains.kotlinx.dataframe.type
 import org.jetbrains.kotlinx.dataframe.typeClass
 import org.jetbrains.kotlinx.dataframe.util.IS_COMPARABLE
@@ -48,11 +50,23 @@ public inline fun <reified T> AnyCol.isType(): Boolean = type() == typeOf<T>()
 /** Returns `true` when this column's type is a subtype of `Number?` */
 public fun AnyCol.isNumber(): Boolean = isSubtypeOf<Number?>()
 
+/** Returns `true` only when this column's type is exactly `Number` or `Number?`. */
+public fun AnyCol.isMixedNumber(): Boolean = type().isMixedNumber()
+
 /**
  * Returns `true` when this column has the (nullable) type of either:
  * [Byte], [Short], [Int], [Long], [Float], or [Double].
  */
-public fun AnyCol.isPrimitiveNumber(): Boolean = type().withNullability(false) in primitiveNumberTypes
+public fun AnyCol.isPrimitiveNumber(): Boolean = type().isPrimitiveNumber()
+
+/**
+ * Returns `true` when this column has the (nullable) type of either:
+ * [Byte], [Short], [Int], [Long], [Float], [Double], or [Number].
+ *
+ * Careful: Will return `true` if the column contains multiple number types that
+ * might NOT be primitive.
+ */
+public fun AnyCol.isPrimitiveOrMixedNumber(): Boolean = type().isPrimitiveOrMixedNumber()
 
 public fun AnyCol.isList(): Boolean = typeClass == List::class
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
@@ -18,11 +18,10 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateAll
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateFor
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOf
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOfRow
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.primitiveNumberColumns
+import org.jetbrains.kotlinx.dataframe.impl.aggregation.primitiveOrMixedNumberColumns
 import org.jetbrains.kotlinx.dataframe.impl.columns.toNumberColumns
-import org.jetbrains.kotlinx.dataframe.impl.primitiveNumberTypes
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveOrMixedNumber
 import kotlin.reflect.KProperty
-import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
 
 /* TODO KDocs:
@@ -47,10 +46,10 @@ public inline fun <T, reified R : Number> DataColumn<T>.meanOf(
 // region DataRow
 
 public fun AnyRow.rowMean(skipNA: Boolean = skipNA_default): Double =
-    Aggregators.mean(skipNA).aggregateOfRow(this, primitiveNumberColumns())
+    Aggregators.mean(skipNA).aggregateOfRow(this, primitiveOrMixedNumberColumns())
 
 public inline fun <reified T : Number?> AnyRow.rowMeanOf(skipNA: Boolean = skipNA_default): Double {
-    require(typeOf<T>().withNullability(false) in primitiveNumberTypes) {
+    require(typeOf<T>().isPrimitiveOrMixedNumber()) {
         "Type ${T::class.simpleName} is not a primitive number type. Mean only supports primitive number types."
     }
     return Aggregators.mean(skipNA).aggregateOfRow(this) { colsOf<T>() }
@@ -61,7 +60,7 @@ public inline fun <reified T : Number?> AnyRow.rowMeanOf(skipNA: Boolean = skipN
 // region DataFrame
 
 public fun <T> DataFrame<T>.mean(skipNA: Boolean = skipNA_default): DataRow<T> =
-    meanFor(skipNA, primitiveNumberColumns())
+    meanFor(skipNA, primitiveOrMixedNumberColumns())
 
 public fun <T, C : Number> DataFrame<T>.meanFor(
     skipNA: Boolean = skipNA_default,
@@ -112,7 +111,7 @@ public inline fun <T, reified D : Number> DataFrame<T>.meanOf(
 @Refine
 @Interpretable("GroupByMean1")
 public fun <T> Grouped<T>.mean(skipNA: Boolean = skipNA_default): DataFrame<T> =
-    meanFor(skipNA, primitiveNumberColumns())
+    meanFor(skipNA, primitiveOrMixedNumberColumns())
 
 @Refine
 @Interpretable("GroupByMean0")
@@ -177,7 +176,7 @@ public inline fun <T, reified R : Number> Grouped<T>.meanOf(
 // region Pivot
 
 public fun <T> Pivot<T>.mean(skipNA: Boolean = skipNA_default, separate: Boolean = false): DataRow<T> =
-    meanFor(skipNA, separate, primitiveNumberColumns())
+    meanFor(skipNA, separate, primitiveOrMixedNumberColumns())
 
 public fun <T, C : Number> Pivot<T>.meanFor(
     skipNA: Boolean = skipNA_default,
@@ -220,7 +219,7 @@ public inline fun <T, reified R : Number> Pivot<T>.meanOf(
 // region PivotGroupBy
 
 public fun <T> PivotGroupBy<T>.mean(separate: Boolean = false, skipNA: Boolean = skipNA_default): DataFrame<T> =
-    meanFor(skipNA, separate, primitiveNumberColumns())
+    meanFor(skipNA, separate, primitiveOrMixedNumberColumns())
 
 public fun <T, C : Number> PivotGroupBy<T>.meanFor(
     skipNA: Boolean = skipNA_default,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
@@ -25,10 +25,9 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
 
-/*
- * TODO KDocs:
+/* TODO KDocs:
  * Calculating the mean is supported for all primitive number types.
- * Nulls are filtered from columns.
+ * Nulls are filtered out.
  * The return type is always Double, Double.NaN for empty input, never null.
  * (May introduce loss of precision for Longs).
  * For mixed primitive number types, [TwoStepNumbersAggregator] unifies the numbers before calculating the mean.
@@ -48,16 +47,13 @@ public inline fun <T, reified R : Number> DataColumn<T>.meanOf(
 // region DataRow
 
 public fun AnyRow.rowMean(skipNA: Boolean = skipNA_default): Double =
-    Aggregators.mean(skipNA).aggregateOfRow(this) {
-        colsOf<Number?> { it.isPrimitiveNumber() }
-    }
+    Aggregators.mean(skipNA).aggregateOfRow(this, primitiveNumberColumns())
 
 public inline fun <reified T : Number?> AnyRow.rowMeanOf(skipNA: Boolean = skipNA_default): Double {
     require(typeOf<T>().withNullability(false) in primitiveNumberTypes) {
         "Type ${T::class.simpleName} is not a primitive number type. Mean only supports primitive number types."
     }
-    return Aggregators.mean(skipNA)
-        .aggregateOfRow(this) { colsOf<T>() }
+    return Aggregators.mean(skipNA).aggregateOfRow(this) { colsOf<T>() }
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.toColumnsSetOf
-import org.jetbrains.kotlinx.dataframe.columns.values
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregator
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.cast
@@ -26,18 +25,32 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.numberColumns
 import org.jetbrains.kotlinx.dataframe.impl.columns.toNumberColumns
 import org.jetbrains.kotlinx.dataframe.impl.primitiveNumberTypes
 import org.jetbrains.kotlinx.dataframe.impl.zero
-import org.jetbrains.kotlinx.dataframe.math.sum
 import org.jetbrains.kotlinx.dataframe.math.sumOf
 import kotlin.reflect.KProperty
 import kotlin.reflect.typeOf
 
 // region DataColumn
 
-@JvmName("sumT")
-public fun <T : Number> DataColumn<T>.sum(): T = values.sum(type())
+@JvmName("sumInt")
+public fun DataColumn<Int?>.sum(): Int = Aggregators.sum.aggregate(this) as Int
 
-@JvmName("sumTNullable")
-public fun <T : Number> DataColumn<T?>.sum(): T = values.sum(type())
+@JvmName("sumShort")
+public fun DataColumn<Short?>.sum(): Int = Aggregators.sum.aggregate(this) as Int
+
+@JvmName("sumByte")
+public fun DataColumn<Byte?>.sum(): Int = Aggregators.sum.aggregate(this) as Int
+
+@JvmName("sumLong")
+public fun DataColumn<Long?>.sum(): Long = Aggregators.sum.aggregate(this) as Long
+
+@JvmName("sumFloat")
+public fun DataColumn<Float?>.sum(): Float = Aggregators.sum.aggregate(this) as Float
+
+@JvmName("sumDouble")
+public fun DataColumn<Double?>.sum(): Double = Aggregators.sum.aggregate(this) as Double
+
+@JvmName("sumNumber")
+public fun DataColumn<Number?>.sum(): Number = Aggregators.sum.aggregate(this)
 
 public inline fun <T, reified R : Number> DataColumn<T>.sumOf(crossinline expression: (T) -> R): R? =
     (Aggregators.sum as Aggregator<*, *>).cast<R>().of(this, expression)
@@ -49,7 +62,7 @@ public inline fun <T, reified R : Number> DataColumn<T>.sumOf(crossinline expres
 public fun AnyRow.rowSum(): Number =
     Aggregators.sum.aggregateOfRow(this) {
         colsOf<Number?> { it.isPrimitiveNumber() }
-    } ?: 0.0
+    }
 
 public inline fun <reified T : Number> AnyRow.rowSumOf(): Number /*todo*/ {
     require(typeOf<T>() in primitiveNumberTypes) {
@@ -57,7 +70,6 @@ public inline fun <reified T : Number> AnyRow.rowSumOf(): Number /*todo*/ {
     }
     return Aggregators.sum
         .aggregateOfRow(this) { colsOf<T>() }
-        ?: 0.0
 }
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -21,14 +21,13 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateAll
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateFor
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOf
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOfRow
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.primitiveNumberColumns
+import org.jetbrains.kotlinx.dataframe.impl.aggregation.primitiveOrMixedNumberColumns
 import org.jetbrains.kotlinx.dataframe.impl.columns.toNumberColumns
-import org.jetbrains.kotlinx.dataframe.impl.primitiveNumberTypes
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveOrMixedNumber
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
-import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
 
 /* TODO KDocs
@@ -70,7 +69,7 @@ public inline fun <C, reified V : Number> DataColumn<C>.sumOf(crossinline expres
 
 // region DataRow
 
-public fun AnyRow.rowSum(): Number = Aggregators.sum.aggregateOfRow(this, primitiveNumberColumns())
+public fun AnyRow.rowSum(): Number = Aggregators.sum.aggregateOfRow(this, primitiveOrMixedNumberColumns())
 
 @JvmName("rowSumOfShort")
 public inline fun <reified T : Short?> AnyRow.rowSumOf(_kClass: KClass<Short> = Short::class): Int =
@@ -98,7 +97,7 @@ public inline fun <reified T : Double?> AnyRow.rowSumOf(_kClass: KClass<Double> 
 
 // unfortunately, we cannot make a `reified T : Number?` due to clashes
 public fun AnyRow.rowSumOf(type: KType): Number {
-    require(type.withNullability(false) in primitiveNumberTypes) {
+    require(type.isPrimitiveOrMixedNumber()) {
         "Type $type is not a primitive number type. Mean only supports primitive number types."
     }
     return Aggregators.sum.aggregateOfRow(this) { colsOf(type) }
@@ -107,7 +106,7 @@ public fun AnyRow.rowSumOf(type: KType): Number {
 
 // region DataFrame
 
-public fun <T> DataFrame<T>.sum(): DataRow<T> = sumFor(primitiveNumberColumns())
+public fun <T> DataFrame<T>.sum(): DataRow<T> = sumFor(primitiveOrMixedNumberColumns())
 
 public fun <T, C : Number> DataFrame<T>.sumFor(columns: ColumnsForAggregateSelector<T, C?>): DataRow<T> =
     Aggregators.sum.aggregateFor(this, columns)
@@ -185,7 +184,7 @@ public inline fun <T, reified C : Number> DataFrame<T>.sumOf(crossinline express
 // region GroupBy
 @Refine
 @Interpretable("GroupBySum1")
-public fun <T> Grouped<T>.sum(): DataFrame<T> = sumFor(primitiveNumberColumns())
+public fun <T> Grouped<T>.sum(): DataFrame<T> = sumFor(primitiveOrMixedNumberColumns())
 
 @Refine
 @Interpretable("GroupBySum0")
@@ -229,7 +228,7 @@ public inline fun <T, reified R : Number> Grouped<T>.sumOf(
 
 // region Pivot
 
-public fun <T> Pivot<T>.sum(separate: Boolean = false): DataRow<T> = sumFor(separate, primitiveNumberColumns())
+public fun <T> Pivot<T>.sum(separate: Boolean = false): DataRow<T> = sumFor(separate, primitiveOrMixedNumberColumns())
 
 public fun <T, R : Number> Pivot<T>.sumFor(
     separate: Boolean = false,
@@ -266,7 +265,8 @@ public inline fun <T, reified R : Number> Pivot<T>.sumOf(crossinline expression:
 
 // region PivotGroupBy
 
-public fun <T> PivotGroupBy<T>.sum(separate: Boolean = false): DataFrame<T> = sumFor(separate, primitiveNumberColumns())
+public fun <T> PivotGroupBy<T>.sum(separate: Boolean = false): DataFrame<T> =
+    sumFor(separate, primitiveOrMixedNumberColumns())
 
 public fun <T, R : Number> PivotGroupBy<T>.sumFor(
     separate: Boolean = false,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTypeInference::class)
+
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyRow
@@ -13,19 +15,16 @@ import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.toColumnsSetOf
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregator
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.cast
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateAll
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateFor
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOf
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOfRow
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.of
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.numberColumns
 import org.jetbrains.kotlinx.dataframe.impl.columns.toNumberColumns
 import org.jetbrains.kotlinx.dataframe.impl.primitiveNumberTypes
 import org.jetbrains.kotlinx.dataframe.impl.zero
-import org.jetbrains.kotlinx.dataframe.math.sumOf
+import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KProperty
 import kotlin.reflect.typeOf
 
@@ -52,8 +51,37 @@ public fun DataColumn<Double?>.sum(): Double = Aggregators.sum.aggregate(this) a
 @JvmName("sumNumber")
 public fun DataColumn<Number?>.sum(): Number = Aggregators.sum.aggregate(this)
 
-public inline fun <T, reified R : Number> DataColumn<T>.sumOf(noinline expression: (T) -> R): R? =
-    (Aggregators.sum as Aggregator<*, *>).cast<R>().aggregateOf(this, expression)
+@JvmName("sumOfInt")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Int?): Int = Aggregators.sum.aggregateOf(this, expression) as Int
+
+@JvmName("sumOfShort")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Short?): Int =
+    Aggregators.sum.aggregateOf(this, expression) as Int
+
+@JvmName("sumOfByte")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Byte?): Int = Aggregators.sum.aggregateOf(this, expression) as Int
+
+@JvmName("sumOfLong")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Long?): Long =
+    Aggregators.sum.aggregateOf(this, expression) as Long
+
+@JvmName("sumOfFloat")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Float?): Float =
+    Aggregators.sum.aggregateOf(this, expression) as Float
+
+@JvmName("sumOfDouble")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Double?): Double =
+    Aggregators.sum.aggregateOf(this, expression) as Double
+
+@JvmName("sumOfNumber")
+@OverloadResolutionByLambdaReturnType
+public fun <T> DataColumn<T>.sumOf(expression: (T) -> Number?): Number = Aggregators.sum.aggregateOf(this, expression)
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/TypeUtils.kt
@@ -477,7 +477,7 @@ internal fun guessValueType(
             it.isSubclassOf(Number::class) && it != nothingClass
         }
         if (usedNumberClasses.isNotEmpty()) {
-            val unifiedNumberClass = usedNumberClasses.unifiedNumberClass() as KClass<Number>
+            val unifiedNumberClass = usedNumberClasses.unifiedNumberClassOrNull() as KClass<Number>
             classes -= usedNumberClasses
             classes += unifiedNumberClass
         }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
@@ -2,14 +2,17 @@ package org.jetbrains.kotlinx.dataframe.impl.aggregation
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.aggregation.Aggregatable
 import org.jetbrains.kotlinx.dataframe.aggregation.NamedValue
+import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.isNumber
 import org.jetbrains.kotlinx.dataframe.api.isPrimitiveNumber
 import org.jetbrains.kotlinx.dataframe.api.valuesAreComparable
 import org.jetbrains.kotlinx.dataframe.columns.TypeSuggestion
 import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 
 internal inline fun <T> Aggregatable<T>.remainingColumns(
     crossinline predicate: (AnyCol) -> Boolean,
@@ -26,6 +29,9 @@ internal fun <T> Aggregatable<T>.numberColumns(): ColumnsSelector<T, Number?> =
 @Suppress("UNCHECKED_CAST")
 internal fun <T> Aggregatable<T>.primitiveNumberColumns(): ColumnsSelector<T, Number?> =
     remainingColumns { it.isPrimitiveNumber() } as ColumnsSelector<T, Number?>
+
+internal fun <T> DataRow<T>.primitiveNumberColumns(): ColumnsSelector<T, Number?> =
+    { cols { it.isPrimitiveNumber() }.cast() }
 
 internal fun NamedValue.toColumnWithPath() =
     path to createColumnGuessingType(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/getColumns.kt
@@ -8,11 +8,10 @@ import org.jetbrains.kotlinx.dataframe.aggregation.NamedValue
 import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.isNumber
-import org.jetbrains.kotlinx.dataframe.api.isPrimitiveNumber
+import org.jetbrains.kotlinx.dataframe.api.isPrimitiveOrMixedNumber
 import org.jetbrains.kotlinx.dataframe.api.valuesAreComparable
 import org.jetbrains.kotlinx.dataframe.columns.TypeSuggestion
 import org.jetbrains.kotlinx.dataframe.impl.columns.createColumnGuessingType
-import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 
 internal inline fun <T> Aggregatable<T>.remainingColumns(
     crossinline predicate: (AnyCol) -> Boolean,
@@ -27,11 +26,11 @@ internal fun <T> Aggregatable<T>.numberColumns(): ColumnsSelector<T, Number?> =
     remainingColumns { it.isNumber() } as ColumnsSelector<T, Number?>
 
 @Suppress("UNCHECKED_CAST")
-internal fun <T> Aggregatable<T>.primitiveNumberColumns(): ColumnsSelector<T, Number?> =
-    remainingColumns { it.isPrimitiveNumber() } as ColumnsSelector<T, Number?>
+internal fun <T> Aggregatable<T>.primitiveOrMixedNumberColumns(): ColumnsSelector<T, Number?> =
+    remainingColumns { it.isPrimitiveOrMixedNumber() } as ColumnsSelector<T, Number?>
 
-internal fun <T> DataRow<T>.primitiveNumberColumns(): ColumnsSelector<T, Number?> =
-    { cols { it.isPrimitiveNumber() }.cast() }
+internal fun <T> DataRow<T>.primitiveOrMixedNumberColumns(): ColumnsSelector<T, Number?> =
+    { cols { it.isPrimitiveOrMixedNumber() }.cast() }
 
 internal fun NamedValue.toColumnWithPath() =
     path to createColumnGuessingType(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/forEveryColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/forEveryColumn.kt
@@ -41,7 +41,7 @@ internal fun <T, C, R> Aggregator<*, R>.aggregateFor(
     }
 
 internal fun <T, C, R> AggregateInternalDsl<T>.aggregateFor(
-    columns: ColumnsForAggregateSelector<T, C>,
+    columns: ColumnsForAggregateSelector<T, C?>,
     aggregator: Aggregator<C, R>,
 ) {
     val cols = df.getAggregateColumns(columns)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/row.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/row.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.impl.aggregation.modes
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.api.getColumns
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregator
 
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregator
  * @param columns selector of which columns inside the [row] to aggregate
  */
 @PublishedApi
-internal fun <V, R> Aggregator<V, R>.aggregateOfRow(row: AnyRow, columns: ColumnsSelector<*, V?>): R {
+internal fun <T, V, R> Aggregator<V, R>.aggregateOfRow(row: DataRow<T>, columns: ColumnsSelector<T, V?>): R {
     val filteredColumns = row.df().getColumns(columns)
     return aggregateCalculatingType(
         values = filteredColumns.mapNotNull { row[it] },

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/withinAllColumns.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/withinAllColumns.kt
@@ -15,18 +15,18 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.internal
 import org.jetbrains.kotlinx.dataframe.impl.emptyPath
 
 @PublishedApi
-internal fun <T, C, R> Aggregator<*, R>.aggregateAll(data: DataFrame<T>, columns: ColumnsSelector<T, C>): R =
+internal fun <T, C, R> Aggregator<*, R>.aggregateAll(data: DataFrame<T>, columns: ColumnsSelector<T, C?>): R =
     data.aggregateAll(cast2(), columns)
 
 internal fun <T, R, C> Aggregator<*, R>.aggregateAll(
     data: Grouped<T>,
     name: String?,
-    columns: ColumnsSelector<T, C>,
+    columns: ColumnsSelector<T, C?>,
 ): DataFrame<T> = data.aggregateAll(cast(), columns, name)
 
 internal fun <T, R, C> Aggregator<*, R>.aggregateAll(
     data: PivotGroupBy<T>,
-    columns: ColumnsSelector<T, C>,
+    columns: ColumnsSelector<T, C?>,
 ): DataFrame<T> = data.aggregateAll(cast(), columns)
 
 internal fun <T, C, R> DataFrame<T>.aggregateAll(aggregator: Aggregator<C, R>, columns: ColumnsSelector<T, C?>): R =
@@ -34,7 +34,7 @@ internal fun <T, C, R> DataFrame<T>.aggregateAll(aggregator: Aggregator<C, R>, c
 
 internal fun <T, C, R> Grouped<T>.aggregateAll(
     aggregator: Aggregator<C, R>,
-    columns: ColumnsSelector<T, C>,
+    columns: ColumnsSelector<T, C?>,
     name: String?,
 ): DataFrame<T> =
     aggregateInternal {
@@ -48,7 +48,7 @@ internal fun <T, C, R> Grouped<T>.aggregateAll(
 
 internal fun <T, C, R> PivotGroupBy<T>.aggregateAll(
     aggregator: Aggregator<C, R>,
-    columns: ColumnsSelector<T, C>,
+    columns: ColumnsSelector<T, C?>,
 ): DataFrame<T> =
     aggregate {
         val cols = get(columns)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
@@ -8,40 +8,6 @@ import kotlin.reflect.full.withNullability
 import kotlin.reflect.typeOf
 import kotlin.sequences.filterNotNull
 
-@PublishedApi
-internal fun <T, R : Number> Iterable<T>.sumOf(type: KType, selector: (T) -> R?): Number =
-    asSequence().sumOf(type, selector)
-
-@Suppress("UNCHECKED_CAST")
-@PublishedApi
-internal fun <T, R : Number> Sequence<T>.sumOf(type: KType, selector: (T) -> R?): Number {
-    if (type.isMarkedNullable) {
-        return filterNotNull().sumOf(type.withNullability(false), selector)
-    }
-    return when (type.withNullability(false)) {
-        typeOf<Double>() -> sumOf(selector as (T) -> Double)
-
-        typeOf<Float>() -> map(selector as (T) -> Float).sum()
-
-        typeOf<Int>() -> sumOf(selector as (T) -> Int)
-
-        // Note: returns Int
-        typeOf<Short>() -> map(selector as (T) -> Short).sum()
-
-        // Note: returns Int
-        typeOf<Byte>() -> map(selector as (T) -> Byte).sum()
-
-        typeOf<Long>() -> sumOf(selector as (T) -> Long)
-
-        nothingType -> 0.0
-
-        typeOf<Number>() ->
-            error("Encountered non-specific Number type in sumOf function. This should not occur.")
-
-        else -> throw IllegalArgumentException("sumOf is not supported for $type")
-    }
-}
-
 internal fun Iterable<Number?>.sum(type: KType): Number = asSequence().sum(type)
 
 @Suppress("UNCHECKED_CAST")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
@@ -50,9 +50,11 @@ internal val sumTypeConversion: CalculateReturnTypeOrNull = { type, _ ->
         typeOf<Short>(), typeOf<Byte>() -> typeOf<Int>()
 
         // type remains the same
-        typeOf<Int>(), typeOf<Long>(), typeOf<Double>(), typeOf<Float>() -> type
+        typeOf<Int>(), typeOf<Long>(), typeOf<Double>(), typeOf<Float>(), typeOf<Number>() -> type
 
-        // defaults to Double
-        else -> typeOf<Double>()
+        nothingType -> typeOf<Double>()
+
+        else ->
+            error("Unable to compute the sum for ${renderType(type)}, Only primitive numbers are supported.")
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
@@ -45,18 +45,14 @@ internal fun Sequence<Number?>.sum(type: KType): Number {
 
 /** T: Number? -> T */
 internal val sumTypeConversion: CalculateReturnTypeOrNull = { type, _ ->
-    when (type.withNullability(false)) {
-        typeOf<Int>(),
-        typeOf<Short>(),
-        typeOf<Byte>(),
-        -> typeOf<Int>()
+    when (val type = type.withNullability(false)) {
+        // type changes to Int
+        typeOf<Short>(), typeOf<Byte>() -> typeOf<Int>()
 
-        typeOf<Long>() -> typeOf<Long>()
+        // type remains the same
+        typeOf<Int>(), typeOf<Long>(), typeOf<Double>(), typeOf<Float>() -> type
 
-        typeOf<Double>() -> typeOf<Double>()
-
-        typeOf<Float>() -> typeOf<Float>()
-
+        // defaults to Double
         else -> typeOf<Double>()
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
@@ -1,139 +1,94 @@
 package org.jetbrains.kotlinx.dataframe.math
 
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.CalculateReturnTypeOrNull
-import java.math.BigDecimal
-import java.math.BigInteger
+import org.jetbrains.kotlinx.dataframe.impl.nothingType
+import org.jetbrains.kotlinx.dataframe.impl.renderType
 import kotlin.reflect.KType
 import kotlin.reflect.full.withNullability
+import kotlin.reflect.typeOf
+import kotlin.sequences.filterNotNull
 
 @PublishedApi
-internal fun <T, R : Number> Iterable<T>.sumOf(type: KType, selector: (T) -> R?): R {
+internal fun <T, R : Number> Iterable<T>.sumOf(type: KType, selector: (T) -> R?): Number =
+    asSequence().sumOf(type, selector)
+
+@Suppress("UNCHECKED_CAST")
+@PublishedApi
+internal fun <T, R : Number> Sequence<T>.sumOf(type: KType, selector: (T) -> R?): Number {
     if (type.isMarkedNullable) {
-        val seq = asSequence().mapNotNull(selector).asIterable()
-        return seq.sum(type)
+        return filterNotNull().sumOf(type.withNullability(false), selector)
     }
-    return when (type.classifier) {
-        Double::class -> sumOf(selector as ((T) -> Double)) as R
+    return when (type.withNullability(false)) {
+        typeOf<Double>() -> sumOf(selector as (T) -> Double)
 
-        // careful, conversion to Double to Float occurs! TODO, Issue #558
-        Float::class -> sumOf { (selector as ((T) -> Float))(it).toDouble() }.toFloat() as R
+        typeOf<Float>() -> map(selector as (T) -> Float).sum()
 
-        Int::class -> sumOf(selector as ((T) -> Int)) as R
+        typeOf<Int>() -> sumOf(selector as (T) -> Int)
 
-        // careful, conversion to Int occurs! TODO, Issue #558
-        Short::class -> sumOf { (selector as ((T) -> Short))(it).toInt() }.toShort() as R
+        // Note: returns Int
+        typeOf<Short>() -> map(selector as (T) -> Short).sum()
 
-        // careful, conversion to Int occurs! TODO, Issue #558
-        Byte::class -> sumOf { (selector as ((T) -> Byte))(it).toInt() }.toByte() as R
+        // Note: returns Int
+        typeOf<Byte>() -> map(selector as (T) -> Byte).sum()
 
-        Long::class -> sumOf(selector as ((T) -> Long)) as R
+        typeOf<Long>() -> sumOf(selector as (T) -> Long)
 
-        BigDecimal::class -> sumOf(selector as ((T) -> BigDecimal)) as R
+        nothingType -> 0.0
 
-        BigInteger::class -> sumOf(selector as ((T) -> BigInteger)) as R
-
-        Number::class -> sumOf { (selector as ((T) -> Number))(it).toDouble() } as R
-
-        Nothing::class -> 0.0 as R
+        typeOf<Number>() ->
+            error("Encountered non-specific Number type in sumOf function. This should not occur.")
 
         else -> throw IllegalArgumentException("sumOf is not supported for $type")
     }
 }
 
-@PublishedApi
-internal fun <T : Number> Iterable<T>.sum(type: KType): T =
-    when (type.classifier) {
-        Double::class -> (this as Iterable<Double>).sum() as T
+internal fun Iterable<Number?>.sum(type: KType): Number = asSequence().sum(type)
 
-        Float::class -> (this as Iterable<Float>).sum() as T
-
-        Int::class -> (this as Iterable<Int>).sum() as T
-
-        // TODO result should be Int, but same type as input is returned, Issue #558
-        Short::class -> (this as Iterable<Short>).sum().toShort() as T
-
-        // TODO result should be Int, but same type as input is returned, Issue #558
-        Byte::class -> (this as Iterable<Byte>).sum().toByte() as T
-
-        Long::class -> (this as Iterable<Long>).sum() as T
-
-        BigDecimal::class -> (this as Iterable<BigDecimal>).sum() as T
-
-        BigInteger::class -> (this as Iterable<BigInteger>).sum() as T
-
-        Number::class -> (this as Iterable<Number>).map { it.toDouble() }.sum() as T
-
-        Nothing::class -> 0.0 as T
-
-        else -> throw IllegalArgumentException("sum is not supported for $type")
-    }
-
+@Suppress("UNCHECKED_CAST")
 @JvmName("sumNullableT")
 @PublishedApi
-internal fun <T : Number> Iterable<T?>.sum(type: KType): T =
-    when (type.classifier) {
-        Double::class -> (this as Iterable<Double?>).asSequence().filterNotNull().sum() as T
-
-        Float::class -> (this as Iterable<Float?>).asSequence().filterNotNull().sum() as T
-
-        Int::class -> (this as Iterable<Int?>).asSequence().filterNotNull().sum() as T
-
-        // TODO result should be Int, but same type as input is returned, Issue #558
-        Short::class -> (this as Iterable<Short?>).asSequence().filterNotNull().sum().toShort() as T
-
-        // TODO result should be Int, but same type as input is returned, Issue #558
-        Byte::class -> (this as Iterable<Short?>).asSequence().filterNotNull().sum().toByte() as T
-
-        Long::class -> (this as Iterable<Long?>).asSequence().filterNotNull().sum() as T
-
-        BigDecimal::class -> (this as Iterable<BigDecimal?>).asSequence().filterNotNull().sum() as T
-
-        BigInteger::class -> (this as Iterable<BigInteger?>).asSequence().filterNotNull().sum() as T
-
-        Number::class -> (this as Iterable<Number?>).asSequence().filterNotNull().map { it.toDouble() }.sum() as T
-
-        Nothing::class -> 0.0 as T
-
-        else -> throw IllegalArgumentException("sum is not supported for $type")
+internal fun Sequence<Number?>.sum(type: KType): Number {
+    if (type.isMarkedNullable) {
+        return filterNotNull().sum(type.withNullability(false))
     }
+    return when (type.withNullability(false)) {
+        typeOf<Double>() -> (this as Sequence<Double>).sum()
+
+        typeOf<Float>() -> (this as Sequence<Float>).sum()
+
+        typeOf<Int>() -> (this as Sequence<Int>).sum()
+
+        // Note: returns Int
+        typeOf<Short>() -> (this as Sequence<Short>).sum()
+
+        // Note: returns Int
+        typeOf<Byte>() -> (this as Sequence<Byte>).sum()
+
+        typeOf<Long>() -> (this as Sequence<Long>).sum()
+
+        typeOf<Number>() ->
+            error("Encountered non-specific Number type in sum function. This should not occur.")
+
+        nothingType -> 0.0
+
+        else -> throw IllegalArgumentException(
+            "Unable to compute the sum for ${renderType(type)}, Only primitive numbers are supported.",
+        )
+    }
+}
 
 /** T: Number? -> T */
 internal val sumTypeConversion: CalculateReturnTypeOrNull = { type, _ ->
-    type.withNullability(false)
-}
+    when (type.withNullability(false)) {
+        typeOf<Int>(),
+        typeOf<Short>(),
+        typeOf<Byte>(),
+        -> typeOf<Int>()
 
-@PublishedApi
-internal fun Iterable<BigDecimal>.sum(): BigDecimal {
-    var sum: BigDecimal = BigDecimal.ZERO
-    for (element in this) {
-        sum += element
-    }
-    return sum
-}
+        typeOf<Double>() -> typeOf<Double>()
 
-@PublishedApi
-internal fun Sequence<BigDecimal>.sum(): BigDecimal {
-    var sum: BigDecimal = BigDecimal.ZERO
-    for (element in this) {
-        sum += element
-    }
-    return sum
-}
+        typeOf<Float>() -> typeOf<Float>()
 
-@PublishedApi
-internal fun Iterable<BigInteger>.sum(): BigInteger {
-    var sum: BigInteger = BigInteger.ZERO
-    for (element in this) {
-        sum += element
+        else -> typeOf<Double>()
     }
-    return sum
-}
-
-@PublishedApi
-internal fun Sequence<BigInteger>.sum(): BigInteger {
-    var sum: BigInteger = BigInteger.ZERO
-    for (element in this) {
-        sum += element
-    }
-    return sum
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/sum.kt
@@ -85,6 +85,8 @@ internal val sumTypeConversion: CalculateReturnTypeOrNull = { type, _ ->
         typeOf<Byte>(),
         -> typeOf<Int>()
 
+        typeOf<Long>() -> typeOf<Long>()
+
         typeOf<Double>() -> typeOf<Double>()
 
         typeOf<Float>() -> typeOf<Float>()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/UtilTests.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlinx.dataframe.impl.commonParents
 import org.jetbrains.kotlinx.dataframe.impl.commonType
 import org.jetbrains.kotlinx.dataframe.impl.commonTypeListifyValues
 import org.jetbrains.kotlinx.dataframe.impl.createType
-import org.jetbrains.kotlinx.dataframe.impl.getUnifiedNumberClass
+import org.jetbrains.kotlinx.dataframe.impl.getUnifiedNumberClassOrNull
 import org.jetbrains.kotlinx.dataframe.impl.guessValueType
 import org.jetbrains.kotlinx.dataframe.impl.isArray
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveArray
@@ -426,40 +426,40 @@ class UtilTests {
     @Test
     fun `common number types`() {
         // Same type
-        getUnifiedNumberClass(Int::class, Int::class) shouldBe Int::class
-        getUnifiedNumberClass(Double::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClassOrNull(Int::class, Int::class) shouldBe Int::class
+        getUnifiedNumberClassOrNull(Double::class, Double::class) shouldBe Double::class
 
         // Direct parent-child relationships
-        getUnifiedNumberClass(Int::class, UShort::class) shouldBe Int::class
-        getUnifiedNumberClass(Long::class, UInt::class) shouldBe Long::class
-        getUnifiedNumberClass(Double::class, Float::class) shouldBe Double::class
-        getUnifiedNumberClass(UShort::class, Short::class) shouldBe Int::class
-        getUnifiedNumberClass(UByte::class, Byte::class) shouldBe Short::class
+        getUnifiedNumberClassOrNull(Int::class, UShort::class) shouldBe Int::class
+        getUnifiedNumberClassOrNull(Long::class, UInt::class) shouldBe Long::class
+        getUnifiedNumberClassOrNull(Double::class, Float::class) shouldBe Double::class
+        getUnifiedNumberClassOrNull(UShort::class, Short::class) shouldBe Int::class
+        getUnifiedNumberClassOrNull(UByte::class, Byte::class) shouldBe Short::class
 
-        getUnifiedNumberClass(UByte::class, UShort::class) shouldBe UShort::class
+        getUnifiedNumberClassOrNull(UByte::class, UShort::class) shouldBe UShort::class
 
         // Multi-level relationships
-        getUnifiedNumberClass(Byte::class, Int::class) shouldBe Int::class
-        getUnifiedNumberClass(UByte::class, Long::class) shouldBe Long::class
-        getUnifiedNumberClass(Short::class, Double::class) shouldBe Double::class
-        getUnifiedNumberClass(UInt::class, Int::class) shouldBe Long::class
+        getUnifiedNumberClassOrNull(Byte::class, Int::class) shouldBe Int::class
+        getUnifiedNumberClassOrNull(UByte::class, Long::class) shouldBe Long::class
+        getUnifiedNumberClassOrNull(Short::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClassOrNull(UInt::class, Int::class) shouldBe Long::class
 
         // Top-level types
-        getUnifiedNumberClass(BigDecimal::class, Double::class) shouldBe BigDecimal::class
-        getUnifiedNumberClass(BigInteger::class, Long::class) shouldBe BigInteger::class
-        getUnifiedNumberClass(BigDecimal::class, BigInteger::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(BigDecimal::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(BigInteger::class, Long::class) shouldBe BigInteger::class
+        getUnifiedNumberClassOrNull(BigDecimal::class, BigInteger::class) shouldBe BigDecimal::class
 
         // Distant relationships
-        getUnifiedNumberClass(Byte::class, BigDecimal::class) shouldBe BigDecimal::class
-        getUnifiedNumberClass(UByte::class, Double::class) shouldBe Double::class
+        getUnifiedNumberClassOrNull(Byte::class, BigDecimal::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(UByte::class, Double::class) shouldBe Double::class
 
         // Complex type promotions
-        getUnifiedNumberClass(Int::class, Float::class) shouldBe Double::class
-        getUnifiedNumberClass(Long::class, Double::class) shouldBe BigDecimal::class
-        getUnifiedNumberClass(ULong::class, Double::class) shouldBe BigDecimal::class
-        getUnifiedNumberClass(BigInteger::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(Int::class, Float::class) shouldBe Double::class
+        getUnifiedNumberClassOrNull(Long::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(ULong::class, Double::class) shouldBe BigDecimal::class
+        getUnifiedNumberClassOrNull(BigInteger::class, Double::class) shouldBe BigDecimal::class
 
         // Edge case with null
-        getUnifiedNumberClass(null, Int::class) shouldBe Int::class
+        getUnifiedNumberClassOrNull(null, Int::class) shouldBe Int::class
     }
 }


### PR DESCRIPTION
Helps https://github.com/Kotlin/dataframe/issues/961

- Simplified `sum` implementation, based on the table at https://github.com/Kotlin/dataframe/issues/961
- Fixed public `sum` overloads so they always return the correct type based on the table
- tiny fixes for `aggregateOfRow`
- Selecting "no" columns in `mean` and `sum` will now select primitive- or mixed numbers only. This automatically excludes columns with unsupported numbers and in the slight case unsupported numbers end up in a mixed column, we provide a helpful exception.