### PR TITLE
Set version to 1.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectName=dataframe
-version=0.16.0
+version=1.0.0-Beta1
 jupyterApiTCRepo=
 kotlin.jupyter.add.scanner=false
 org.gradle.jvmargs=-Xmx4G

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectName=dataframe
-version=1.0.0-Beta1
+version=1.0.0
 jupyterApiTCRepo=
 kotlin.jupyter.add.scanner=false
 org.gradle.jvmargs=-Xmx4G


### PR DESCRIPTION
https://github.com/Kotlin/dataframe/pull/1095 + https://github.com/Kotlin/kotlin-jupyter-libraries/pull/470 only works when our build version starts with a "1", so it makes sense to bump our dev version to our first 1.X beta release :). We can follow the naming standard of Kotlin itself.