### PR TITLE
Support convert shortcuts

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -405,6 +405,11 @@ public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annot
 	public abstract fun name ()Ljava/lang/String;
 }
 
+public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annotations/Converter : java/lang/annotation/Annotation {
+	public abstract fun klass ()Ljava/lang/Class;
+	public abstract fun nullable ()Z
+}
+
 public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annotations/CsvOptions : java/lang/annotation/Annotation {
 	public abstract fun delimiter ()C
 }
@@ -1713,41 +1718,67 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConvertKt {
 	public static final fun toDoubleTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toFloat (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toFloatTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toIFrame (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun toIFrame$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toImg (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun toImg$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toInstant (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toIframeFromUrl (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toIframeFromUrl$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toIframeFromUrlNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toIframeFromUrlNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;ZLjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toImgFromUrl (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toImgFromUrl$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toImgFromUrlNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toImgFromUrlNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toInstantFromString (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toInstantFromStringNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toInt (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toIntTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDate (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toLocalDate (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun toLocalDate$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateFromString (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateFromString$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateFromStringNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateFromStringNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateFromTInt (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalDateFromTInt$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateFromTIntNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateFromTIntNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateFromTLong (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalDateFromTLong$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateFromTLongNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateFromTLongNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateTime (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toLocalDateTime (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun toLocalDateTime$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateTimeFromString (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateTimeFromString$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateTimeFromStringNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateTimeFromStringNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateTimeFromTInstant (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalDateTimeFromTInstant$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateTimeFromTInstantNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateTimeFromTInstantNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateTimeFromTInt (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalDateTimeFromTInt$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateTimeFromTIntNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateTimeFromTIntNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalDateTimeFromTLong (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalDateTimeFromTLong$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalDateTimeFromTLongNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalDateTimeFromTLongNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalTime (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toLocalTime (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun toLocalTime$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalTimeFromString (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalTimeFromString$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalTimeFromStringNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalTimeFromStringNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Ljava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalTimeFromTInt (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalTimeFromTInt$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalTimeFromTIntNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalTimeFromTIntNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLocalTimeFromTLong (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun toLocalTimeFromTLong$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toLocalTimeFromTLongNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun toLocalTimeFromTLongNullable$default (Lorg/jetbrains/kotlinx/dataframe/api/Convert;Lkotlinx/datetime/TimeZone;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLong (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toLongTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toStr (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toStrTAny (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun toURL (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toUrlFromString (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun toUrlFromStringNullable (Lorg/jetbrains/kotlinx/dataframe/api/Convert;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ConvertSchemaDsl {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.annotations
 
+import kotlin.reflect.KClass
+
 @Target(AnnotationTarget.CLASS)
 public annotation class HasSchema(val schemaArg: Int)
 
@@ -46,3 +48,9 @@ internal annotation class Check
  */
 @Target(AnnotationTarget.FUNCTION)
 internal annotation class AccessApiOverload
+
+/**
+ * Provides argument to `ToSpecificType` interpreter - to what type compiler plugin should convert selected columns
+ */
+@Target(AnnotationTarget.FUNCTION)
+public annotation class Converter<T : Any>(val klass: KClass<T>, val nullable: Boolean = false)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowColumnExpression
 import org.jetbrains.kotlinx.dataframe.RowValueExpression
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Converter
 import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
@@ -284,13 +285,38 @@ public fun <T : Any> DataColumn<T?>.convertToBoolean(): DataColumn<Boolean?> = c
 
 // region convert URL
 
-public fun <T, R : URL?> Convert<T, R>.toIFrame(
+@JvmName("toIframeFromUrlNullable")
+@Refine
+@Converter<IFRAME>(IFRAME::class, nullable = true)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, URL?>.toIFrame(
+    border: Boolean = false,
+    width: Int? = null,
+    height: Int? = null,
+): DataFrame<T> = to { it.map { url -> url?.let { IFRAME(url.toString(), border, width, height) } } }
+
+@JvmName("toIframeFromUrl")
+@Refine
+@Converter<IFRAME>(IFRAME::class, nullable = false)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, URL>.toIFrame(
     border: Boolean = false,
     width: Int? = null,
     height: Int? = null,
 ): DataFrame<T> = to { it.map { IFRAME(it.toString(), border, width, height) } }
 
-public fun <T, R : URL?> Convert<T, R>.toImg(width: Int? = null, height: Int? = null): DataFrame<T> =
+@JvmName("toImgFromUrlNullable")
+@Refine
+@Converter<IMG>(IMG::class, nullable = true)
+@Interpretable("ToSpecificType")
+public fun <T, R : URL?> Convert<T, URL?>.toImg(width: Int? = null, height: Int? = null): DataFrame<T> =
+    to { it.map { url -> url?.let { IMG(url.toString(), width, height) } } }
+
+@JvmName("toImgFromUrl")
+@Refine
+@Converter<IMG>(IMG::class, nullable = false)
+@Interpretable("ToSpecificType")
+public fun <T, R : URL?> Convert<T, URL>.toImg(width: Int? = null, height: Int? = null): DataFrame<T> =
     to { it.map { IMG(it.toString(), width, height) } }
 
 // endregion
@@ -302,7 +328,17 @@ public fun DataColumn<String>.convertToURL(): DataColumn<URL> = map { URL(it) }
 @JvmName("convertToURLFromStringNullable")
 public fun DataColumn<String?>.convertToURL(): DataColumn<URL?> = map { it?.let { URL(it) } }
 
-public fun <T, R : String?> Convert<T, R>.toURL(): DataFrame<T> = to { it.convertToURL() }
+@JvmName("toUrlFromStringNullable")
+@Refine
+@Converter<URL>(URL::class, nullable = true)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, String?>.toURL(): DataFrame<T> = to { it.convertToURL() }
+
+@JvmName("toUrlFromString")
+@Refine
+@Converter<URL>(URL::class, nullable = false)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, String>.toURL(): DataFrame<T> = to { it.convertToURL() }
 
 // endregion
 
@@ -313,7 +349,17 @@ public fun DataColumn<String>.convertToInstant(): DataColumn<Instant> = map { In
 @JvmName("convertToInstantFromStringNullable")
 public fun DataColumn<String?>.convertToInstant(): DataColumn<Instant?> = map { it?.let { Instant.parse(it) } }
 
-public fun <T, R : String?> Convert<T, R>.toInstant(): DataFrame<T> = to { it.convertToInstant() }
+@JvmName("toInstantFromStringNullable")
+@Refine
+@Converter<Instant>(Instant::class, nullable = true)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, String?>.toInstant(): DataFrame<T> = to { it.convertToInstant() }
+
+@JvmName("toInstantFromString")
+@Refine
+@Converter<Instant>(Instant::class, nullable = false)
+@Interpretable("ToSpecificType")
+public fun <T> Convert<T, String>.toInstant(): DataFrame<T> = to { it.convertToInstant() }
 
 // endregion
 
@@ -352,17 +398,51 @@ public fun DataColumn<String?>.convertToLocalDate(
     return map { it?.let { converter(it.trim()) ?: error("Can't convert `$it` to LocalDate") } }
 }
 
+@JvmName("toLocalDateFromTLongNullable")
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long?>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalDate(zone) }
+
 @JvmName("toLocalDateFromTLong")
-public fun <T, R : Long?> Convert<T, R>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalDate(zone) }
 
 @JvmName("toLocalDateFromTInt")
-public fun <T, R : Int?> Convert<T, R>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int?>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalDate(zone) }
 
-public fun <T, R : String?> Convert<T, R>.toLocalDate(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+@JvmName("toLocalDateFromTIntNullable")
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int>.toLocalDate(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalDate(zone) }
+
+@JvmName("toLocalDateFromStringNullable")
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = true)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String?>.toLocalDate(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
     to { it.convertToLocalDate(pattern, locale) }
 
+@JvmName("toLocalDateFromString")
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = false)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String>.toLocalDate(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+    to { it.convertToLocalDate(pattern, locale) }
+
+@Refine
+@Converter<LocalDate>(LocalDate::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, *>.toLocalDate(): DataFrame<T> = to { it.convertTo<LocalDate>() }
 
 // endregion
@@ -402,17 +482,51 @@ public fun DataColumn<String?>.convertToLocalTime(
     return map { it?.let { converter(it.trim()) ?: error("Can't convert `$it` to LocalTime") } }
 }
 
+@JvmName("toLocalTimeFromTLongNullable")
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long?>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalTime(zone) }
+
 @JvmName("toLocalTimeFromTLong")
-public fun <T, R : Long?> Convert<T, R>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalTime(zone) }
+
+@JvmName("toLocalTimeFromTIntNullable")
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int?>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalTime(zone) }
 
 @JvmName("toLocalTimeFromTInt")
-public fun <T, R : Int?> Convert<T, R>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int>.toLocalTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalTime(zone) }
 
-public fun <T, R : String?> Convert<T, R>.toLocalTime(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+@JvmName("toLocalTimeFromStringNullable")
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = true)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String?>.toLocalTime(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
     to { it.convertToLocalTime(pattern, locale) }
 
+@JvmName("toLocalTimeFromString")
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = false)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String>.toLocalTime(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+    to { it.convertToLocalTime(pattern, locale) }
+
+@Refine
+@Converter<LocalTime>(LocalTime::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, *>.toLocalTime(): DataFrame<T> = to { it.convertTo<LocalTime>() }
 
 // endregion
@@ -460,65 +574,155 @@ public fun DataColumn<String?>.convertToLocalDateTime(
     return map { it?.let { converter(it.trim()) ?: error("Can't convert `$it` to LocalDateTime") } }
 }
 
+@JvmName("toLocalDateTimeFromTLongNullable")
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long?>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalDateTime(zone) }
+
 @JvmName("toLocalDateTimeFromTLong")
-public fun <T, R : Long?> Convert<T, R>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Long>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalDateTime(zone) }
+
+@JvmName("toLocalDateTimeFromTInstantNullable")
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Instant?>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalDateTime(zone) }
 
 @JvmName("toLocalDateTimeFromTInstant")
-public fun <T, R : Instant?> Convert<T, R>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Instant>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+    to { it.convertToLocalDateTime(zone) }
+
+@JvmName("toLocalDateTimeFromTIntNullable")
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = true)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int?>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalDateTime(zone) }
 
 @JvmName("toLocalDateTimeFromTInt")
-public fun <T, R : Int?> Convert<T, R>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = false)
+@Interpretable("ToSpecificTypeZone")
+public fun <T> Convert<T, Int>.toLocalDateTime(zone: TimeZone = defaultTimeZone): DataFrame<T> =
     to { it.convertToLocalDateTime(zone) }
 
-public fun <T, R : String?> Convert<T, R>.toLocalDateTime(
-    pattern: String? = null,
-    locale: Locale? = null,
-): DataFrame<T> = to { it.convertToLocalDateTime(pattern, locale) }
+@JvmName("toLocalDateTimeFromStringNullable")
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = true)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String?>.toLocalDateTime(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+    to { it.convertToLocalDateTime(pattern, locale) }
 
+@JvmName("toLocalDateTimeFromString")
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = false)
+@Interpretable("ToSpecificTypePattern")
+public fun <T> Convert<T, String>.toLocalDateTime(pattern: String? = null, locale: Locale? = null): DataFrame<T> =
+    to { it.convertToLocalDateTime(pattern, locale) }
+
+@Refine
+@Converter<LocalDateTime>(LocalDateTime::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, *>.toLocalDateTime(): DataFrame<T> = to { it.convertTo<LocalDateTime>() }
 
 // endregion
 
 @JvmName("toIntTAny")
+@Refine
+@Converter<Int>(Int::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toInt(): DataFrame<T> = to<Int>()
 
+@Refine
+@Converter<Int>(Int::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toInt(): DataFrame<T> = to<Int?>()
 
 @JvmName("toLongTAny")
+@Refine
+@Converter<Long>(Long::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toLong(): DataFrame<T> = to<Long>()
 
+@Refine
+@Converter<Long>(Long::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toLong(): DataFrame<T> = to<Long?>()
 
 @JvmName("toStrTAny")
+@Refine
+@Converter<String>(String::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toStr(): DataFrame<T> = to<String>()
 
+@Refine
+@Converter<String>(String::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toStr(): DataFrame<T> = to<String?>()
 
 @JvmName("toDoubleTAny")
+@Refine
+@Converter<Double>(Double::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toDouble(): DataFrame<T> = to<Double>()
 
+@Refine
+@Converter<Double>(Double::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toDouble(): DataFrame<T> = to<Double?>()
 
 @JvmName("toFloatTAny")
+@Refine
+@Converter<Float>(Float::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toFloat(): DataFrame<T> = to<Float>()
 
+@Refine
+@Converter<Float>(Float::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toFloat(): DataFrame<T> = to<Float?>()
 
 @JvmName("toBigDecimalTAny")
+@Refine
+@Converter<BigDecimal>(BigDecimal::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toBigDecimal(): DataFrame<T> = to<BigDecimal>()
 
+@Refine
+@Converter<BigDecimal>(BigDecimal::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toBigDecimal(): DataFrame<T> = to<BigDecimal?>()
 
 @JvmName("toBigIntegerTAny")
+@Refine
+@Converter<BigInteger>(BigInteger::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toBigInteger(): DataFrame<T> = to<BigInteger>()
 
+@Refine
+@Converter<BigInteger>(BigInteger::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toBigInteger(): DataFrame<T> = to<BigInteger?>()
 
 @JvmName("toBooleanTAny")
+@Refine
+@Converter<Boolean>(Boolean::class, nullable = false)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any>.toBoolean(): DataFrame<T> = to<Boolean>()
 
+@Refine
+@Converter<Boolean>(Boolean::class, nullable = true)
+@Interpretable("ToSpecificType")
 public fun <T> Convert<T, Any?>.toBoolean(): DataFrame<T> = to<Boolean?>()
 
 public fun <T, C> Convert<T, List<List<C>>>.toDataFrames(containsColumns: Boolean = false): DataFrame<T> =

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -142,11 +142,13 @@ internal fun <T, C> Split<T, C>.toDataFrame(): DataFrame<T> =
 
 // region into
 
+@AccessApiOverload
 public fun <T, C, R> SplitWithTransform<T, C, R>.into(
     firstName: ColumnAccessor<*>,
     vararg otherNames: ColumnAccessor<*>,
 ): DataFrame<T> = into(listOf(firstName.name()) + otherNames.map { it.name() })
 
+@AccessApiOverload
 public fun <T, C, R> SplitWithTransform<T, C, R>.into(
     firstName: KProperty<*>,
     vararg otherNames: KProperty<*>,
@@ -183,6 +185,7 @@ public fun <T, C> Split<T, DataFrame<C>>.into(
 public fun <T, A, B> Split<T, Pair<A, B>>.into(firstCol: String, secondCol: String): DataFrame<T> =
     by { listOf(it.first, it.second) }.into(firstCol, secondCol)
 
+@AccessApiOverload
 public inline fun <T, reified A, reified B> Split<T, Pair<A, B>>.into(
     firstCol: ColumnAccessor<A>,
     secondCol: ColumnAccessor<B>,
@@ -208,11 +211,13 @@ public fun <T, C, R> SplitWithTransform<T, C, R>.inward(
     extraNamesGenerator: ColumnNamesGenerator<C>? = null,
 ): DataFrame<T> = inward(names.toList(), extraNamesGenerator)
 
+@AccessApiOverload
 public fun <T, C, R> SplitWithTransform<T, C, R>.inward(
     firstName: ColumnAccessor<*>,
     vararg otherNames: ColumnAccessor<*>,
 ): DataFrame<T> = inward(listOf(firstName.name()) + otherNames.map { it.name() })
 
+@AccessApiOverload
 public fun <T, C, R> SplitWithTransform<T, C, R>.inward(
     firstName: KProperty<*>,
     vararg otherNames: KProperty<*>,
@@ -232,6 +237,7 @@ public fun <T, C : DataFrame<R>, R> Split<T, C>.inward(
 public fun <T, A, B> Split<T, Pair<A, B>>.inward(firstCol: String, secondCol: String): DataFrame<T> =
     by { listOf(it.first, it.second) }.inward(firstCol, secondCol)
 
+@AccessApiOverload
 public inline fun <T, reified A, reified B> Split<T, Pair<A, B>>.inward(
     firstCol: ColumnAccessor<A>,
     secondCol: ColumnAccessor<B>,

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/interpret.kt
@@ -92,7 +92,7 @@ fun <T> KotlinTypeFacade.interpret(
 ): Interpreter.Success<T>? {
     val refinedArguments: RefinedArguments = functionCall.collectArgumentExpressions()
 
-    val defaultArguments = processor.expectedArguments.filter { it.defaultValue is Present }.map { it.name }.toSet()
+    val defaultArguments = processor.expectedArguments.filter { it.defaultValue is Present }.map { it.name }.toSet() + THIS_CALL
     val actualValueArguments = refinedArguments.associateBy { it.name.identifier }.toSortedMap()
     val conflictingKeys = additionalArguments.keys intersect actualValueArguments.keys
     if (conflictingKeys.isNotEmpty()) {
@@ -139,6 +139,7 @@ fun <T> KotlinTypeFacade.interpret(
     val arguments = mutableMapOf<String, Interpreter.Success<Any?>>()
     arguments += additionalArguments
     arguments += typeArguments
+    arguments[THIS_CALL] = Interpreter.Success(functionCall)
     val interpretationResults = refinedArguments.refinedArguments.mapNotNull {
         val name = it.name.identifier
         val expectedArgument = expectedArgsMap[name] ?: error("$processor $name")
@@ -566,6 +567,8 @@ internal fun FirExpression.getSchema(session: FirSession): ObjectWithSchema? {
         } ?: error("Annotate ${symbol} with @HasSchema")
     }
 }
+
+private const val THIS_CALL = "functionCall"
 
 internal class ObjectWithSchema(val schemaArg: Int, val typeRef: ConeKotlinType)
 

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -200,6 +200,9 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Take2
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.TakeLast0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.TakeLast1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.TakeLast2
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToSpecificType
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToSpecificTypePattern
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ToSpecificTypeZone
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ValueCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ValueCols1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.WithoutNulls0
@@ -290,6 +293,9 @@ internal inline fun <reified T> String.load(): T {
         "Convert2" -> Convert2()
         "Convert6" -> Convert6()
         "To0" -> To0()
+        "ToSpecificType" -> ToSpecificType()
+        "ToSpecificTypeZone" -> ToSpecificTypeZone()
+        "ToSpecificTypePattern" -> ToSpecificTypePattern()
         "With0" -> With0()
         "PerRowCol" -> PerRowCol()
         "Explode0" -> Explode0()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlinx.dataframe.annotations.ColumnName
+import org.jetbrains.kotlinx.dataframe.annotations.Converter
 import org.jetbrains.kotlinx.dataframe.annotations.Order
 import org.jetbrains.kotlinx.dataframe.annotations.ScopeProperty
 import kotlin.reflect.KClass
@@ -54,6 +55,7 @@ object Names {
         get() = FqName("org.jetbrains.kotlinx.dataframe.annotations.Interpretable")
     private val annotationsPackage = FqName("org.jetbrains.kotlinx.dataframe.annotations")
     val ORDER_ANNOTATION = ClassId(annotationsPackage, Name.identifier(Order::class.simpleName!!))
+    val CONVERTER_ANNOTATION = ClassId(annotationsPackage, Name.identifier(Converter::class.simpleName!!))
     val ORDER_ARGUMENT = Name.identifier(Order::order.name)
     val SCOPE_PROPERTY_ANNOTATION = ClassId(annotationsPackage, Name.identifier(ScopeProperty::class.simpleName!!))
     val COLUMN_NAME_ANNOTATION = ClassId(annotationsPackage, Name.identifier(ColumnName::class.simpleName!!))

--- a/plugins/kotlin-dataframe/testData/box/convertToShortcuts.kt
+++ b/plugins/kotlin-dataframe/testData/box/convertToShortcuts.kt
@@ -1,0 +1,21 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+import kotlinx.datetime.*
+
+fun box(): String {
+    val daysToStandardMillis = 24 * 60 * 60 * 1000L * 366
+    val df = dataFrameOf("a")(60L * 1000L + daysToStandardMillis).convert { a }.toLocalDateTime(TimeZone.UTC)
+    val localDateTime: LocalDateTime = df.a[0]
+
+    val df1 = dataFrameOf("a")(60L * 1000L + daysToStandardMillis, null).convert { a }.toLocalDateTime(TimeZone.UTC)
+    val localDateTime1: LocalDateTime? = df1.a[0]
+
+    val df2 = dataFrameOf("a")(123).convert { a }.toStr()
+    val str: String = df2.a[0]
+
+    val df3 = dataFrameOf("a")(123, null).convert { a }.toStr()
+    df3.compareSchemas(strict = true)
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -90,6 +90,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("convertToShortcuts.kt")
+  public void testConvertToShortcuts() {
+    runTest("testData/box/convertToShortcuts.kt");
+  }
+
+  @Test
   @TestMetadata("convert_to.kt")
   public void testConvert_to() {
     runTest("testData/box/convert_to.kt");


### PR DESCRIPTION
I tried to minimize repetition and come up with somewhat generic solution. However the way framework works, we still must have delegated properties matching function arguments. I decided to not provide a way for interpreter to ignore any unknown arguments in this PR 