### PR TITLE
Fix bug that prevented SQL Server row limts

### DIFF
--- a/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/db/MsSql.kt
+++ b/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/db/MsSql.kt
@@ -50,7 +50,6 @@ public object MsSql : DbType("sqlserver") {
     override fun convertSqlTypeToKType(tableColumnMetadata: TableColumnMetadata): KType? = null
 
     public override fun sqlQueryLimit(sqlQuery: String, limit: Int): String {
-        sqlQuery.replace("SELECT", "SELECT TOP $limit", ignoreCase = true)
-        return sqlQuery
+        return sqlQuery.replace("SELECT", "SELECT TOP $limit", ignoreCase = true)
     }
 }

--- a/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/mssqlTest.kt
+++ b/dataframe-jdbc/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/mssqlTest.kt
@@ -1,0 +1,35 @@
+package org.jetbrains.kotlinx.dataframe.io
+
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.filter
+import org.jetbrains.kotlinx.dataframe.io.db.MsSql
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import kotlin.reflect.typeOf
+
+class MsSqlTest {
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownClass() {
+        }
+    }
+
+    @Test
+    fun `test SQL Server TOP limit functionality`() {
+        MsSql.sqlQueryLimit("SELECT * FROM TestTable1", 1) shouldBe "SELECT TOP 1 * FROM TestTable1"
+    }
+}


### PR DESCRIPTION
Fixes #1135 

MsSql.sqlQueryLimit was returning the unmodified query and throwing the modified version away.  Unit tests fails before fix and succeeds after.