### PR TITLE
[Compiler plugin] join operations support

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1186,11 +1186,9 @@ public final class org/jetbrains/kotlinx/dataframe/api/ColumnDescription_Extensi
 	public static final fun NullableColumnDescription_unique (Lorg/jetbrains/kotlinx/dataframe/DataRow;)Ljava/lang/Integer;
 }
 
-public final class org/jetbrains/kotlinx/dataframe/api/ColumnMatch : org/jetbrains/kotlinx/dataframe/columns/ColumnSet {
-	public fun <init> (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)V
-	public final fun getLeft ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
-	public final fun getRight ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
-	public fun resolve (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnResolutionContext;)Ljava/util/List;
+public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColumnMatch : org/jetbrains/kotlinx/dataframe/columns/ColumnSet {
+	public abstract fun getLeft ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
+	public abstract fun getRight ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl {
@@ -2535,6 +2533,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/IsEmptyKt {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/JoinDsl : org/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl {
+	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/api/JoinDsl$Companion;
 	public abstract fun getRight ()Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public fun match (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/api/ColumnMatch;
 	public fun match (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/api/ColumnMatch;
@@ -2545,7 +2544,13 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/JoinDsl : or
 	public fun match (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/api/ColumnMatch;
 }
 
+public final class org/jetbrains/kotlinx/dataframe/api/JoinDsl$Companion {
+	public final fun defaultJoinColumns (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/DataFrame;)Lkotlin/jvm/functions/Function2;
+	public final fun getColumns (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+}
+
 public final class org/jetbrains/kotlinx/dataframe/api/JoinKt {
+	public static final fun ColumnMatch (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/api/ColumnMatch;
 	public static final fun excludeJoin (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun excludeJoin (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static synthetic fun excludeJoin$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
@@ -5666,6 +5671,10 @@ public final class org/jetbrains/kotlinx/dataframe/impl/codeGen/NameNormalizerIm
 public final class org/jetbrains/kotlinx/dataframe/impl/codeGen/SchemaReaderKt {
 	public static final fun getUrlCodeGenReader (Lorg/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator$Companion;)Lkotlin/jvm/functions/Function4;
 	public static final fun getUrlDfReader (Lorg/jetbrains/kotlinx/dataframe/codeGen/CodeGenerator$Companion;)Lkotlin/jvm/functions/Function2;
+}
+
+public abstract interface class org/jetbrains/kotlinx/dataframe/impl/columns/ColumnsList : org/jetbrains/kotlinx/dataframe/columns/ColumnSet {
+	public abstract fun getColumns ()Ljava/util/List;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/impl/columns/ColumnsResolverTransformer {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/and.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/and.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlinx.dataframe.documentation.DoubleIndent
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
-import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnsList
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnListImpl
 import kotlin.reflect.KProperty
 
 // region ColumnsSelectionDsl
@@ -114,7 +114,7 @@ public interface AndColumnsSelectionDsl {
 
     /** @include [ColumnsResolverAndDocs] {@set [ColumnsResolverAndDocs.Argument] [`colsOf`][SingleColumn.colsOf]`<`[`Int`][Int]`>()`} */
     @Interpretable("And0")
-    public infix fun <C> ColumnsResolver<C>.and(other: ColumnsResolver<C>): ColumnSet<C> = ColumnsList(this, other)
+    public infix fun <C> ColumnsResolver<C>.and(other: ColumnsResolver<C>): ColumnSet<C> = ColumnListImpl(this, other)
 
     /** @include [ColumnsResolverAndDocs] {@set [ColumnsResolverAndDocs.Argument] `{ colA `[`/`][DataColumn.div]`  2.0  `[`named`][ColumnReference.named]` "half colA" \}`} */
     public infix fun <C> ColumnsResolver<C>.and(other: () -> ColumnsResolver<C>): ColumnSet<C> = this and other()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/join.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/join.kt
@@ -10,8 +10,12 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
+import org.jetbrains.kotlinx.dataframe.columns.UnresolvedColumnsPolicy
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
+import org.jetbrains.kotlinx.dataframe.impl.DataFrameReceiver
+import org.jetbrains.kotlinx.dataframe.impl.api.extractJoinColumns
 import org.jetbrains.kotlinx.dataframe.impl.api.joinImpl
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnListImpl
 import kotlin.reflect.KProperty
 
 @Refine
@@ -28,6 +32,8 @@ public fun <A, B> DataFrame<A>.join(
     type: JoinType = JoinType.Inner,
 ): DataFrame<A> = join(other, type) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("InnerJoin")
 public fun <A, B> DataFrame<A>.innerJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -36,6 +42,8 @@ public fun <A, B> DataFrame<A>.innerJoin(
 public fun <A, B> DataFrame<A>.innerJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     innerJoin(other) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("LeftJoin")
 public fun <A, B> DataFrame<A>.leftJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -44,6 +52,8 @@ public fun <A, B> DataFrame<A>.leftJoin(
 public fun <A, B> DataFrame<A>.leftJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     leftJoin(other) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("RightJoin")
 public fun <A, B> DataFrame<A>.rightJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -52,6 +62,8 @@ public fun <A, B> DataFrame<A>.rightJoin(
 public fun <A, B> DataFrame<A>.rightJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     rightJoin(other) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("FullJoin")
 public fun <A, B> DataFrame<A>.fullJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -60,6 +72,8 @@ public fun <A, B> DataFrame<A>.fullJoin(
 public fun <A, B> DataFrame<A>.fullJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     fullJoin(other) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("FilterJoin")
 public fun <A, B> DataFrame<A>.filterJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -68,6 +82,8 @@ public fun <A, B> DataFrame<A>.filterJoin(
 public fun <A, B> DataFrame<A>.filterJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     filterJoin(other) { columns.toColumnSet() }
 
+@Refine
+@Interpretable("ExcludeJoin")
 public fun <A, B> DataFrame<A>.excludeJoin(
     other: DataFrame<B>,
     selector: JoinColumnsSelector<A, B>? = null,
@@ -107,13 +123,43 @@ public interface JoinDsl<out A, out B> : ColumnsSelectionDsl<A> {
     @AccessApiOverload
     public infix fun <C> KProperty<C>.match(other: ColumnReference<C>): ColumnMatch<C> =
         ColumnMatch(toColumnAccessor(), other)
+
+    public companion object {
+        public fun <A, B> defaultJoinColumns(left: DataFrame<A>, right: DataFrame<B>): JoinColumnsSelector<A, B> =
+            {
+                left.columnNames().intersect(right.columnNames().toSet())
+                    .map { it.toColumnAccessor() }
+                    .let { ColumnListImpl(it) }
+            }
+
+        public fun <A, B> getColumns(
+            left: DataFrame<A>,
+            other: DataFrame<B>,
+            selector: JoinColumnsSelector<A, B>,
+        ): List<ColumnMatch<Any?>> {
+            val receiver = object : DataFrameReceiver<A>(left, UnresolvedColumnsPolicy.Fail), JoinDsl<A, B> {
+                override val right: DataFrame<B> = DataFrameReceiver(other, UnresolvedColumnsPolicy.Fail)
+            }
+            val columns = selector(receiver, left)
+            return columns.extractJoinColumns()
+        }
+    }
 }
 
-public class ColumnMatch<C>(public val left: ColumnReference<C>, public val right: ColumnReference<C>) : ColumnSet<C> {
+public interface ColumnMatch<C> : ColumnSet<C> {
+    public val left: ColumnReference<C>
+    public val right: ColumnReference<C>
+}
+
+internal class ColumnMatchImpl<C>(override val left: ColumnReference<C>, override val right: ColumnReference<C>) :
+    ColumnMatch<C> {
 
     override fun resolve(context: ColumnResolutionContext): List<ColumnWithPath<C>> =
         throw UnsupportedOperationException()
 }
+
+public fun <C> ColumnMatch(left: ColumnReference<C>, right: ColumnReference<C>): ColumnMatch<C> =
+    ColumnMatchImpl(left, right)
 
 public typealias JoinColumnsSelector<A, B> = JoinDsl<A, B>.(ColumnsContainer<A>) -> ColumnsResolver<*>
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/joinWith.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/joinWith.kt
@@ -3,6 +3,8 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Selector
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.impl.api.joinWithImpl
 
 public interface JoinedDataRow<out A, out B> : DataRow<A> {
@@ -11,27 +13,41 @@ public interface JoinedDataRow<out A, out B> : DataRow<A> {
 
 public typealias JoinExpression<A, B> = Selector<JoinedDataRow<A, B>, Boolean>
 
+@Refine
+@Interpretable("JoinWith")
 public fun <A, B> DataFrame<A>.joinWith(
     right: DataFrame<B>,
     type: JoinType = JoinType.Inner,
     joinExpression: JoinExpression<A, B>,
 ): DataFrame<A> = joinWithImpl(right, type, addNewColumns = type.addNewColumns, joinExpression)
 
+@Refine
+@Interpretable("InnerJoinWith")
 public fun <A, B> DataFrame<A>.innerJoinWith(right: DataFrame<B>, joinExpression: JoinExpression<A, B>): DataFrame<A> =
     joinWith(right, JoinType.Inner, joinExpression)
 
+@Refine
+@Interpretable("LeftJoinWith")
 public fun <A, B> DataFrame<A>.leftJoinWith(right: DataFrame<B>, joinExpression: JoinExpression<A, B>): DataFrame<A> =
     joinWith(right, JoinType.Left, joinExpression)
 
+@Refine
+@Interpretable("RightJoinWith")
 public fun <A, B> DataFrame<A>.rightJoinWith(right: DataFrame<B>, joinExpression: JoinExpression<A, B>): DataFrame<A> =
     joinWith(right, JoinType.Right, joinExpression)
 
+@Refine
+@Interpretable("FullJoinWith")
 public fun <A, B> DataFrame<A>.fullJoinWith(right: DataFrame<B>, joinExpression: JoinExpression<A, B>): DataFrame<A> =
     joinWith(right, JoinType.Full, joinExpression)
 
+@Refine
+@Interpretable("FilterJoinWith")
 public fun <A, B> DataFrame<A>.filterJoinWith(right: DataFrame<B>, joinExpression: JoinExpression<A, B>): DataFrame<A> =
     joinWithImpl(right, JoinType.Inner, addNewColumns = false, joinExpression)
 
+@Refine
+@Interpretable("ExcludeJoinWith")
 public fun <A, B> DataFrame<A>.excludeJoinWith(
     right: DataFrame<B>,
     joinExpression: JoinExpression<A, B>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/none.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/none.kt
@@ -4,7 +4,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
-import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnsList
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnListImpl
 
 // region ColumnsSelectionDsl
 
@@ -48,7 +48,7 @@ public interface NoneColumnsSelectionDsl {
      *
      * @return An empty [ColumnsResolver].
      */
-    public fun none(): ColumnsResolver<*> = ColumnsList<Any?>(emptyList())
+    public fun none(): ColumnsResolver<*> = ColumnListImpl<Any?>(emptyList())
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/constructors.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/constructors.kt
@@ -2,14 +2,14 @@ package org.jetbrains.kotlinx.dataframe.columns
 
 import org.jetbrains.kotlinx.dataframe.api.toColumnAccessor
 import org.jetbrains.kotlinx.dataframe.impl.asList
-import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnsList
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnListImpl
 import kotlin.reflect.KProperty
 
 // region toColumnSet
 
 // region Array
 
-public fun Array<out ColumnsResolver<*>>.toColumnSet(): ColumnSet<Any?> = ColumnsList(asList())
+public fun Array<out ColumnsResolver<*>>.toColumnSet(): ColumnSet<Any?> = ColumnListImpl(asList())
 
 @JvmName("toColumnSetString")
 public fun Array<out String>.toColumnSet(): ColumnSet<Any?> = map { it.toColumnAccessor() }.toColumnSet()
@@ -20,7 +20,7 @@ public fun Array<out ColumnPath>.toColumnSet(): ColumnSet<Any?> = map { it.toCol
 public fun <C> Array<out KProperty<C>>.toColumnSet(): ColumnSet<C> = map { it.toColumnAccessor() }.toColumnSet()
 
 @JvmName("toColumnSetC")
-public fun <C> Array<out ColumnsResolver<C>>.toColumnSet(): ColumnSet<C> = ColumnsList(asList())
+public fun <C> Array<out ColumnsResolver<C>>.toColumnSet(): ColumnSet<C> = ColumnListImpl(asList())
 
 public fun <C> Array<out ColumnReference<C>>.toColumnSet(): ColumnSet<C> = asIterable().toColumnSet()
 
@@ -28,7 +28,7 @@ public fun <C> Array<out ColumnReference<C>>.toColumnSet(): ColumnSet<C> = asIte
 
 // region Iterable
 
-public fun Iterable<ColumnsResolver<*>>.toColumnSet(): ColumnSet<Any?> = ColumnsList(asList())
+public fun Iterable<ColumnsResolver<*>>.toColumnSet(): ColumnSet<Any?> = ColumnListImpl(asList())
 
 @JvmName("toColumnSetString")
 public fun Iterable<String>.toColumnSet(): ColumnSet<Any?> = map { it.toColumnAccessor() }.toColumnSet()
@@ -40,10 +40,10 @@ public fun Iterable<ColumnPath>.toColumnSet(): ColumnSet<Any?> = map { it.toColu
 public fun <C> Iterable<KProperty<C>>.toColumnSet(): ColumnSet<C> = map { it.toColumnAccessor() }.toColumnSet()
 
 @JvmName("toColumnSetC")
-public fun <C> Iterable<ColumnsResolver<C>>.toColumnSet(): ColumnSet<C> = ColumnsList(toList())
+public fun <C> Iterable<ColumnsResolver<C>>.toColumnSet(): ColumnSet<C> = ColumnListImpl(toList())
 
 @JvmName("toColumnSetColumnReference")
-public fun <C> Iterable<ColumnReference<C>>.toColumnSet(): ColumnSet<C> = ColumnsList(toList())
+public fun <C> Iterable<ColumnReference<C>>.toColumnSet(): ColumnSet<C> = ColumnListImpl(toList())
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnsList.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ColumnsList.kt
@@ -4,7 +4,13 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 
-internal class ColumnsList<C>(val columns: List<ColumnsResolver<C>>) : ColumnSet<C> {
+public interface ColumnsList<C> : ColumnSet<C> {
+    public val columns: List<ColumnsResolver<C>>
+}
+
+internal class ColumnListImpl<C>(override val columns: List<ColumnsResolver<C>>) :
+    ColumnSet<C>,
+    ColumnsList<C> {
     constructor(vararg columns: ColumnsResolver<C>) : this(columns.toList())
 
     override fun resolve(context: ColumnResolutionContext) = columns.flatMap { it.resolve(context) }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/join.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/join.kt
@@ -1,51 +1,115 @@
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
+import org.jetbrains.kotlinx.dataframe.ColumnsContainer
+import org.jetbrains.kotlinx.dataframe.api.JoinColumnsSelector
+import org.jetbrains.kotlinx.dataframe.api.JoinDsl
+import org.jetbrains.kotlinx.dataframe.api.JoinType
+import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
+import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
+import org.jetbrains.kotlinx.dataframe.api.remove
+import org.jetbrains.kotlinx.dataframe.api.toDataFrameFromPairs
+import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
+import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
-import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ConeTypesAdapter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
-import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleCol
-import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleColumnGroup
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Present
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataColumn
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asDataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.asSimpleColumn
 import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.enum
+import org.jetbrains.kotlinx.dataframe.plugin.impl.makeNullable
+import org.jetbrains.kotlinx.dataframe.plugin.impl.toPluginDataFrameSchema
 
-internal class Join0 : AbstractInterpreter<PluginDataFrameSchema>() {
+internal abstract class AbstractJoin() : AbstractInterpreter<PluginDataFrameSchema>() {
     val Arguments.receiver: PluginDataFrameSchema by dataFrame()
     val Arguments.other: PluginDataFrameSchema by dataFrame()
-    val Arguments.selector: ColumnMatchApproximation by arg()
+    val Arguments.selector: ColumnSet<*>? by arg()
+
+    fun Arguments.join(type: JoinType): PluginDataFrameSchema {
+        val leftDf = receiver.asDataFrame()
+        val rightDf = other.asDataFrame()
+        val joinSelector: JoinColumnsSelector<*, *> = if (selector != null) {
+            { it: ColumnsContainer<*> -> selector!! }
+        } else {
+            JoinDsl.defaultJoinColumns(leftDf, rightDf)
+        }
+        val joinColumns = JoinDsl.getColumns(leftDf, rightDf, joinSelector)
+
+        val filteredRightDf = rightDf.remove { joinColumns.map { it.right }.toColumnSet() }
+        val left = leftDf.getColumnsWithPaths { colsAtAnyDepth().filter { !it.isColumnGroup() } }
+            .map { it.path to it.data }
+        val right = filteredRightDf.getColumnsWithPaths { colsAtAnyDepth().filter { !it.isColumnGroup() } }
+            .map { it.path to it.data }
+
+        val result = buildList {
+            when (type) {
+                JoinType.Inner -> {
+                    addAll(left)
+                    addAll(right)
+                }
+                JoinType.Left -> {
+                    addAll(left)
+                    addAll(right.map { it.first to makeNullable(it.second.asSimpleColumn()).asDataColumn() })
+                }
+                JoinType.Right -> {
+                    addAll(left.map { it.first to makeNullable(it.second.asSimpleColumn()).asDataColumn() })
+                    addAll(right)
+                }
+                JoinType.Full -> {
+                    addAll(left.map { it.first to makeNullable(it.second.asSimpleColumn()).asDataColumn() })
+                    addAll(right.map { it.first to makeNullable(it.second.asSimpleColumn()).asDataColumn() })
+                }
+                JoinType.Filter -> addAll(left)
+                JoinType.Exclude -> addAll(left)
+            }
+        }
+        return result.toDataFrameFromPairs<ConeTypesAdapter>().toPluginDataFrameSchema()
+    }
+}
+
+internal class Join0 : AbstractJoin() {
+    val Arguments.type: JoinType by enum(defaultValue = Present(JoinType.Inner))
 
     override fun Arguments.interpret(): PluginDataFrameSchema {
-        val nameGenerator = ColumnNameGenerator()
-        val left = receiver.columns()
-        val right = removeImpl(other.columns(), setOf(selector.right.resolve(receiver).single().path.path)).updatedColumns
+        return join(type)
+    }
+}
 
-        val rightColumnGroups = right.filterIsInstance<SimpleColumnGroup>().associateBy { it.name }
+internal class LeftJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Left)
+    }
+}
 
-        val mergedGroups = buildMap {
-            left.filterIsInstance<SimpleColumnGroup>().forEach { leftGroup ->
-                val rightGroup = rightColumnGroups[leftGroup.name]
-                if (rightGroup != null) {
-                    val merge = ColumnNameGenerator()
-                    val columns = (leftGroup.columns() + rightGroup.columns()).map { column ->
-                        val uniqueName = merge.addUnique(column.name)
-                        column.rename(uniqueName)
-                    }
-                    put(leftGroup.name, SimpleColumnGroup(leftGroup.name, columns))
-                }
-            }
-        }
+internal class RightJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Right)
+    }
+}
 
-        fun MutableList<SimpleCol>.addColumns(columns: List<SimpleCol>) {
-            for (column in columns) {
-                val uniqueName = nameGenerator.addUnique(column.name)
-                val colToAdd = mergedGroups[column.name] ?: column
-                add(colToAdd.rename(uniqueName))
-            }
-        }
+internal class FullJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Full)
+    }
+}
 
-        val columns = buildList {
-            addColumns(left)
-            addColumns(right.filterNot { it is SimpleColumnGroup && it.name() in mergedGroups })
-        }
-        return PluginDataFrameSchema(columns)
+internal class InnerJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Inner)
+    }
+}
+
+internal class FilterJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Filter)
+    }
+}
+
+internal class ExcludeJoin : AbstractJoin() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Exclude)
     }
 }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/joinDsl.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/joinDsl.kt
@@ -1,13 +1,29 @@
 package org.jetbrains.kotlinx.dataframe.plugin.impl.api
 
+import org.jetbrains.kotlinx.dataframe.api.ColumnMatch
+import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
+import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.data.ColumnWithPathApproximation
 
-internal data class ColumnMatchApproximation(val left: ColumnsResolver, val right: ColumnsResolver)
+internal data class ColumnMatchApproximation(
+    override val left: SingleColumnApproximation,
+    override val right: SingleColumnApproximation
+): ColumnMatch<Any?>, ColumnsResolver {
+    override fun resolve(df: PluginDataFrameSchema): List<ColumnWithPathApproximation> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun resolve(context: ColumnResolutionContext): List<ColumnWithPath<Any?>> {
+        throw UnsupportedOperationException()
+    }
+}
 
 internal class Match0 : AbstractInterpreter<ColumnMatchApproximation>() {
-    val Arguments.receiver: ColumnsResolver by arg()
-    val Arguments.other: ColumnsResolver by arg()
+    val Arguments.receiver: SingleColumnApproximation by arg()
+    val Arguments.other: SingleColumnApproximation by arg()
 
     override fun Arguments.interpret(): ColumnMatchApproximation {
         return ColumnMatchApproximation(receiver, other)

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/joinWith.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/joinWith.kt
@@ -1,0 +1,105 @@
+package org.jetbrains.kotlinx.dataframe.plugin.impl.api
+
+import org.jetbrains.kotlinx.dataframe.api.JoinType
+import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
+import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
+import org.jetbrains.kotlinx.dataframe.plugin.impl.PluginDataFrameSchema
+import org.jetbrains.kotlinx.dataframe.plugin.impl.Present
+import org.jetbrains.kotlinx.dataframe.plugin.impl.SimpleCol
+import org.jetbrains.kotlinx.dataframe.plugin.impl.dataFrame
+import org.jetbrains.kotlinx.dataframe.plugin.impl.enum
+import org.jetbrains.kotlinx.dataframe.plugin.impl.ignore
+import org.jetbrains.kotlinx.dataframe.plugin.impl.makeNullable
+
+internal abstract class AbstractJoinWith() : AbstractInterpreter<PluginDataFrameSchema>() {
+    val Arguments.receiver: PluginDataFrameSchema by dataFrame()
+    val Arguments.right: PluginDataFrameSchema by dataFrame()
+    val Arguments.joinExpression by ignore()
+
+    fun Arguments.join(type: JoinType): PluginDataFrameSchema {
+        val left = receiver.columns()
+        val right = right.columns()
+
+        val nameGenerator = ColumnNameGenerator()
+
+        fun MutableList<SimpleCol>.addColumns(columns: List<SimpleCol>) {
+            for (column in columns) {
+                val uniqueName = nameGenerator.addUnique(column.name)
+                add(column.rename(uniqueName))
+            }
+        }
+
+        val result = buildList {
+            when (type) {
+                JoinType.Inner -> {
+                    addColumns(left)
+                    addColumns(right)
+                }
+
+                JoinType.Left -> {
+                    addColumns(left)
+                    addColumns(right.map { makeNullable(it) })
+                }
+
+                JoinType.Right -> {
+                    addColumns(left.map { makeNullable(it) })
+                    addColumns(right)
+                }
+
+                JoinType.Full -> {
+                    addColumns(left.map { makeNullable(it) })
+                    addColumns(right.map { makeNullable(it) })
+                }
+
+                JoinType.Filter -> addColumns(left)
+                JoinType.Exclude -> addColumns(left)
+            }
+        }
+        return PluginDataFrameSchema(result)
+    }
+}
+
+internal class JoinWith : AbstractJoinWith() {
+    val Arguments.type: JoinType by enum(defaultValue = Present(JoinType.Inner))
+
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(type)
+    }
+}
+
+internal class LeftJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Left)
+    }
+}
+
+internal class RightJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Right)
+    }
+}
+
+internal class FullJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Full)
+    }
+}
+
+internal class InnerJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Inner)
+    }
+}
+
+internal class FilterJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Filter)
+    }
+}
+
+internal class ExcludeJoinWith : AbstractJoinWith() {
+    override fun Arguments.interpret(): PluginDataFrameSchema {
+        return join(JoinType.Exclude)
+    }
+}

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/select.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/impl/api/select.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.fir.types.isMarkedNullable
 import org.jetbrains.kotlin.fir.types.isSubtypeOf
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
+import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnsList
 import org.jetbrains.kotlinx.dataframe.plugin.impl.AbstractInterpreter
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Arguments
 import org.jetbrains.kotlinx.dataframe.plugin.impl.Interpreter
@@ -57,7 +58,9 @@ internal class And0 : AbstractInterpreter<ColumnsResolver>() {
     val Arguments.other: ColumnsResolver by arg()
 
     override fun Arguments.interpret(): ColumnsResolver {
-        return object : ColumnsResolver {
+        return object : ColumnsResolver, ColumnsList<Any?> {
+            override val columns = listOf(receiver, other)
+
             override fun resolve(df: PluginDataFrameSchema): List<ColumnWithPathApproximation> {
                 return receiver.resolve(df) + other.resolve(df)
             }

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -110,7 +110,9 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropLast0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropLast1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropLast2
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropNa0
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ExcludeJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FillNulls0
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FilterJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First2
@@ -119,6 +121,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FlattenDefault
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols2
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FullJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByCount0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
@@ -138,10 +141,12 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceExpression
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReduceInto
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByReducePredicate
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByXs
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.InnerJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.InsertAfter0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Last0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Last1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Last2
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.LeftJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByStd0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByStd1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByStdOf
@@ -193,6 +198,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCase
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCaseClause
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Reorder
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReorderColumnsByName
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RightJoin
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single2
@@ -212,7 +218,6 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.WithoutNulls0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.WithoutNulls1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.WithoutNulls2
 import org.jetbrains.kotlinx.dataframe.plugin.utils.Names
-
 
 internal fun FirFunctionCall.loadInterpreter(session: FirSession): Interpreter<*>? {
     val interpreter = Stdlib.interpreter(this)
@@ -311,6 +316,12 @@ internal inline fun <reified T> String.load(): T {
         "InsertAfter0" -> InsertAfter0()
         "InsertAt" -> InsertAt()
         "Join0" -> Join0()
+        "LeftJoin" -> LeftJoin()
+        "RightJoin" -> RightJoin()
+        "FullJoin" -> FullJoin()
+        "InnerJoin" -> InnerJoin()
+        "ExcludeJoin" -> ExcludeJoin()
+        "FilterJoin" -> FilterJoin()
         "Match0" -> Match0()
         "Rename" -> Rename()
         "RenameMapping" -> RenameMapping()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -111,8 +111,10 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropLast1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropLast2
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DropNa0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ExcludeJoin
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ExcludeJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FillNulls0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FilterJoin
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FilterJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.First2
@@ -122,6 +124,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FrameCols2
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FullJoin
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.FullJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByAdd
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByCount0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByInto
@@ -153,7 +156,10 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupByStdOf
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupBySum0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupBySum1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.GroupBySumOf
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.InnerJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.InsertAt
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.JoinWith
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.LeftJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MapToFrame
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Merge0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.MergeId
@@ -199,6 +205,7 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RenameToCamelCaseClause
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Reorder
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ReorderColumnsByName
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RightJoin
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.RightJoinWith
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Single2
@@ -322,6 +329,13 @@ internal inline fun <reified T> String.load(): T {
         "InnerJoin" -> InnerJoin()
         "ExcludeJoin" -> ExcludeJoin()
         "FilterJoin" -> FilterJoin()
+        "JoinWith" -> JoinWith()
+        "LeftJoinWith" -> LeftJoinWith()
+        "RightJoinWith" -> RightJoinWith()
+        "FullJoinWith" -> FullJoinWith()
+        "InnerJoinWith" -> InnerJoinWith()
+        "ExcludeJoinWith" -> ExcludeJoinWith()
+        "FilterJoinWith" -> FilterJoinWith()
         "Match0" -> Match0()
         "Rename" -> Rename()
         "RenameMapping" -> RenameMapping()

--- a/plugins/kotlin-dataframe/testData/box/joinKinds.kt
+++ b/plugins/kotlin-dataframe/testData/box/joinKinds.kt
@@ -1,0 +1,44 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val typed = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val typed2 = dataFrameOf("name", "origin", "grade", "age")(
+        "Alice", "London", 3, "young",
+        "Alice", "London", 5, "old",
+        "Bob", "Tokyo", 4, "young",
+        "Bob", "Paris", 5, "old",
+        "Charlie", "Moscow", 1, "young",
+        "Charlie", "Moscow", 2, "old",
+        "Bob", "Paris", 4, null,
+    )
+
+    typed.join(typed2) { name and it.city.match(right.origin) }.assert()
+
+    typed.join(typed2, type = JoinType.Inner) { name and it.city.match(right.origin) }.assert()
+
+    typed.innerJoin(typed2) { name and it.city.match(right.origin) }.assert()
+
+    typed.leftJoin(typed2) { name and it.city.match(right.origin) }.assert()
+
+    typed.rightJoin(typed2) { name and it.city.match(right.origin) }.assert()
+
+    typed.fullJoin(typed2) { name and it.city.match(right.origin) }.assert()
+
+    typed.filterJoin(typed2) { city.match(right.origin) }.assert()
+
+    typed.excludeJoin(typed2) { city.match(right.origin) }.assert()
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/joinWithKinds.kt
+++ b/plugins/kotlin-dataframe/testData/box/joinWithKinds.kt
@@ -1,0 +1,44 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val typed = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val typed2 = dataFrameOf("name", "origin", "grade", "age")(
+        "Alice", "London", 3, "young",
+        "Alice", "London", 5, "old",
+        "Bob", "Tokyo", 4, "young",
+        "Bob", "Paris", 5, "old",
+        "Charlie", "Moscow", 1, "young",
+        "Charlie", "Moscow", 2, "old",
+        "Bob", "Paris", 4, null,
+    )
+
+    typed.joinWith(typed2) { name == right.name && city == right.origin }.assert()
+
+    typed.joinWith(typed2, type = JoinType.Inner) { name == right.name && city == right.origin }.assert()
+
+    typed.innerJoinWith(typed2) { name == right.name && city == right.origin }.assert()
+
+    typed.leftJoinWith(typed2) { name == right.name && city == right.origin }.assert()
+
+    typed.rightJoinWith(typed2) { name == right.name && city == right.origin }.assert()
+
+    typed.fullJoinWith(typed2) { name == right.name && city == right.origin }.assert()
+
+    typed.filterJoinWith(typed2) { city == right.origin }.assert()
+
+    typed.excludeJoinWith(typed2) { city == right.origin }.assert()
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/joinWith_duplicateColumnGroups.kt
+++ b/plugins/kotlin-dataframe/testData/box/joinWith_duplicateColumnGroups.kt
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val typed = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val typed2 = dataFrameOf("name", "origin", "grade", "age")(
+        "Alice", "London", 3, "young",
+        "Alice", "London", 5, "old",
+        "Bob", "Tokyo", 4, "young",
+        "Bob", "Paris", 5, "old",
+        "Charlie", "Moscow", 1, "young",
+        "Charlie", "Moscow", 2, "old",
+        "Bob", "Paris", 4, null,
+    )
+
+    val joinWithGroups = typed.group { name and age }.into("gr")
+        .innerJoinWith(typed2.group { origin and age }.into("gr")) { gr.name == right.name }
+
+    // columns from right are duplicated, including groups
+    joinWithGroups.gr1.age
+
+    println(joinWithGroups.schema())
+    joinWithGroups.assert()
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/join_matchColumnGroups.kt
+++ b/plugins/kotlin-dataframe/testData/box/join_matchColumnGroups.kt
@@ -1,0 +1,47 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val typed = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val typed2 = dataFrameOf("name", "origin", "grade", "age")(
+        "Alice", "London", 3, "young",
+        "Alice", "London", 5, "old",
+        "Bob", "Tokyo", 4, "young",
+        "Bob", "Paris", 5, "old",
+        "Charlie", "Moscow", 1, "young",
+        "Charlie", "Moscow", 2, "old",
+        "Bob", "Paris", 4, null,
+    )
+
+    val add2 = typed.group { name and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "i" from { index() }
+            }
+        }
+    }
+    val add3 = typed2.group { origin and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "i" from { index() }
+            }
+        }
+    }
+
+    val joinWithGroups2 = add2.innerJoin(add3) { gr1.match(gr1) }
+
+    joinWithGroups2.assert()
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/join_mergeColumnGroups.kt
+++ b/plugins/kotlin-dataframe/testData/box/join_mergeColumnGroups.kt
@@ -1,0 +1,72 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val typed = dataFrameOf("name", "age", "city", "weight")(
+        "Alice", 15, "London", 54,
+        "Bob", 45, "Dubai", 87,
+        "Charlie", 20, "Moscow", null,
+        "Charlie", 40, "Milan", null,
+        "Bob", 30, "Tokyo", 68,
+        "Alice", 20, null, 55,
+        "Charlie", 30, "Moscow", 90,
+    )
+
+    val typed2 = dataFrameOf("name", "origin", "grade", "age")(
+        "Alice", "London", 3, "young",
+        "Alice", "London", 5, "old",
+        "Bob", "Tokyo", 4, "young",
+        "Bob", "Paris", 5, "old",
+        "Charlie", "Moscow", 1, "young",
+        "Charlie", "Moscow", 2, "old",
+        "Bob", "Paris", 4, null,
+    )
+
+    val joinWithGroups = typed.group { name and age }.into("gr")
+        .innerJoin(typed2.group { origin and age }.into("gr")) { gr.name.match(right.name) }
+
+    println(joinWithGroups.schema())
+    joinWithGroups.assert()
+
+
+    val add = typed.group { name and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "i" from { index() }
+            }
+        }
+    }
+    val add1 = typed2.group { origin and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "a" from { "abc" }
+            }
+        }
+    }
+
+    val joinWithGroups1 = add.innerJoin(add1) { gr.name.match(right.name) }
+
+    println(joinWithGroups1.schema())
+    joinWithGroups1.assert()
+
+    val add2 = typed.group { name and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "i" from { index() }
+            }
+        }
+    }
+    val add3 = typed2.group { origin and age }.into("gr").add {
+        "gr1" {
+            "gr2" {
+                "i" from { index() }
+            }
+        }
+    }
+
+    val joinWithGroups2 = add2.innerJoin(add3) { gr1.match(gr1) }
+    joinWithGroups2.assert()
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/testUtils.kt
+++ b/plugins/kotlin-dataframe/testData/testUtils.kt
@@ -1,8 +1,11 @@
 import org.jetbrains.kotlinx.dataframe.*
 import org.jetbrains.kotlinx.dataframe.annotations.*
 import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.columns.*
 import org.jetbrains.kotlinx.dataframe.io.*
-import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.schema.*
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSubtypeOf
 
 inline fun <reified T> DataFrame<T>.compareSchemas(strict: Boolean = false) {
     val schema = schema()
@@ -54,6 +57,56 @@ fun compare(runtime: DataFrameSchema, schemas: List<DataFrameSchema>, strict: Bo
             schemas.forEachIndexed { i, schema ->
                 appendLine("Compile $i")
                 appendLine(schema.toString())
+            }
+        }
+    }
+}
+
+// Usual DataFrameSchema.compare is either strict comparison where both set of columns and their type must be the same
+// or subtype relation where subset of columns can vary.
+// This checks that schemas have same set of columns, but compile time columns can be nullable where runtime is narrowed to non-nullable
+
+sealed interface Mismatch
+data class AcceptableNullabilityMismatch(val path: ColumnPath, val compile: KType, val runtime: KType) : Mismatch
+data class ErrorMismatch(val message: String) : Mismatch
+
+inline fun <reified T> DataFrame<T>.assert(print: Boolean = false): List<Mismatch> {
+    val mismatches = mutableListOf<Mismatch>()
+    equals(compileTimeSchema(), schema(), mismatches, pathOf())
+    if (print) {
+        println(mismatches.joinToString("\n"))
+    } else if (mismatches.any { it is  ErrorMismatch}) {
+        error(mismatches.joinToString("\n"))
+    }
+    return mismatches
+}
+
+fun equals(compile: DataFrameSchema, runtime: DataFrameSchema, mismatches: MutableList<Mismatch>, path: ColumnPath) {
+    runtime.columns.forEach { name, runtimeColumnSchema ->
+        val compileColumnSchema = compile.columns[name]
+        if (compileColumnSchema == null) error("No column ${name} found in: ${compile.columns.keys.map { path + it }}")
+
+        when (runtimeColumnSchema) {
+            is ColumnSchema.Value -> {
+                if (!runtimeColumnSchema.type.isSubtypeOf(compileColumnSchema.type)) {
+                    mismatches += ErrorMismatch("$name: ${runtimeColumnSchema.type} is not subtype of ${compileColumnSchema.type}")
+                } else if (runtimeColumnSchema.type != compileColumnSchema.type) {
+                    mismatches += AcceptableNullabilityMismatch(path + name, compile = compileColumnSchema.type, runtime = runtimeColumnSchema.type)
+                }
+            }
+            is ColumnSchema.Group -> {
+                if (compileColumnSchema !is ColumnSchema.Group) {
+                    mismatches += ErrorMismatch("$name of ${compileColumnSchema.kind} but Group was expected")
+                } else {
+                    equals(compileColumnSchema.schema, runtimeColumnSchema.schema, mismatches, path + name)
+                }
+            }
+            is ColumnSchema.Frame -> {
+                if (compileColumnSchema !is ColumnSchema.Group) {
+                    mismatches += ErrorMismatch("$name of ${compileColumnSchema.kind} but Frame was expected")
+                } else {
+                    equals(compileColumnSchema.schema, runtimeColumnSchema.schema, mismatches, path + name)
+                }
             }
         }
     }

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -157,8 +157,8 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   @Test
   @TestMetadata("distinct.kt")
   public void testDistinct() {
-        runTest("testData/box/distinct.kt");
-    }
+    runTest("testData/box/distinct.kt");
+  }
 
   @Test
   @TestMetadata("dropNA.kt")
@@ -380,6 +380,18 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   @TestMetadata("joinKinds.kt")
   public void testJoinKinds() {
     runTest("testData/box/joinKinds.kt");
+  }
+
+  @Test
+  @TestMetadata("joinWithKinds.kt")
+  public void testJoinWithKinds() {
+    runTest("testData/box/joinWithKinds.kt");
+  }
+
+  @Test
+  @TestMetadata("joinWith_duplicateColumnGroups.kt")
+  public void testJoinWith_duplicateColumnGroups() {
+    runTest("testData/box/joinWith_duplicateColumnGroups.kt");
   }
 
   @Test

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -377,9 +377,27 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("joinKinds.kt")
+  public void testJoinKinds() {
+    runTest("testData/box/joinKinds.kt");
+  }
+
+  @Test
   @TestMetadata("join_1.kt")
   public void testJoin_1() {
     runTest("testData/box/join_1.kt");
+  }
+
+  @Test
+  @TestMetadata("join_matchColumnGroups.kt")
+  public void testJoin_matchColumnGroups() {
+    runTest("testData/box/join_matchColumnGroups.kt");
+  }
+
+  @Test
+  @TestMetadata("join_mergeColumnGroups.kt")
+  public void testJoin_mergeColumnGroups() {
+    runTest("testData/box/join_mergeColumnGroups.kt");
   }
 
   @Test


### PR DESCRIPTION
In first commit i adapted `ColumnMatch` and `ColumnList` to embed them into compiler plugin column resolving mechanism
New util functions designed to make sure all column names generated by compiler plugin in join are exactly as in runtime, and make sure there are no missing columns. They can however sometimes have nullability where runtime narrows the type to non-nullable