### PR TITLE
Add a constructor to create a nested dataframe from columns inplace

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1387,6 +1387,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConstructorsKt {
 	public static final fun columnGroupTyped (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnAccessor;
 	public static final fun columnOf (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun columnOf (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/columns/FrameColumn;
+	public static final fun columnOf ([Lkotlin/Pair;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnGroup;
 	public static final fun columnOf ([Lorg/jetbrains/kotlinx/dataframe/DataFrame;)Lorg/jetbrains/kotlinx/dataframe/columns/FrameColumn;
 	public static final fun columnOf ([Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public static final fun dataFrameOf (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
@@ -1397,6 +1398,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/ConstructorsKt {
 	public static final fun dataFrameOf ([Lkotlin/Pair;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun dataFrameOf ([Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun dataFrameOf ([Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/api/DataFrameBuilder;
+	public static final fun dataFrameOfColumns ([Lkotlin/Pair;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun emptyDataFrame ()Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun frameColumn ()Lorg/jetbrains/kotlinx/dataframe/api/ColumnDelegate;
 	public static final fun frameColumn (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnAccessor;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
@@ -269,6 +270,15 @@ public inline fun <reified T> column(values: Iterable<T>): DataColumn<T> =
         allColsMakesColGroup = true,
     ).forceResolve()
 
+@Refine
+@Interpretable("ColumnOfPairs")
+public fun columnOf(vararg columns: Pair<String, AnyBaseCol>): ColumnGroup<*> =
+    dataFrameOf(
+        columns.map { (name, col) ->
+            col.rename(name)
+        },
+    ).asColumnGroup()
+
 // endregion
 
 // region create DataFrame
@@ -289,6 +299,12 @@ public fun dataFrameOf(columns: Iterable<AnyBaseCol>): DataFrame<*> {
     val nrow = if (cols.isEmpty()) 0 else cols[0].size
     return DataFrameImpl<Unit>(cols, nrow)
 }
+
+@Refine
+@JvmName("dataFrameOfColumns")
+@Interpretable("DataFrameOfPairs")
+public fun dataFrameOf(vararg columns: Pair<String, AnyBaseCol>): DataFrame<*> =
+    dataFrameOf(columns.map { (name, col) -> col.rename(name) })
 
 public fun dataFrameOf(vararg header: ColumnReference<*>): DataFrameBuilder = DataFrameBuilder(header.map { it.name() })
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Create.kt
@@ -263,6 +263,21 @@ class Create : TestBase() {
 
     @Test
     @TransformDataFrameExpressions
+    fun createNestedDataFrameInplace() {
+        // SampleStart
+        // DataFrame with 2 columns and 3 rows
+        val df = dataFrameOf(
+            "name" to columnOf(
+                "firstName" to columnOf("Alice", "Bob", "Charlie"),
+                "lastName" to columnOf("Cooper", "Dylan", "Daniels"),
+            ),
+            "age" to columnOf(15, 20, 100),
+        )
+        // SampleEnd
+    }
+
+    @Test
+    @TransformDataFrameExpressions
     fun createDataFrameWithFill() {
         // SampleStart
         // Multiplication table

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -1935,6 +1935,21 @@ class DataFrameTests : BaseTest() {
     }
 
     @Test
+    fun `create nested dataframe inplace`() {
+        val df = dataFrameOf(
+            "a" to columnOf("1"),
+            "b" to columnOf(
+                "c" to columnOf("2"),
+            ),
+            "d" to columnOf(dataFrameOf("a")(123)),
+            "gr" to listOf("1").toDataFrame().asColumnGroup(),
+        )
+
+        df.columnNames() shouldBe listOf("a", "b", "d", "gr")
+        df.getColumnGroup("gr")["value"].values() shouldBe listOf("1")
+    }
+
+    @Test
     fun `get typed column by name`() {
         val col = df.getColumn("name").cast<String>()
         col[0].substring(0, 3) shouldBe "Ali"

--- a/docs/StardustDocs/topics/createDataFrame.md
+++ b/docs/StardustDocs/topics/createDataFrame.md
@@ -44,6 +44,23 @@ val df = dataFrameOf(
 
 <!---END-->
 
+Create DataFrame with nested columns inplace:
+
+<!---FUN createNestedDataFrameInplace-->
+
+```kotlin
+// DataFrame with 2 columns and 3 rows
+val df = dataFrameOf(
+    "name" to columnOf(
+        "firstName" to columnOf("Alice", "Bob", "Charlie"),
+        "lastName" to columnOf("Cooper", "Dylan", "Daniels"),
+    ),
+    "age" to columnOf(15, 20, 100),
+)
+```
+
+<!---END-->
+
 <!---FUN createDataFrameFromColumns-->
 
 ```kotlin

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/FunctionCallTransformer.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/FunctionCallTransformer.kt
@@ -101,7 +101,13 @@ class FunctionCallTransformer(
         fun transformOrNull(call: FirFunctionCall, originalSymbol: FirNamedFunctionSymbol): FirFunctionCall?
     }
 
-    private val transformers = listOf(GroupByCallTransformer(), DataFrameCallTransformer(), DataRowCallTransformer())
+    // also update [ReturnTypeBasedReceiverInjector.SCHEMA_TYPES]
+    private val transformers = listOf(
+        GroupByCallTransformer(),
+        DataFrameCallTransformer(),
+        DataRowCallTransformer(),
+        ColumnGroupCallTransformer(),
+    )
 
     override fun intercept(callInfo: CallInfo, symbol: FirNamedFunctionSymbol): CallReturnType? {
         val callSiteAnnotations = (callInfo.callSite as? FirAnnotationContainer)?.annotations ?: emptyList()
@@ -193,6 +199,8 @@ class FunctionCallTransformer(
     inner class DataFrameCallTransformer : CallTransformer by DataSchemaLikeCallTransformer(Names.DF_CLASS_ID)
 
     inner class DataRowCallTransformer : CallTransformer by DataSchemaLikeCallTransformer(Names.DATA_ROW_CLASS_ID)
+
+    inner class ColumnGroupCallTransformer : CallTransformer by DataSchemaLikeCallTransformer(Names.COLUM_GROUP_CLASS_ID)
 
     inner class GroupByCallTransformer : CallTransformer {
         override fun interceptOrNull(

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ReturnTypeBasedReceiverInjector.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ReturnTypeBasedReceiverInjector.kt
@@ -16,10 +16,19 @@ import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
 import org.jetbrains.kotlinx.dataframe.plugin.utils.Names
 
 class ReturnTypeBasedReceiverInjector(session: FirSession) : FirExpressionResolutionExtension(session) {
+    companion object {
+        private val SCHEMA_TYPES = setOf(
+            Names.DF_CLASS_ID,
+            Names.GROUP_BY_CLASS_ID,
+            Names.DATA_ROW_CLASS_ID,
+            Names.COLUM_GROUP_CLASS_ID,
+        )
+    }
+
     @OptIn(SymbolInternals::class)
     override fun addNewImplicitReceivers(functionCall: FirFunctionCall): List<ConeKotlinType> {
         val callReturnType = functionCall.resolvedType
-        return if (callReturnType.classId in setOf(Names.DF_CLASS_ID, Names.GROUP_BY_CLASS_ID, Names.DATA_ROW_CLASS_ID)) {
+        return if (callReturnType.classId in SCHEMA_TYPES) {
             val typeArguments = callReturnType.typeArguments
             typeArguments
                 .mapNotNull {

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/loadInterpreter.kt
@@ -96,11 +96,13 @@ import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColsAtAnyDepth2
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColsOf0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColsOf1
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColsOf2
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColumnOfPairs
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ColumnRange
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.ConcatWithKeys
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameBuilderInvoke0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameOf0
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameOf3
+import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameOfPairs
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameUnfold
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.DataFrameXs
 import org.jetbrains.kotlinx.dataframe.plugin.impl.api.Drop0
@@ -409,6 +411,8 @@ internal inline fun <reified T> String.load(): T {
         "toDataFrameDefault" -> ToDataFrameDefault()
         "ToDataFrameDslStringInvoke" -> ToDataFrameDslStringInvoke()
         "DataFrameOf0" -> DataFrameOf0()
+        "DataFrameOfPairs" -> DataFrameOfPairs()
+        "ColumnOfPairs" -> ColumnOfPairs()
         "DataFrameBuilderInvoke0" -> DataFrameBuilderInvoke0()
         "ToDataFrameColumn" -> ToDataFrameColumn()
         "FillNulls0" -> FillNulls0()

--- a/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
+++ b/plugins/kotlin-dataframe/src/org/jetbrains/kotlinx/dataframe/plugin/utils/Names.kt
@@ -31,10 +31,17 @@ object Names {
 
     val COLUM_GROUP_CLASS_ID: ClassId
         get() = ClassId(FqName("org.jetbrains.kotlinx.dataframe.columns"), Name.identifier("ColumnGroup"))
+    val FRAME_COLUMN_CLASS_ID: ClassId
+        get() = ClassId(FqName("org.jetbrains.kotlinx.dataframe.columns"), Name.identifier("FrameColumn"))
     val DATA_COLUMN_CLASS_ID: ClassId
         get() = ClassId(
             FqName.fromSegments(listOf("org", "jetbrains", "kotlinx", "dataframe")),
             Name.identifier("DataColumn")
+        )
+    val BASE_COLUMN_CLASS_ID: ClassId
+        get() = ClassId(
+            FqName.fromSegments(listOf("org", "jetbrains", "kotlinx", "dataframe", "columns")),
+            Name.identifier("BaseColumn")
         )
     val COLUMNS_CONTAINER_CLASS_ID: ClassId
         get() = ClassId(

--- a/plugins/kotlin-dataframe/testData/box/columnOf_nested.kt
+++ b/plugins/kotlin-dataframe/testData/box/columnOf_nested.kt
@@ -1,0 +1,15 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val group = columnOf(
+        "c" to columnOf("2"),
+        "d" to columnOf(123),
+    )
+    val str: DataColumn<String> = group.c
+    val i: DataColumn<Int> = group.d
+
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/testData/box/dataFrameOf_nested.kt
+++ b/plugins/kotlin-dataframe/testData/box/dataFrameOf_nested.kt
@@ -1,0 +1,20 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = dataFrameOf(
+        "a" to columnOf("1"),
+        "b" to columnOf(
+            "c" to columnOf("2"),
+        ),
+        "d" to columnOf(dataFrameOf("a")(123)),
+        "gr" to listOf("1").toDataFrame().asColumnGroup(),
+    )
+    val str: DataColumn<String> = df.a
+    val str1: DataColumn<String> = df.b.c
+    val i: DataColumn<Int> = df.d[0].a
+    val str2: DataColumn<String> = df.gr.value
+    return "OK"
+}

--- a/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
+++ b/plugins/kotlin-dataframe/tests-gen/org/jetbrains/kotlin/fir/dataframe/DataFrameBlackBoxCodegenTestGenerated.java
@@ -77,6 +77,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   }
 
   @Test
+  @TestMetadata("columnOf_nested.kt")
+  public void testColumnOf_nested() {
+    runTest("testData/box/columnOf_nested.kt");
+  }
+
+  @Test
   @TestMetadata("columnWithStarProjection.kt")
   public void testColumnWithStarProjection() {
     runTest("testData/box/columnWithStarProjection.kt");
@@ -116,6 +122,12 @@ public class DataFrameBlackBoxCodegenTestGenerated extends AbstractDataFrameBlac
   @TestMetadata("dataFrameOf.kt")
   public void testDataFrameOf() {
     runTest("testData/box/dataFrameOf.kt");
+  }
+
+  @Test
+  @TestMetadata("dataFrameOf_nested.kt")
+  public void testDataFrameOf_nested() {
+    runTest("testData/box/dataFrameOf_nested.kt");
   }
 
   @Test


### PR DESCRIPTION
I believe it will be a very useful addition for samples, simplifies many of our existing examples that use dataFrameOf(vararg columns: AnyBaseCol) + variables (see the issue) and more robust compiler plugin support
https://github.com/Kotlin/dataframe/issues/353. We need it to migrate our docs before 1.0

Another example here: 
https://github.com/Kotlin/dataframe/blob/a0c1a185c43c95f648367b24a90c4e2c10492b3f/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/TestBase.kt#L57