### PR TITLE
Percentile

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3486,63 +3486,108 @@ public final class org/jetbrains/kotlinx/dataframe/api/ParserOptions {
 
 public final class org/jetbrains/kotlinx/dataframe/api/PercentileKt {
 	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Ljava/lang/Comparable;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataColumn;DZ)D
 	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLkotlin/jvm/functions/Function2;)Ljava/lang/Comparable;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;)D
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;Z)Ljava/lang/Object;
 	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;)Ljava/lang/Comparable;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;Z)D
 	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Ljava/lang/Comparable;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DLjava/lang/String;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DLjava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)D
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DLjava/lang/String;ZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentile (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataColumn;DZILjava/lang/Object;)D
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)D
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)D
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)D
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DLjava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentile$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileBy (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLjava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileBy (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;DLjava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/api/ReducedGroupBy;
+	public static final fun percentileBy (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DLjava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/api/ReducedPivot;
+	public static final fun percentileBy (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DLjava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/api/ReducedPivotGroupBy;
+	public static synthetic fun percentileBy$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLjava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileBy$default (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;DLjava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/ReducedGroupBy;
+	public static synthetic fun percentileBy$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DLjava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/ReducedPivot;
+	public static synthetic fun percentileBy$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DLjava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/ReducedPivotGroupBy;
+	public static final fun percentileByOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLjava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileByOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLjava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun percentileFor (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZZ)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Grouped;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;DZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Ljava/lang/String;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lkotlin/reflect/KProperty;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/Pivot;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataRow;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;DZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Ljava/lang/String;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lkotlin/reflect/KProperty;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static synthetic fun percentileFor$default (Lorg/jetbrains/kotlinx/dataframe/api/PivotGroupBy;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataColumn;D)Ljava/lang/Comparable;
+	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataColumn;DZ)Ljava/lang/Double;
 	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DLkotlin/jvm/functions/Function2;)Ljava/lang/Comparable;
-	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;)Ljava/lang/Double;
+	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;Z)Ljava/lang/Object;
 	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;)Ljava/lang/Comparable;
+	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;Z)Ljava/lang/Double;
 	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Ljava/lang/Comparable;
-	public static final fun rowPercentile (Lorg/jetbrains/kotlinx/dataframe/DataRow;D)Ljava/lang/Object;
-	public static final fun rowPercentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataRow;D)Ljava/lang/Object;
+	public static final fun percentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Z)Ljava/lang/Double;
+	public static synthetic fun percentileOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataColumn;DZILjava/lang/Object;)Ljava/lang/Double;
+	public static synthetic fun percentileOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;DZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Double;
+	public static synthetic fun percentileOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun percentileOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)Ljava/lang/Double;
+	public static synthetic fun percentileOrNull$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;D[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;ZILjava/lang/Object;)Ljava/lang/Double;
+	public static final fun rowPercentile (Lorg/jetbrains/kotlinx/dataframe/DataRow;)Ljava/lang/Void;
+	public static final fun rowPercentileOrNull (Lorg/jetbrains/kotlinx/dataframe/DataRow;)Ljava/lang/Void;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/Pivot : org/jetbrains/kotlinx/dataframe/aggregation/Aggregatable {
@@ -5577,7 +5622,6 @@ public final class org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/
 public final class org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators {
 	public static final field INSTANCE Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators;
 	public final fun getMean ()Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/AggregatorOptionSwitch1;
-	public final fun getPercentile ()Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/AggregatorOptionSwitch1;
 	public final fun getStd ()Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/AggregatorOptionSwitch2;
 	public final fun getSum ()Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/AggregatorOptionSwitch1;
 	public final fun max (Z)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
@@ -5585,6 +5629,9 @@ public final class org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/
 	public final fun medianComparables ()Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
 	public final fun medianNumbers (Z)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
 	public final fun min (Z)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
+	public final fun percentileCommon (DZ)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
+	public final fun percentileComparables (D)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
+	public final fun percentileNumbers (DZ)Lorg/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregator;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/aggregation/modes/NoAggregationKt {
@@ -6545,8 +6592,7 @@ public final class org/jetbrains/kotlinx/dataframe/math/MinMaxKt {
 	public static final fun minOrNull (Lkotlin/sequences/Sequence;Lkotlin/reflect/KType;Z)Ljava/lang/Comparable;
 }
 
-public final class org/jetbrains/kotlinx/dataframe/math/PercentileKt {
-	public static final fun percentile (Ljava/lang/Iterable;DLkotlin/reflect/KType;)Ljava/lang/Comparable;
+public final class org/jetbrains/kotlinx/dataframe/math/QuantileKt {
 	public static final fun quickSelect (Ljava/util/List;I)Ljava/lang/Comparable;
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     kotlinCompilerPluginClasspathSamples(projects.plugins.expressionsConverter)
 
     api(libs.commonsCsv)
+
     implementation(libs.commonsIo)
     implementation(libs.serialization.core)
     implementation(libs.serialization.json)
@@ -81,6 +82,9 @@ dependencies {
     testImplementation(libs.kotlin.scriptingJvm)
     testImplementation(libs.jsoup)
     testImplementation(libs.sl4jsimple)
+
+    // for checking results
+    testImplementation(libs.commonsStatisticsDescriptive)
 
     // for samples.api
     testImplementation(projects.dataframeCsv)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
@@ -38,6 +38,8 @@ import kotlin.reflect.KProperty
  *  This needs to be explained by KDocs
  *
  * medianBy is new for all overloads :)
+ * Uses [QuantileEstimationMethod.R8] for primitive numbers, else [QuantileEstimationMethod.R3].
+ * MedianBy also uses [QuantileEstimationMethod.R3].
  */
 
 // region DataColumn

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -28,12 +28,12 @@ public fun <T : Comparable<T>> DataColumn<T?>.percentile(percentile: Double): T 
     percentileOrNull(percentile).suggestIfNull("percentile")
 
 public fun <T : Comparable<T>> DataColumn<T?>.percentileOrNull(percentile: Double): T? =
-    Aggregators.percentile(percentile).cast<T>().aggregateSingleColumn(this)
+    Aggregators.oldPercentile(percentile).cast<T>().aggregateSingleColumn(this)
 
 public inline fun <T, reified R : Comparable<R>> DataColumn<T>.percentileOfOrNull(
     percentile: Double,
     noinline expression: (T) -> R?,
-): R? = Aggregators.percentile(percentile).cast<R?>().aggregateOf(this, expression)
+): R? = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, expression)
 
 public inline fun <T, reified R : Comparable<R>> DataColumn<T>.percentileOf(
     percentile: Double,
@@ -45,7 +45,7 @@ public inline fun <T, reified R : Comparable<R>> DataColumn<T>.percentileOf(
 // region DataRow
 
 public fun AnyRow.rowPercentileOrNull(percentile: Double): Any? =
-    Aggregators.percentile(percentile).aggregateSingleColumn(
+    Aggregators.oldPercentile(percentile).aggregateSingleColumn(
         values().filterIsInstance<Comparable<Any?>>().toValueColumn(),
     )
 
@@ -68,7 +68,7 @@ public fun <T> DataFrame<T>.percentile(percentile: Double): DataRow<T> =
 public fun <T, C : Comparable<C>> DataFrame<T>.percentileFor(
     percentile: Double,
     columns: ColumnsForAggregateSelector<T, C?>,
-): DataRow<T> = Aggregators.percentile(percentile).aggregateFor(this, columns)
+): DataRow<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, columns)
 
 public fun <T> DataFrame<T>.percentileFor(percentile: Double, vararg columns: String): DataRow<T> =
     percentileFor(percentile) { columns.toComparableColumns() }
@@ -103,7 +103,7 @@ public fun <T, C : Comparable<C>> DataFrame<T>.percentile(percentile: Double, va
 public fun <T, C : Comparable<C>> DataFrame<T>.percentileOrNull(
     percentile: Double,
     columns: ColumnsSelector<T, C?>,
-): C? = Aggregators.percentile(percentile).aggregateAll(this, columns) as C?
+): C? = Aggregators.oldPercentile(percentile).aggregateAll(this, columns) as C?
 
 public fun <T> DataFrame<T>.percentileOrNull(percentile: Double, vararg columns: String): Any? =
     percentileOrNull(percentile) { columns.toComparableColumns() }
@@ -121,7 +121,7 @@ public fun <T, C : Comparable<C>> DataFrame<T>.percentileOrNull(percentile: Doub
 public inline fun <T, reified R : Comparable<R>> DataFrame<T>.percentileOf(
     percentile: Double,
     crossinline expression: RowExpression<T, R?>,
-): R? = Aggregators.percentile(percentile).aggregateOf(this, expression) as R?
+): R? = Aggregators.oldPercentile(percentile).aggregateOf(this, expression) as R?
 
 // endregion
 
@@ -133,7 +133,7 @@ public fun <T> Grouped<T>.percentile(percentile: Double): DataFrame<T> =
 public fun <T, C : Comparable<C>> Grouped<T>.percentileFor(
     percentile: Double,
     columns: ColumnsForAggregateSelector<T, C?>,
-): DataFrame<T> = Aggregators.percentile(percentile).aggregateFor(this, columns)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, columns)
 
 public fun <T> Grouped<T>.percentileFor(percentile: Double, vararg columns: String): DataFrame<T> =
     percentileFor(percentile) { columns.toComparableColumns() }
@@ -154,7 +154,7 @@ public fun <T, C : Comparable<C>> Grouped<T>.percentile(
     percentile: Double,
     name: String? = null,
     columns: ColumnsSelector<T, C?>,
-): DataFrame<T> = Aggregators.percentile(percentile).aggregateAll(this, name, columns)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateAll(this, name, columns)
 
 public fun <T> Grouped<T>.percentile(percentile: Double, vararg columns: String, name: String? = null): DataFrame<T> =
     percentile(percentile, name) { columns.toComparableColumns() }
@@ -177,7 +177,7 @@ public inline fun <T, reified R : Comparable<R>> Grouped<T>.percentileOf(
     percentile: Double,
     name: String? = null,
     crossinline expression: RowExpression<T, R?>,
-): DataFrame<T> = Aggregators.percentile(percentile).cast<R?>().aggregateOf(this, name, expression)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, name, expression)
 
 // endregion
 
@@ -244,7 +244,7 @@ public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentileFor(
     percentile: Double,
     separate: Boolean = false,
     columns: ColumnsForAggregateSelector<T, C?>,
-): DataFrame<T> = Aggregators.percentile(percentile).aggregateFor(this, separate, columns)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, separate, columns)
 
 public fun <T> PivotGroupBy<T>.percentileFor(
     percentile: Double,
@@ -269,7 +269,7 @@ public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentileFor(
 public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentile(
     percentile: Double,
     columns: ColumnsSelector<T, C?>,
-): DataFrame<T> = Aggregators.percentile(percentile).aggregateAll(this, columns)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateAll(this, columns)
 
 public fun <T> PivotGroupBy<T>.percentile(percentile: Double, vararg columns: String): DataFrame<T> =
     percentile(percentile) { columns.toComparableColumns() }
@@ -289,6 +289,6 @@ public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentile(
 public inline fun <T, reified R : Comparable<R>> PivotGroupBy<T>.percentileOf(
     percentile: Double,
     crossinline expression: RowExpression<T, R?>,
-): DataFrame<T> = Aggregators.percentile(percentile).cast<R?>().aggregateOf(this, expression)
+): DataFrame<T> = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, expression)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -38,6 +38,9 @@ import kotlin.reflect.KProperty
  *  This needs to be explained by KDocs
  *
  * percentileBy is new for all overloads :)
+ *
+ * Uses [QuantileEstimationMethod.R8] for primitive numbers, else [QuantileEstimationMethod.R3].
+ * PercentileBy also uses [QuantileEstimationMethod.R3].
  */
 
 // region DataColumn

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTypeInference::class)
+
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyRow
@@ -8,287 +10,652 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
+import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators
-import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.cast
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.intraComparableColumns
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateAll
+import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateByOrNull
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateFor
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOf
+import org.jetbrains.kotlinx.dataframe.impl.aggregation.modes.aggregateOfRow
 import org.jetbrains.kotlinx.dataframe.impl.columns.toComparableColumns
 import org.jetbrains.kotlinx.dataframe.impl.suggestIfNull
-import org.jetbrains.kotlinx.dataframe.math.percentile
+import org.jetbrains.kotlinx.dataframe.util.ROW_PERCENTILE
+import org.jetbrains.kotlinx.dataframe.util.ROW_PERCENTILE_OR_NULL
+import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KProperty
-import kotlin.reflect.typeOf
+
+/* TODO KDocs
+ * numbers -> Double or null
+ * comparable -> itself or null
+ *
+ * TODO cases where the lambda dictates the return type require explicit type arguments for
+ *  non-number, comparable overloads: https://youtrack.jetbrains.com/issue/KT-76683
+ *  so, `df.percentile { intCol }` works, but needs `df.percentile<_, String> { stringCol }` or `df.percentile({ dateCol })`
+ *  This needs to be explained by KDocs
+ *
+ * percentileBy is new for all overloads :)
+ */
 
 // region DataColumn
 
-public fun <T : Comparable<T>> DataColumn<T?>.percentile(percentile: Double): T =
+public fun <T : Comparable<T & Any>?> DataColumn<T>.percentile(percentile: Double): T & Any =
     percentileOrNull(percentile).suggestIfNull("percentile")
 
-public fun <T : Comparable<T>> DataColumn<T?>.percentileOrNull(percentile: Double): T? =
-    Aggregators.oldPercentile(percentile).cast<T>().aggregateSingleColumn(this)
+public fun <T : Comparable<T & Any>?> DataColumn<T>.percentileOrNull(percentile: Double): T? =
+    Aggregators.percentileComparables<T>(percentile).aggregateSingleColumn(this)
 
-public inline fun <T, reified R : Comparable<R>> DataColumn<T>.percentileOfOrNull(
+public fun <T> DataColumn<T>.percentile(
     percentile: Double,
-    noinline expression: (T) -> R?,
-): R? = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, expression)
+    skipNaN: Boolean = skipNaNDefault,
+): Double
+    where T : Comparable<T & Any>?, T : Number? =
+    percentileOrNull(percentile = percentile, skipNaN = skipNaN).suggestIfNull("percentile")
 
-public inline fun <T, reified R : Comparable<R>> DataColumn<T>.percentileOf(
+public fun <T> DataColumn<T>.percentileOrNull(
     percentile: Double,
-    noinline expression: (T) -> R?,
-): R = percentileOfOrNull(percentile, expression).suggestIfNull("percentileOf")
+    skipNaN: Boolean = skipNaNDefault,
+): Double?
+    where T : Comparable<T & Any>?, T : Number? =
+    Aggregators.percentileNumbers<T>(percentile, skipNaN).aggregateSingleColumn(this)
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.percentileBy(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline selector: (T) -> R,
+): T & Any = percentileByOrNull(percentile, skipNaN, selector).suggestIfNull("percentileBy")
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.percentileByOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline selector: (T) -> R,
+): T? = Aggregators.percentileCommon<R>(percentile, skipNaN).aggregateByOrNull(this, selector)
+
+// TODO, requires explicit type R due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.percentileOf(
+    percentile: Double,
+    crossinline expression: (T) -> R,
+): R & Any = percentileOfOrNull(percentile, expression).suggestIfNull("percentileOf")
+
+// TODO, requires explicit type R due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.percentileOfOrNull(
+    percentile: Double,
+    crossinline expression: (T) -> R,
+): R? = Aggregators.percentileComparables<R>(percentile).aggregateOf(this, expression)
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R> DataColumn<T>.percentileOf(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: (T) -> R,
+): Double
+    where R : Comparable<R & Any>?, R : Number? =
+    percentileOfOrNull(percentile, skipNaN, expression).suggestIfNull("percentileOf")
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R> DataColumn<T>.percentileOfOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: (T) -> R,
+): Double?
+    where R : Comparable<R & Any>?, R : Number? =
+    Aggregators.percentileNumbers<R>(percentile, skipNaN).aggregateOf(this, expression)
 
 // endregion
 
 // region DataRow
 
-public fun AnyRow.rowPercentileOrNull(percentile: Double): Any? =
-    Aggregators.oldPercentile(percentile).aggregateSingleColumn(
-        values().filterIsInstance<Comparable<Any?>>().toValueColumn(),
-    )
+@Deprecated(ROW_PERCENTILE_OR_NULL, level = DeprecationLevel.ERROR)
+public fun AnyRow.rowPercentileOrNull(): Nothing? = error(ROW_PERCENTILE_OR_NULL)
 
-public fun AnyRow.rowPercentile(percentile: Double): Any =
-    rowPercentileOrNull(percentile).suggestIfNull("rowPercentile")
+@Deprecated(ROW_PERCENTILE, level = DeprecationLevel.ERROR)
+public fun AnyRow.rowPercentile(): Nothing = error(ROW_PERCENTILE)
 
 public inline fun <reified T : Comparable<T>> AnyRow.rowPercentileOfOrNull(percentile: Double): T? =
-    valuesOf<T>().percentile(percentile, typeOf<T>())
+    Aggregators.percentileComparables<T>(percentile).aggregateOfRow(this) { colsOf<T?>() }
 
 public inline fun <reified T : Comparable<T>> AnyRow.rowPercentileOf(percentile: Double): T =
     rowPercentileOfOrNull<T>(percentile).suggestIfNull("rowPercentileOf")
+
+public inline fun <reified T> AnyRow.rowPercentileOfOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+): Double?
+    where T : Comparable<T>, T : Number =
+    Aggregators.percentileNumbers<T>(percentile, skipNaN).aggregateOfRow(this) { colsOf<T?>() }
+
+public inline fun <reified T> AnyRow.rowPercentileOf(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+): Double
+    where T : Comparable<T>, T : Number =
+    rowPercentileOfOrNull<T>(percentile, skipNaN).suggestIfNull("rowPercentileOf")
 
 // endregion
 
 // region DataFrame
 
-public fun <T> DataFrame<T>.percentile(percentile: Double): DataRow<T> =
-    percentileFor(percentile, intraComparableColumns())
+public fun <T> DataFrame<T>.percentile(percentile: Double, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
+    percentileFor(percentile, skipNaN, intraComparableColumns())
 
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileFor(
     percentile: Double,
-    columns: ColumnsForAggregateSelector<T, C?>,
-): DataRow<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, columns)
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsForAggregateSelector<T, C>,
+): DataRow<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateFor(this, columns)
 
-public fun <T> DataFrame<T>.percentileFor(percentile: Double, vararg columns: String): DataRow<T> =
-    percentileFor(percentile) { columns.toComparableColumns() }
-
-@AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileFor(
+public fun <T> DataFrame<T>.percentileFor(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
-): DataRow<T> = percentileFor(percentile) { columns.toColumnSet() }
+    vararg columns: String,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileFor(
     percentile: Double,
-    vararg columns: KProperty<C?>,
-): DataRow<T> = percentileFor(percentile) { columns.toColumnSet() }
-
-public fun <T, C : Comparable<C>> DataFrame<T>.percentile(percentile: Double, columns: ColumnsSelector<T, C?>): C =
-    percentileOrNull(percentile, columns).suggestIfNull("percentile")
-
-public fun <T> DataFrame<T>.percentile(percentile: Double, vararg columns: String): Any =
-    percentile(percentile) { columns.toComparableColumns() }
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentile(percentile: Double, vararg columns: ColumnReference<C?>): C =
-    percentile(percentile) { columns.toColumnSet() }
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileFor(
+    percentile: Double,
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, skipNaN) { columns.toColumnSet() }
 
-@AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentile(percentile: Double, vararg columns: KProperty<C?>): C =
-    percentile(percentile) { columns.toColumnSet() }
+// TODO, requires explicit type C due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentile(
+    percentile: Double,
+    columns: ColumnsSelector<T, C>,
+): C & Any = percentileOrNull(percentile, columns).suggestIfNull("percentile")
 
+// TODO, requires explicit type C due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
 @Suppress("UNCHECKED_CAST")
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileOrNull(
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileOrNull(
     percentile: Double,
-    columns: ColumnsSelector<T, C?>,
-): C? = Aggregators.oldPercentile(percentile).aggregateAll(this, columns) as C?
+    columns: ColumnsSelector<T, C>,
+): C? = Aggregators.percentileComparables<C>(percentile).aggregateAll(this, columns)
 
-public fun <T> DataFrame<T>.percentileOrNull(percentile: Double, vararg columns: String): Any? =
-    percentileOrNull(percentile) { columns.toComparableColumns() }
+@OverloadResolutionByLambdaReturnType
+public fun <T, C> DataFrame<T>.percentile(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsSelector<T, C>,
+): Double
+    where C : Number?, C : Comparable<C & Any>? =
+    percentileOrNull(percentile, skipNaN, columns).suggestIfNull("percentile")
+
+@OverloadResolutionByLambdaReturnType
+@Suppress("UNCHECKED_CAST")
+public fun <T, C> DataFrame<T>.percentileOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsSelector<T, C>,
+): Double?
+    where C : Comparable<C & Any>?, C : Number? =
+    Aggregators.percentileNumbers<C>(percentile, skipNaN).aggregateAll(this, columns)
+
+public fun <T> DataFrame<T>.percentile(
+    percentile: Double,
+    vararg columns: String,
+    skipNaN: Boolean = skipNaNDefault,
+): Any = percentileOrNull(percentile, *columns, skipNaN = skipNaN).suggestIfNull("percentile")
+
+public fun <T> DataFrame<T>.percentileOrNull(
+    percentile: Double,
+    vararg columns: String,
+    skipNaN: Boolean = skipNaNDefault,
+): Any? =
+    Aggregators.percentileCommon<Comparable<Any>?>(percentile, skipNaN).aggregateAll(this) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileOrNull(
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentile(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
-): C? = percentileOrNull(percentile) { columns.toColumnSet() }
+    vararg columns: ColumnReference<C>,
+): C & Any = percentileOrNull(percentile, *columns).suggestIfNull("percentile")
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> DataFrame<T>.percentileOrNull(percentile: Double, vararg columns: KProperty<C?>): C? =
-    percentileOrNull(percentile) { columns.toColumnSet() }
-
-public inline fun <T, reified R : Comparable<R>> DataFrame<T>.percentileOf(
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileOrNull(
     percentile: Double,
-    crossinline expression: RowExpression<T, R?>,
-): R? = Aggregators.oldPercentile(percentile).aggregateOf(this, expression) as R?
+    vararg columns: ColumnReference<C>,
+): C? = percentileOrNull<T, C>(percentile) { columns.toColumnSet() }
+
+@AccessApiOverload
+public fun <T, C> DataFrame<T>.percentile(
+    percentile: Double,
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): Double
+    where C : Comparable<C & Any>?, C : Number? =
+    percentileOrNull(percentile, *columns, skipNaN = skipNaN).suggestIfNull("percentile")
+
+@AccessApiOverload
+public fun <T, C> DataFrame<T>.percentileOrNull(
+    percentile: Double,
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): Double?
+    where C : Comparable<C & Any>?, C : Number? =
+    percentileOrNull(percentile, skipNaN) { columns.toColumnSet() }
+
+@AccessApiOverload
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentile(
+    percentile: Double,
+    vararg columns: KProperty<C>,
+): C & Any = percentileOrNull(percentile, *columns).suggestIfNull("percentile")
+
+@AccessApiOverload
+public fun <T, C : Comparable<C & Any>?> DataFrame<T>.percentileOrNull(
+    percentile: Double,
+    vararg columns: KProperty<C>,
+): C? = percentileOrNull<T, C>(percentile) { columns.toColumnSet() }
+
+@AccessApiOverload
+public fun <T, C> DataFrame<T>.percentile(
+    percentile: Double,
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): Double
+    where C : Comparable<C & Any>?, C : Number? =
+    percentileOrNull(percentile, *columns, skipNaN = skipNaN).suggestIfNull("percentile")
+
+@AccessApiOverload
+public fun <T, C> DataFrame<T>.percentileOrNull(
+    percentile: Double,
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): Double?
+    where C : Comparable<C & Any>?, C : Number? =
+    percentileOrNull(percentile, skipNaN) { columns.toColumnSet() }
+
+// TODO, requires explicit type R due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataFrame<T>.percentileOf(
+    percentile: Double,
+    crossinline expression: RowExpression<T, R>,
+): R & Any = percentileOfOrNull(percentile, expression).suggestIfNull("percentileOf")
+
+// TODO, requires explicit type R due to https://youtrack.jetbrains.com/issue/KT-76683
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R : Comparable<R & Any>?> DataFrame<T>.percentileOfOrNull(
+    percentile: Double,
+    crossinline expression: RowExpression<T, R>,
+): R? = Aggregators.percentileComparables<R>(percentile).aggregateOf(this, expression)
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R> DataFrame<T>.percentileOf(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, R>,
+): Double
+    where R : Comparable<R & Any>?, R : Number? =
+    percentileOfOrNull(percentile, skipNaN, expression).suggestIfNull("percentileOf")
+
+@OverloadResolutionByLambdaReturnType
+public inline fun <T, reified R> DataFrame<T>.percentileOfOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, R>,
+): Double?
+    where R : Comparable<R & Any>?, R : Number? =
+    Aggregators.percentileNumbers<R>(percentile, skipNaN).aggregateOf(this, expression)
+
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileBy(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, C>,
+): DataRow<T> = percentileByOrNull(percentile, skipNaN, expression).suggestIfNull("percentileBy")
+
+public fun <T> DataFrame<T>.percentileBy(
+    percentile: Double,
+    column: String,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileByOrNull(percentile, column, skipNaN).suggestIfNull("percentileBy")
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileBy(
+    percentile: Double,
+    column: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileByOrNull(percentile, column, skipNaN).suggestIfNull("percentileBy")
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileBy(
+    percentile: Double,
+    column: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileByOrNull(percentile, column, skipNaN).suggestIfNull("percentileBy")
+
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileByOrNull(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, C>,
+): DataRow<T>? = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateByOrNull(this, expression)
+
+public fun <T> DataFrame<T>.percentileByOrNull(
+    percentile: Double,
+    column: String,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T>? = percentileByOrNull(percentile, column.toColumnOf<Comparable<Any>?>(), skipNaN)
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileByOrNull(
+    percentile: Double,
+    column: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T>? = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateByOrNull(this, column)
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.percentileByOrNull(
+    percentile: Double,
+    column: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T>? = percentileByOrNull(percentile, column.toColumnAccessor(), skipNaN)
 
 // endregion
 
 // region GroupBy
+@Refine
+@Interpretable("GroupByPercentile1")
+public fun <T> Grouped<T>.percentile(percentile: Double, skipNaN: Boolean = skipNaNDefault): DataFrame<T> =
+    percentileFor(percentile, skipNaN, intraComparableColumns())
 
-public fun <T> Grouped<T>.percentile(percentile: Double): DataFrame<T> =
-    percentileFor(percentile, intraComparableColumns())
-
-public fun <T, C : Comparable<C>> Grouped<T>.percentileFor(
+@Refine
+@Interpretable("GroupByPercentile0")
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentileFor(
     percentile: Double,
-    columns: ColumnsForAggregateSelector<T, C?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, columns)
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsForAggregateSelector<T, C>,
+): DataFrame<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateFor(this, columns)
 
 public fun <T> Grouped<T>.percentileFor(percentile: Double, vararg columns: String): DataFrame<T> =
     percentileFor(percentile) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Grouped<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentileFor(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
-): DataFrame<T> = percentileFor(percentile) { columns.toColumnSet() }
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Grouped<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentileFor(
     percentile: Double,
-    vararg columns: KProperty<C?>,
-): DataFrame<T> = percentileFor(percentile) { columns.toColumnSet() }
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, skipNaN) { columns.toColumnSet() }
 
-public fun <T, C : Comparable<C>> Grouped<T>.percentile(
+@Refine
+@Interpretable("GroupByPercentile0")
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentile(
     percentile: Double,
     name: String? = null,
-    columns: ColumnsSelector<T, C?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateAll(this, name, columns)
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsSelector<T, C>,
+): DataFrame<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateAll(this, name, columns)
 
-public fun <T> Grouped<T>.percentile(percentile: Double, vararg columns: String, name: String? = null): DataFrame<T> =
-    percentile(percentile, name) { columns.toComparableColumns() }
+public fun <T> Grouped<T>.percentile(
+    percentile: Double,
+    vararg columns: String,
+    name: String? = null,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, name, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Grouped<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentile(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
+    vararg columns: ColumnReference<C>,
     name: String? = null,
-): DataFrame<T> = percentile(percentile, name) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, name, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Grouped<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentile(
     percentile: Double,
-    vararg columns: KProperty<C?>,
+    vararg columns: KProperty<C>,
     name: String? = null,
-): DataFrame<T> = percentile(percentile, name) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, name, skipNaN) { columns.toColumnSet() }
 
-public inline fun <T, reified R : Comparable<R>> Grouped<T>.percentileOf(
+@Refine
+@Interpretable("GroupByPercentileOf")
+public inline fun <T, reified R : Comparable<R & Any>?> Grouped<T>.percentileOf(
     percentile: Double,
     name: String? = null,
-    crossinline expression: RowExpression<T, R?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, name, expression)
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, R>,
+): DataFrame<T> = Aggregators.percentileCommon<R>(percentile, skipNaN).aggregateOf(this, name, expression)
+
+@Interpretable("GroupByReduceExpression") // TODO?
+public inline fun <T, G, reified R : Comparable<R & Any>?> GroupBy<T, G>.percentileBy(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline rowExpression: RowExpression<G, R>,
+): ReducedGroupBy<T, G> = reduce { percentileByOrNull(percentile, skipNaN, rowExpression) }
+
+@AccessApiOverload
+public inline fun <T, G, reified C : Comparable<C & Any>?> GroupBy<T, G>.percentileBy(
+    percentile: Double,
+    column: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedGroupBy<T, G> = reduce { percentileByOrNull(percentile, column, skipNaN) }
+
+public fun <T, G> GroupBy<T, G>.percentileBy(
+    percentile: Double,
+    column: String,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedGroupBy<T, G> = percentileBy(percentile, column.toColumnAccessor().cast<Comparable<Any>?>(), skipNaN)
+
+@AccessApiOverload
+public inline fun <T, G, reified C : Comparable<C & Any>?> GroupBy<T, G>.percentileBy(
+    percentile: Double,
+    column: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedGroupBy<T, G> = percentileBy(percentile, column.toColumnAccessor(), skipNaN)
 
 // endregion
 
 // region Pivot
 
-public fun <T> Pivot<T>.percentile(percentile: Double, separate: Boolean = false): DataRow<T> =
-    percentileFor(percentile, separate, intraComparableColumns())
-
-public fun <T, C : Comparable<C>> Pivot<T>.percentileFor(
+public fun <T> Pivot<T>.percentile(
     percentile: Double,
     separate: Boolean = false,
-    columns: ColumnsForAggregateSelector<T, C?>,
-): DataRow<T> = delegate { percentileFor(percentile, separate, columns) }
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, separate, skipNaN, intraComparableColumns())
+
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentileFor(
+    percentile: Double,
+    separate: Boolean = false,
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsForAggregateSelector<T, C>,
+): DataRow<T> = delegate { percentileFor(percentile, separate, skipNaN, columns) }
 
 public fun <T> Pivot<T>.percentileFor(
     percentile: Double,
     vararg columns: String,
     separate: Boolean = false,
-): DataRow<T> = percentileFor(percentile, separate) { columns.toComparableColumns() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, separate, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Pivot<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentileFor(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
+    vararg columns: ColumnReference<C>,
     separate: Boolean = false,
-): DataRow<T> = percentileFor(percentile, separate) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, separate, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Pivot<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentileFor(
     percentile: Double,
-    vararg columns: KProperty<C?>,
+    vararg columns: KProperty<C>,
     separate: Boolean = false,
-): DataRow<T> = percentileFor(percentile, separate) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentileFor(percentile, separate, skipNaN) { columns.toColumnSet() }
 
-public fun <T, C : Comparable<C>> Pivot<T>.percentile(percentile: Double, columns: ColumnsSelector<T, C?>): DataRow<T> =
-    delegate { percentile(percentile, columns) }
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentile(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsSelector<T, C>,
+): DataRow<T> = delegate { percentile(percentile, skipNaN, columns) }
 
-public fun <T> Pivot<T>.percentile(percentile: Double, vararg columns: String): DataRow<T> =
-    percentile(percentile) { columns.toComparableColumns() }
+public fun <T> Pivot<T>.percentile(
+    percentile: Double,
+    vararg columns: String,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentile(percentile, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Pivot<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentile(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
-): DataRow<T> = percentile(percentile) { columns.toColumnSet() }
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentile(percentile, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> Pivot<T>.percentile(percentile: Double, vararg columns: KProperty<C?>): DataRow<T> =
-    percentile(percentile) { columns.toColumnSet() }
-
-public inline fun <T, reified R : Comparable<R>> Pivot<T>.percentileOf(
+public fun <T, C : Comparable<C & Any>?> Pivot<T>.percentile(
     percentile: Double,
-    crossinline expression: RowExpression<T, R?>,
-): DataRow<T> = delegate { percentileOf(percentile, expression) }
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataRow<T> = percentile(percentile, skipNaN) { columns.toColumnSet() }
 
+public inline fun <T, reified R : Comparable<R & Any>?> Pivot<T>.percentileOf(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, R>,
+): DataRow<T> = delegate { percentileOf(percentile, skipNaN, expression) }
+
+public inline fun <T, reified R : Comparable<R & Any>?> Pivot<T>.percentileBy(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline rowExpression: RowExpression<T, R>,
+): ReducedPivot<T> = reduce { percentileByOrNull(percentile, skipNaN, rowExpression) }
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> Pivot<T>.percentileBy(
+    percentile: Double,
+    column: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivot<T> = reduce { percentileByOrNull(percentile, column, skipNaN) }
+
+public fun <T> Pivot<T>.percentileBy(
+    percentile: Double,
+    column: String,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivot<T> = percentileBy(percentile, column.toColumnAccessor().cast<Comparable<Any>?>(), skipNaN)
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> Pivot<T>.percentileBy(
+    percentile: Double,
+    column: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivot<T> = percentileBy(percentile, column.toColumnAccessor(), skipNaN)
 // endregion
 
 // region PivotGroupBy
 
-public fun <T> PivotGroupBy<T>.percentile(percentile: Double, separate: Boolean = false): DataFrame<T> =
-    percentileFor(percentile, separate, intraComparableColumns())
-
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentileFor(
+public fun <T> PivotGroupBy<T>.percentile(
     percentile: Double,
     separate: Boolean = false,
-    columns: ColumnsForAggregateSelector<T, C?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateFor(this, separate, columns)
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, separate, skipNaN, intraComparableColumns())
+
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentileFor(
+    percentile: Double,
+    separate: Boolean = false,
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsForAggregateSelector<T, C>,
+): DataFrame<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateFor(this, separate, columns)
 
 public fun <T> PivotGroupBy<T>.percentileFor(
     percentile: Double,
     vararg columns: String,
     separate: Boolean = false,
-): DataFrame<T> = percentileFor(percentile, separate) { columns.toComparableColumns() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, separate, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentileFor(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
+    vararg columns: ColumnReference<C>,
     separate: Boolean = false,
-): DataFrame<T> = percentileFor(percentile, separate) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, separate, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentileFor(
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentileFor(
     percentile: Double,
-    vararg columns: KProperty<C?>,
+    vararg columns: KProperty<C>,
     separate: Boolean = false,
-): DataFrame<T> = percentileFor(percentile, separate) { columns.toColumnSet() }
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentileFor(percentile, separate, skipNaN) { columns.toColumnSet() }
 
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentile(
     percentile: Double,
-    columns: ColumnsSelector<T, C?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).aggregateAll(this, columns)
+    skipNaN: Boolean = skipNaNDefault,
+    columns: ColumnsSelector<T, C>,
+): DataFrame<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateAll(this, columns)
 
-public fun <T> PivotGroupBy<T>.percentile(percentile: Double, vararg columns: String): DataFrame<T> =
-    percentile(percentile) { columns.toComparableColumns() }
+public fun <T> PivotGroupBy<T>.percentile(
+    percentile: Double,
+    vararg columns: String,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, skipNaN) { columns.toComparableColumns() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentile(
     percentile: Double,
-    vararg columns: ColumnReference<C?>,
-): DataFrame<T> = percentile(percentile) { columns.toColumnSet() }
+    vararg columns: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, skipNaN) { columns.toColumnSet() }
 
 @AccessApiOverload
-public fun <T, C : Comparable<C>> PivotGroupBy<T>.percentile(
+public fun <T, C : Comparable<C & Any>?> PivotGroupBy<T>.percentile(
     percentile: Double,
-    vararg columns: KProperty<C?>,
-): DataFrame<T> = percentile(percentile) { columns.toColumnSet() }
+    vararg columns: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): DataFrame<T> = percentile(percentile, skipNaN) { columns.toColumnSet() }
 
-public inline fun <T, reified R : Comparable<R>> PivotGroupBy<T>.percentileOf(
+public inline fun <T, reified R : Comparable<R & Any>?> PivotGroupBy<T>.percentileOf(
     percentile: Double,
-    crossinline expression: RowExpression<T, R?>,
-): DataFrame<T> = Aggregators.oldPercentile(percentile).cast<R?>().aggregateOf(this, expression)
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline expression: RowExpression<T, R>,
+): DataFrame<T> = Aggregators.percentileCommon<R>(percentile, skipNaN).aggregateOf(this, expression)
+
+public inline fun <T, reified R : Comparable<R & Any>?> PivotGroupBy<T>.percentileBy(
+    percentile: Double,
+    skipNaN: Boolean = skipNaNDefault,
+    crossinline rowExpression: RowExpression<T, R>,
+): ReducedPivotGroupBy<T> = reduce { percentileByOrNull(percentile, skipNaN, rowExpression) }
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> PivotGroupBy<T>.percentileBy(
+    percentile: Double,
+    column: ColumnReference<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivotGroupBy<T> = reduce { percentileByOrNull(percentile, column, skipNaN) }
+
+public fun <T> PivotGroupBy<T>.percentileBy(
+    percentile: Double,
+    column: String,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivotGroupBy<T> = percentileBy(percentile, column.toColumnAccessor().cast<Comparable<Any>?>(), skipNaN)
+
+@AccessApiOverload
+public inline fun <T, reified C : Comparable<C & Any>?> PivotGroupBy<T>.percentileBy(
+    percentile: Double,
+    column: KProperty<C>,
+    skipNaN: Boolean = skipNaNDefault,
+): ReducedPivotGroupBy<T> = percentileBy(percentile, column.toColumnAccessor(), skipNaN)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlinx.dataframe.math.medianConversion
 import org.jetbrains.kotlinx.dataframe.math.medianOrNull
 import org.jetbrains.kotlinx.dataframe.math.minOrNull
 import org.jetbrains.kotlinx.dataframe.math.minTypeConversion
-import org.jetbrains.kotlinx.dataframe.math.percentile
 import org.jetbrains.kotlinx.dataframe.math.percentileConversion
 import org.jetbrains.kotlinx.dataframe.math.percentileOrNull
 import org.jetbrains.kotlinx.dataframe.math.std
@@ -147,14 +146,6 @@ internal object Aggregators {
     val mean by withOneOption { skipNaN: Boolean ->
         twoStepReducingForNumbers(meanTypeConversion) { type ->
             mean(type, skipNaN)
-        }
-    }
-
-    // T: Comparable<T>? -> T
-    @Deprecated("todo")
-    val oldPercentile by withOneOption { percentile: Double ->
-        flattenReducingForAny<Comparable<Any?>> { type ->
-            asIterable().percentile(percentile, type)
         }
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/aggregation/aggregators/Aggregators.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.multipleColu
 import org.jetbrains.kotlinx.dataframe.math.indexOfMax
 import org.jetbrains.kotlinx.dataframe.math.indexOfMedian
 import org.jetbrains.kotlinx.dataframe.math.indexOfMin
+import org.jetbrains.kotlinx.dataframe.math.indexOfPercentile
 import org.jetbrains.kotlinx.dataframe.math.maxOrNull
 import org.jetbrains.kotlinx.dataframe.math.maxTypeConversion
 import org.jetbrains.kotlinx.dataframe.math.mean
@@ -20,6 +21,8 @@ import org.jetbrains.kotlinx.dataframe.math.medianOrNull
 import org.jetbrains.kotlinx.dataframe.math.minOrNull
 import org.jetbrains.kotlinx.dataframe.math.minTypeConversion
 import org.jetbrains.kotlinx.dataframe.math.percentile
+import org.jetbrains.kotlinx.dataframe.math.percentileConversion
+import org.jetbrains.kotlinx.dataframe.math.percentileOrNull
 import org.jetbrains.kotlinx.dataframe.math.std
 import org.jetbrains.kotlinx.dataframe.math.stdTypeConversion
 import org.jetbrains.kotlinx.dataframe.math.sum
@@ -148,10 +151,42 @@ internal object Aggregators {
     }
 
     // T: Comparable<T>? -> T
-    val percentile by withOneOption { percentile: Double ->
+    @Deprecated("todo")
+    val oldPercentile by withOneOption { percentile: Double ->
         flattenReducingForAny<Comparable<Any?>> { type ->
             asIterable().percentile(percentile, type)
         }
+    }
+
+    // T : primitive Number? -> Double?
+    // T : Comparable<T & Any>? -> T?
+    fun <T> percentileCommon(
+        percentile: Double,
+        skipNaN: Boolean,
+    ): Aggregator<T & Any, T?>
+        where T : Comparable<T & Any>? =
+        this.percentile.invoke(percentile, skipNaN).cast2()
+
+    // T : Comparable<T & Any>? -> T?
+    fun <T> percentileComparables(percentile: Double): Aggregator<T & Any, T?>
+        where T : Comparable<T & Any>? =
+        percentileCommon<T>(percentile, skipNaNDefault).cast2()
+
+    // T : primitive Number? -> Double?
+    fun <T> percentileNumbers(
+        percentile: Double,
+        skipNaN: Boolean,
+    ): Aggregator<T & Any, Double?>
+        where T : Comparable<T & Any>?, T : Number? =
+        percentileCommon<T>(percentile, skipNaN).cast2()
+
+    @Suppress("UNCHECKED_CAST")
+    private val percentile by withTwoOptions { percentile: Double, skipNaN: Boolean ->
+        flattenHybridForAny<Comparable<Any>, Comparable<Any>?>(
+            getReturnType = percentileConversion,
+            reducer = { type -> percentileOrNull(percentile, type, skipNaN) as Comparable<Any>? },
+            indexOfResult = { type -> indexOfPercentile(percentile, type, skipNaN) },
+        )
     }
 
     // T : primitive Number? -> Double?

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/describe.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/describe.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.ColumnDescription
 import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.after
-import org.jetbrains.kotlinx.dataframe.api.any
 import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.asComparable
 import org.jetbrains.kotlinx.dataframe.api.asNumbers

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/median.kt
@@ -53,6 +53,8 @@ internal fun <T : Comparable<T>> Sequence<T>.medianOrNull(type: KType, skipNaN: 
     }
 
     val p = 0.5
+
+    // TODO make configurable? https://github.com/Kotlin/dataframe/issues/1121
     val (values, method) =
         when {
             type.isPrimitiveNumber() ->
@@ -131,7 +133,7 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfMedian(type: KType, s
         }
     }
 
-    // TODO make configurable?
+    // TODO make configurable? https://github.com/Kotlin/dataframe/issues/1121
     val method = QuantileEstimationMethod.R3
     val p = 0.5
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -54,7 +54,7 @@ internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double
 
     // fake Comparable types to satisfy the compiler
     values as Sequence<Comparable<Any>>
-    method as QuantileEstimationMethod<Comparable<Any>>
+    method as QuantileEstimationMethod<Comparable<Any>, *>
 
     return values.quantileOrNull(
         p = p,
@@ -112,11 +112,9 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
         p = p,
         type = type,
         skipNaN = skipNaN,
-        method = method as QuantileEstimationMethod<T>,
+        method = method as QuantileEstimationMethod<T & Any, Int>,
         name = "percentile",
-    ).let {
-        method.roundIndex(it)
-    }.toInt()
+    )
 }
 
 @PublishedApi

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -48,7 +48,7 @@ internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double
     // percentile of 25.0 means the 25th 100-quantile, so 25 / 100 = 0.25
     val p = percentile / 100.0
 
-    // TODO make configurable
+    // TODO make configurable https://github.com/Kotlin/dataframe/issues/1121
     val (values, method) =
         when {
             type.isPrimitiveNumber() ->
@@ -118,7 +118,7 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
         }
     }
 
-    // TODO make configurable
+    // TODO make configurable https://github.com/Kotlin/dataframe/issues/1121
     val method = QuantileEstimationMethod.R3
 
     // percentile of 25.0 means the 25th 100-quantile, so 25 / 100 = 0.25

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlinx.dataframe.math
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.CalculateReturnType
-import org.jetbrains.kotlinx.dataframe.impl.asList
 import org.jetbrains.kotlinx.dataframe.impl.isIntraComparable
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
@@ -51,8 +50,11 @@ internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double
     // TODO make configurable
     val (values, method) =
         when {
-            type.isPrimitiveNumber() -> this.map { (it as Number).toDouble() } to QuantileEstimationMethod.R8
-            else -> this to QuantileEstimationMethod.R3
+            type.isPrimitiveNumber() ->
+                this.map { (it as Number).toDouble() } to QuantileEstimationMethod.Interpolating.R8
+
+            else ->
+                this to QuantileEstimationMethod.Selecting.R3
         }
 
     // fake Comparable types to satisfy the compiler
@@ -118,71 +120,4 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
         method = method as QuantileEstimationMethod<T & Any, Int>,
         name = "percentile",
     )
-}
-
-@PublishedApi
-internal fun <T : Comparable<T>> Iterable<T?>.percentile(percentile: Double, type: KType): T? {
-    require(percentile in 0.0..100.0) { "Percentile must be in range [0, 100]" }
-
-    @Suppress("UNCHECKED_CAST")
-    val list = if (type.isMarkedNullable) filterNotNull() else (this as Iterable<T>).asList()
-    val size = list.size
-    if (size == 0) return null
-
-    val index = (percentile / 100.0 * (size - 1)).toInt()
-    val fraction = (percentile / 100.0 * (size - 1)) - index
-
-    // median handle for even sized list (legacy logic)
-    if (percentile == 50.0 && size % 2 == 0) {
-        val lower = list.quickSelect(index)
-        val upper = list.quickSelect(index + 1)
-
-        return when (type) {
-            Double::class -> ((lower as Double + upper as Double) / 2.0) as T
-            Float::class -> ((lower as Float + upper as Float) / 2.0f) as T
-            Int::class -> ((lower as Int + upper as Int) / 2) as T
-            Short::class -> ((lower as Short + upper as Short) / 2).toShort() as T
-            Long::class -> ((lower as Long + upper as Long) / 2L) as T
-            Byte::class -> ((lower as Byte + upper as Byte) / 2).toByte() as T
-            BigDecimal::class -> ((lower as BigDecimal + upper as BigDecimal) / 2.toBigDecimal()) as T
-            BigInteger::class -> ((lower as BigInteger + upper as BigInteger) / 2.toBigInteger()) as T
-            else -> lower
-        }
-    }
-
-    if (fraction == 0.0) {
-        return list.quickSelect(index)
-    }
-
-    val lower = list.quickSelect(index)
-    val upper = list.quickSelect(index + 1)
-
-    return when (type.classifier) {
-        Double::class -> ((lower as Double) + (upper as Double - lower as Double) * fraction) as T
-
-        Float::class -> ((lower as Float) + (upper as Float - lower as Float) * fraction) as T
-
-        Int::class -> ((lower as Int) + (upper as Int - lower as Int) * fraction).toInt() as T
-
-        Short::class -> ((lower as Short) + (upper as Short - lower as Short) * fraction).toInt().toShort() as T
-
-        Long::class -> ((lower as Long) + (upper as Long - lower as Long) * fraction).toLong() as T
-
-        Byte::class -> ((lower as Byte) + (upper as Byte - lower as Byte) * fraction).toInt().toByte() as T
-
-        BigDecimal::class -> (
-            (lower as BigDecimal) +
-                (upper as BigDecimal - lower as BigDecimal) * fraction.toBigDecimal()
-        ) as T
-
-        BigInteger::class -> (
-            (lower as BigInteger) +
-                (
-                    (upper as BigInteger - lower as BigInteger) * fraction.toBigDecimal()
-                        .toBigInteger()
-                )
-        ) as T
-
-        else -> lower
-    }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -16,6 +16,9 @@ import kotlin.reflect.typeOf
 
 private val logger = KotlinLogging.logger { }
 
+/**
+ * Uses [QuantileEstimationMethod.R8] for primitive numbers, else [QuantileEstimationMethod.R3]
+ */
 internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double, type: KType, skipNaN: Boolean): Any? {
     when {
         percentile !in 0.0..100.0 -> error("Percentile must be in range [0, 100]")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -58,10 +58,6 @@ internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double
                 this to QuantileEstimationMethod.Selecting.R3
         }
 
-    // fake Comparable types to satisfy the compiler
-    values as Sequence<Comparable<Any>>
-    method as QuantileEstimationMethod<Comparable<Any>, *>
-
     return values.quantileOrNull(
         p = p,
         type = type,
@@ -77,7 +73,7 @@ internal val percentileConversion: CalculateReturnType = { type, isEmpty ->
         type.isPrimitiveNumber() -> typeOf<Double>()
 
         // closest rank method, preferring lower middle,
-        // number R3 of Hyndman and Fan "Sample quantiles in statistical packages"
+        // R3 of Hyndman and Fan "Sample quantiles in statistical packages"
         type.isIntraComparable() -> type
 
         else -> error("Can not calculate percentile for type ${renderType(type)}")
@@ -114,7 +110,7 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
             )
     }
 
-    val indexList = this.mapIndexedNotNull { i, it ->
+    val indexedSequence = this.mapIndexedNotNull { i, it ->
         if (it == null) {
             null
         } else {
@@ -129,7 +125,7 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
     val p = percentile / 100.0
 
     // get the index where the percentile can be found in the sorted sequence
-    val indexEstimation = indexList.quantileIndexEstimation(
+    val indexEstimation = indexedSequence.quantileIndexEstimation(
         p = p,
         type = typeOf<IndexedComparable<Nothing>>(),
         skipNaN = skipNaN,
@@ -142,7 +138,7 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
         "percentile expected a whole number index from quantileIndexEstimation but was $indexEstimation"
     }
 
-    val percentileResult = indexList.toList().quickSelect(k = indexEstimation.toInt())
+    val percentileResult = indexedSequence.toList().quickSelect(k = indexEstimation.toInt())
 
     // return the original unsorted index of the found result
     return percentileResult.index

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
@@ -174,8 +174,9 @@ internal fun <T : Comparable<T>> Sequence<Any?>.quantileIndexEstimation(
  * For the [Selecting], the [Value] type can thus be any self-comparable type, but for [Interpolating],
  * [Value] can only be of type [Double], because it needs to perform calculations on the values.
  *
- * TODO add R2, R4, R5, R6, R9
- * TODO make public if configurable for percentile function
+ * TODO https://github.com/Kotlin/dataframe/issues/1121
+ *   - add R2, R4, R5, R6, R9
+ *   - make public if configurable for percentile function
  */
 internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, Index : Number> {
 
@@ -219,7 +220,7 @@ internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, In
         }
     }
 
-    // TODO add R2, R4, R5, R6, R9
+    // TODO add R2, R4, R5, R6, R9 https://github.com/Kotlin/dataframe/issues/1121
     sealed interface Interpolating : QuantileEstimationMethod<Double, Double> {
 
         /** Linear interpolation of the modes for the order statistics for the uniform distribution on [0, 1]. */
@@ -248,7 +249,7 @@ internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, In
     }
 
     // shortcuts to the various estimation methods
-    // TODO add R2, R4, R5, R6, R9
+    // TODO add R2, R4, R5, R6, R9 https://github.com/Kotlin/dataframe/issues/1121
     companion object {
         val R1 = Selecting.R1
         val R3 = Selecting.R3

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
@@ -229,7 +229,7 @@ internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, In
                     .coerceIn(1.0..count.toDouble())
         }
 
-        /** Linear interpolation of the approximate medians for order statistics. */
+        /** Linear interpolation of the approximate medians for order statistics. Recommended by H & F. */
         data object R8 : Interpolating, PieceWiseLinear {
             override fun oneBasedIndexOfQuantile(p: Double, count: Int): Double =
                 ((count + 1.0 / 3.0) * p + 1.0 / 3.0)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
@@ -19,8 +19,19 @@ import kotlin.reflect.typeOf
 private val logger = KotlinLogging.logger { }
 
 /**
- * p-quantile: the k'th q-quantile, where p = k/q.
+ * Returns the p-quantile: the k'th q-quantile, where p = k/q.
  *
+ * When [method] is a [QuantileEstimationMethod.Selecting] method,
+ * [this] can be a sequence with any self-comparable type.
+ * The returned value will be selected from the sequence.
+ *
+ * Otherwise, when [method] is a [QuantileEstimationMethod.Interpolating] method,
+ * [this] can only be a sequence with primitive number types.
+ * The returned value will be [Double].
+ *
+ * Nulls are not allowed. If NaN is among the values, it will be returned.
+ *
+ * @see QuantileEstimationMethod
  */
 internal fun <T : Comparable<T>> Sequence<Any>.quantileOrNull(
     p: Double,
@@ -55,7 +66,12 @@ internal fun <T : Comparable<T>> Sequence<Any>.quantileOrNull(
     }
 
     // propagate NaN to return if they are not to be skipped
-    if (type.canBeNaN && !skipNaN && any { it.isNaN }) return Double.NaN
+    if (type.canBeNaN && !skipNaN && any { it.isNaN }) {
+        // ensure that using a selecting quantile estimation method always returns the same type as the input
+        if (type == typeOf<Float>() && method is QuantileEstimationMethod.Selecting) return Float.NaN
+
+        return Double.NaN
+    }
 
     val list = when {
         type.canBeNaN -> filter { !it.isNaN }
@@ -201,7 +217,6 @@ internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, In
                 return values.quickSelect(h)
             }
         }
-
     }
 
     // TODO add R2, R4, R5, R6, R9
@@ -227,7 +242,7 @@ internal sealed interface QuantileEstimationMethod<Value : Comparable<Value>, In
                 return values.quickSelect(floor(h).toInt() - 1) + (h - floor(h)) * (
                     values.quickSelect(ceil(h).toInt() - 1) -
                         values.quickSelect(floor(h).toInt() - 1)
-                    )
+                )
             }
         }
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
@@ -1,0 +1,269 @@
+package org.jetbrains.kotlinx.dataframe.math
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.kotlinx.dataframe.api.isNaN
+import org.jetbrains.kotlinx.dataframe.impl.canBeNaN
+import org.jetbrains.kotlinx.dataframe.impl.isIntraComparable
+import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
+import org.jetbrains.kotlinx.dataframe.impl.nothingType
+import org.jetbrains.kotlinx.dataframe.impl.renderType
+import org.jetbrains.kotlinx.dataframe.math.QuantileEstimationMethod.ConstantEstimation
+import org.jetbrains.kotlinx.dataframe.math.QuantileEstimationMethod.LinearEstimation
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.round
+import kotlin.reflect.KType
+import kotlin.reflect.full.withNullability
+import kotlin.reflect.typeOf
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * p-quantile: the k'th q-quantile, where p = k/q.
+ *
+ */
+internal fun <T : Comparable<T>> Sequence<Any>.quantileOrNull(
+    p: Double,
+    type: KType,
+    skipNaN: Boolean,
+    method: QuantileEstimationMethod<T>,
+    name: String = "quantile",
+): Any? {
+    when {
+        p !in 0.0..1.0 -> error("Quantile must be in range [0, 1]")
+
+        type.isMarkedNullable ->
+            error("Encountered nullable type ${renderType(type)} in $name function. This should not occur.")
+
+        // this means the sequence is empty
+        type == nothingType -> return null
+
+        !type.isIntraComparable() ->
+            error(
+                "Unable to compute the $name for ${
+                    renderType(type)
+                }. Only primitive numbers or self-comparables are supported.",
+            )
+
+        type == typeOf<BigDecimal>() || type == typeOf<BigInteger>() ->
+            throw IllegalArgumentException(
+                "Cannot calculate the $name for big numbers in DataFrame. Only primitive numbers are supported.",
+            )
+
+        type == typeOf<Long>() ->
+            logger.warn { "Converting Longs to Doubles to calculate the $name, loss of precision may occur." }
+    }
+
+    // propagate NaN to return if they are not to be skipped
+    if (type.canBeNaN && !skipNaN && any { it.isNaN }) return Double.NaN
+
+    val list = when {
+        type.canBeNaN -> filter { !it.isNaN }
+        else -> this
+    }.toList()
+
+    val size = list.size
+    if (size == 0) return null
+
+    if (size == 1) {
+        val single = list.single()
+        return if (type.isPrimitiveNumber()) (single as Number).toDouble() else single
+    }
+
+    return when (method) {
+        is ConstantEstimation ->
+            method.quantile<T>(p, list as List<T>)
+
+        is LinearEstimation -> {
+            require(type.isPrimitiveNumber()) {
+                "Cannot calculate the $name for non-primitive numbers with estimation method $method."
+            }
+            @Suppress("UNCHECKED_CAST")
+            val convertedList =
+                if (type == typeOf<Double>()) {
+                    list as List<Double>
+                } else {
+                    list.map { (it as Number).toDouble() }
+                }
+
+            method.quantile(p, convertedList)
+        }
+    }
+}
+
+/**
+ * p-quantile: the k'th q-quantile, where p = k/q.
+ *
+ */
+internal fun <T : Comparable<T & Any>?> Sequence<Any?>.indexOfQuantile(
+    p: Double,
+    type: KType,
+    skipNaN: Boolean,
+    method: QuantileEstimationMethod<T>,
+    name: String = "quantile",
+): Double {
+    val nonNullType = type.withNullability(false)
+    when {
+        p !in 0.0..1.0 -> error("Quantile must be in range [0, 1]")
+
+        !nonNullType.isIntraComparable() ->
+            error(
+                "Unable to compute the $name for ${
+                    renderType(type)
+                }. Only primitive numbers or self-comparables are supported.",
+            )
+
+        method is LinearEstimation && !nonNullType.isPrimitiveNumber() ->
+            error(
+                "Cannot calculate the $name for type ${renderType(type)} with estimation method $method." +
+                    "For piecewise linear methods, only primitive numbers are supported",
+            )
+    }
+
+    // propagate NaN to return if they are not to be skipped
+    if (nonNullType.canBeNaN && !skipNaN) {
+        for ((i, it) in this.withIndex()) {
+            if (it.isNaN) return i.toDouble()
+        }
+    }
+
+    val indexedSequence = this.mapIndexedNotNull { i, it ->
+        if (it == null) {
+            null
+        } else {
+            IndexedComparable(i, it as Comparable<Any>)
+        }
+    }
+    val list = when {
+        nonNullType.canBeNaN -> indexedSequence.filterNot { it.value.isNaN }
+        else -> indexedSequence
+    }.toList()
+
+    val size = list.size
+    if (size == 0) return -1.0
+    if (size == 1) return 0.0
+
+    return method.indexOfQuantile(p, size)
+}
+
+internal sealed interface QuantileEstimationMethod<T> {
+
+    /**
+     * Gives the (1-based) index of the [p]-quantile for a distribution of size [count].
+     * If the result `h` is a whole number, the `h`'th smallest of the [count] values is the quantile estimate.
+     * If not, `h` is an estimation of the index of the p-quantile. Rounding or interpolation needs to occur to get
+     * the actual quantile estimate.
+     */
+    fun oneBasedIndexOfQuantile(p: Double, count: Int): Double
+
+    fun quantile(p: Double, values: List<T>): T
+
+    interface ConstantEstimation : QuantileEstimationMethod<Comparable<*>> {
+
+        fun roundIndex(index: Double): Int
+    }
+
+    interface LinearEstimation : QuantileEstimationMethod<Double> {
+
+        override fun quantile(p: Double, values: List<Double>): Double {
+            val h = oneBasedIndexOfQuantile(p, values.size)
+            return values.quickSelect((floor(h).toInt() - 1).coerceIn(0..<values.size)) +
+                (h - floor(h)) * (
+                    values.quickSelect((ceil(h).toInt() - 1).coerceIn(0..<values.size)) -
+                        values.quickSelect((floor(h).toInt() - 1).coerceIn(0..<values.size))
+                )
+        }
+    }
+
+    data object R1 : ConstantEstimation {
+        override fun oneBasedIndexOfQuantile(p: Double, count: Int): Double = p * count
+
+        override fun roundIndex(index: Double): Int = ceil(index).toInt()
+
+        @Suppress("UNCHECKED_CAST")
+        override fun quantile(p: Double, values: List<Comparable<*>>): Comparable<*> {
+            val h = oneBasedIndexOfQuantile(p, values.size)
+            val index = roundIndex(h) - 1
+            return (values as List<Comparable<Any>>).quickSelect(index.coerceIn(0..<values.size))
+        }
+    }
+
+    data object R3 : ConstantEstimation {
+        override fun oneBasedIndexOfQuantile(p: Double, count: Int): Double = count * p - 0.5
+
+        override fun roundIndex(index: Double): Int = round(index).toInt()
+
+        @Suppress("UNCHECKED_CAST")
+        override fun quantile(p: Double, values: List<Comparable<*>>): Comparable<*> {
+            val h = oneBasedIndexOfQuantile(p, values.size)
+            val index = roundIndex(h) - 1
+            return (values as List<Comparable<Any>>).quickSelect(index.coerceIn(0..<values.size))
+        }
+    }
+
+    data object R7 : LinearEstimation {
+        override fun oneBasedIndexOfQuantile(p: Double, count: Int): Double = (count - 1.0) * p + 1.0 / 3.0
+    }
+
+    data object R8 : LinearEstimation {
+        override fun oneBasedIndexOfQuantile(p: Double, count: Int): Double = (count + 1.0 / 3.0) * p + 1.0 / 3.0
+    }
+}
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER", "UNCHECKED_CAST")
+internal fun <T : Comparable<T>> ConstantEstimation.quantile(p: Double, values: List<T>): T =
+    quantile(p, values as List<Comparable<Any>>) as T
+
+internal fun QuantileEstimationMethod<*>.indexOfQuantile(p: Double, count: Int): Double =
+    oneBasedIndexOfQuantile(p = p, count = count) - 1.0
+
+@PublishedApi
+internal fun <T : Comparable<T>> List<T>.quickSelect(k: Int): T {
+    if (k < 0 || k >= size) throw IndexOutOfBoundsException("k = $k, size = $size")
+
+    var list = this
+    var temp = mutableListOf<T>()
+    var less = mutableListOf<T>()
+    var k = k
+    var greater = mutableListOf<T>()
+    while (list.size > 1) {
+        var equal = 0
+        val x = list.random()
+        greater.clear()
+        less.clear()
+        for (v in list) {
+            val comp = v.compareTo(x)
+            when {
+                comp < 0 -> less.add(v)
+                comp > 0 -> greater.add(v)
+                else -> equal++
+            }
+        }
+        when {
+            k < less.size -> {
+                list = less
+                less = temp
+                temp = list
+            }
+
+            k < less.size + equal -> {
+                return x
+            }
+
+            else -> {
+                list = greater
+                greater = temp
+                temp = list
+                k -= less.size + equal
+            }
+        }
+    }
+    return list[0]
+}
+
+internal data class IndexedComparable<T : Comparable<T>>(val index: Int, val value: T) :
+    Comparable<IndexedComparable<T>> {
+    override fun compareTo(other: IndexedComparable<T>): Int = value.compareTo(other.value)
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -83,6 +83,9 @@ internal const val ROW_MAX_OR_NULL = "`rowMaxOrNull` is deprecated in favor of `
 internal const val ROW_MEDIAN = "`rowMedian` is deprecated in favor of `rowMedianOf`. $MESSAGE_0_16"
 internal const val ROW_MEDIAN_OR_NULL = "`rowMedianOrNull` is deprecated in favor of `rowMedianOfOrNull`. $MESSAGE_0_16"
 
+internal const val ROW_PERCENTILE = "`rowPercentile` is deprecated in favor of `rowPercentileOf`. $MESSAGE_0_16"
+internal const val ROW_PERCENTILE_OR_NULL = "`rowPercentileOrNull` is deprecated in favor of `rowPercentileOfOrNull`. $MESSAGE_0_16"
+
 internal const val SUM_NO_SKIPNAN = "This function is just here for binary compatibility. $MESSAGE_0_16"
 internal const val MAX_NO_SKIPNAN = "This function is just here for binary compatibility. $MESSAGE_0_16"
 internal const val MIN_NO_SKIPNAN = "This function is just here for binary compatibility. $MESSAGE_0_16"

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -84,7 +84,8 @@ internal const val ROW_MEDIAN = "`rowMedian` is deprecated in favor of `rowMedia
 internal const val ROW_MEDIAN_OR_NULL = "`rowMedianOrNull` is deprecated in favor of `rowMedianOfOrNull`. $MESSAGE_0_16"
 
 internal const val ROW_PERCENTILE = "`rowPercentile` is deprecated in favor of `rowPercentileOf`. $MESSAGE_0_16"
-internal const val ROW_PERCENTILE_OR_NULL = "`rowPercentileOrNull` is deprecated in favor of `rowPercentileOfOrNull`. $MESSAGE_0_16"
+internal const val ROW_PERCENTILE_OR_NULL =
+    "`rowPercentileOrNull` is deprecated in favor of `rowPercentileOfOrNull`. $MESSAGE_0_16"
 
 internal const val SUM_NO_SKIPNAN = "This function is just here for binary compatibility. $MESSAGE_0_16"
 internal const val MAX_NO_SKIPNAN = "This function is just here for binary compatibility. $MESSAGE_0_16"

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/describe.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/describe.kt
@@ -65,7 +65,7 @@ class DescribeTests {
             mean.shouldBeNaN()
             std.shouldBeNaN()
             min.isNaN shouldBe true
-            p25 shouldBe 1.75
+            p25.isNaN shouldBe true
             median.isNaN shouldBe true
             p75.isNaN shouldBe true
             max.isNaN shouldBe true

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/QuantileTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/QuantileTests.kt
@@ -1,0 +1,762 @@
+package org.jetbrains.kotlinx.dataframe.statistics
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.math.QuantileEstimationMethod
+import org.jetbrains.kotlinx.dataframe.math.quantileOrNull
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class QuantileTests {
+
+    @Test
+    fun `linear estimation`() {
+        // Test R8 with Double - p = 0.1 (10th percentile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.0
+
+        // Test R8 with Double - p = 0.5 (median)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.5
+
+        // Test R8 with Double - p = 0.25 (first quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.4166666666666665
+
+        // Test R8 with Double - p = 0.75 (third quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 3.5833333333333335
+
+        // Test R8 with Double - p = 0.9 (90th percentile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 4.0
+
+        // Test R7 with Double - p = 0.1 (10th percentile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.0
+
+        // Test R7 with Double - p = 0.5 (median)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.8333333333333333
+
+        // Test R7 with Double - p = 0.25 (first quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.0833333333333333
+
+        // Test R7 with Double - p = 0.75 (third quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 2.5833333333333335
+
+        // Test R7 with Double - p = 0.9 (90th percentile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 3.0333333333333337
+
+        // Test R8 with Int - p = 0.5 (median)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.5
+
+        // Test R8 with Int - p = 0.25 (first quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.4166666666666665
+
+        // Test R8 with Int - p = 0.75 (third quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 3.5833333333333335
+
+        // Test R7 with Int - p = 0.5 (median)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.8333333333333333
+
+        // Test R7 with Int - p = 0.25 (first quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.0833333333333333
+
+        // Test R7 with Int - p = 0.75 (third quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 2.5833333333333335
+
+        // Test R8 with Float - p = 0.5 (median)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.5
+
+        // Test R8 with Float - p = 0.25 (first quartile)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.4166666666666665
+
+        // Test R8 with Float - p = 0.75 (third quartile)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 3.5833333333333335
+
+        // Test R7 with Float - p = 0.5 (median)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.8333333333333333
+
+        // Test R7 with Float - p = 0.25 (first quartile)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.0833333333333333
+
+        // Test R7 with Float - p = 0.75 (third quartile)
+        sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Float>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 2.5833333333333335
+
+        // Test R8 with Long - p = 0.5 (median)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.5
+
+        // Test R8 with Long - p = 0.25 (first quartile)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.4166666666666665
+
+        // Test R8 with Long - p = 0.75 (third quartile)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 3.5833333333333335
+
+        // Test R7 with Long - p = 0.5 (median)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.8333333333333333
+
+        // Test R7 with Long - p = 0.25 (first quartile)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 1.0833333333333333
+
+        // Test R7 with Long - p = 0.75 (third quartile)
+        sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Long>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R7,
+        ) shouldBe 2.5833333333333335
+
+        // Test with NaN values and skipNaN = false - p = 0.5 (median)
+        val nanResult = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (nanResult as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = false - p = 0.25 (first quartile)
+        val nanResult25 = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (nanResult25 as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = false - p = 0.75 (third quartile)
+        val nanResult75 = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (nanResult75 as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = true - p = 0.5 (median)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.0
+
+        // Test with NaN values and skipNaN = true - p = 0.25 (first quartile)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 1.1666666666666667
+
+        // Test with NaN values and skipNaN = true - p = 0.75 (third quartile)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 2.8333333333333335
+    }
+
+    @Test
+    fun `constant estimation`() {
+        // Test R3 with Char - p = 0.1 (10th percentile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.1,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'a'
+
+        // Test R3 with Char - p = 0.5 (median)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.5,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'a'
+
+        // Test R3 with Char - p = 0.25 (first quartile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.25,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'a'
+
+        // Test R3 with Char - p = 0.75 (third quartile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.75,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'b'
+
+        // Test R3 with Char - p = 0.9 (90th percentile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.9,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'b'
+
+        // Test R1 with Char - p = 0.1 (10th percentile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.1,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'a'
+
+        // Test R1 with Char - p = 0.5 (median)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.5,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'b'
+
+        // Test R1 with Char - p = 0.25 (first quartile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.25,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'a'
+
+        // Test R1 with Char - p = 0.75 (third quartile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.75,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'c'
+
+        // Test R1 with Char - p = 0.9 (90th percentile)
+        sequenceOf('a', 'c', 'b').quantileOrNull(
+            p = 0.9,
+            type = typeOf<Char>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+        ) shouldBe 'c'
+
+        // Test R3 with String - p = 0.5 (median)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.5,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "apple"
+
+        // Test R3 with String - p = 0.25 (first quartile)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.25,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "apple"
+
+        // Test R3 with String - p = 0.75 (third quartile)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.75,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "banana"
+
+        // Test R1 with String - p = 0.5 (median)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.5,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+        ) shouldBe "banana"
+
+        // Test R1 with String - p = 0.25 (first quartile)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.25,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+        ) shouldBe "apple"
+
+        // Test R1 with String - p = 0.75 (third quartile)
+        sequenceOf("apple", "cherry", "banana").quantileOrNull(
+            p = 0.75,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+        ) shouldBe "cherry"
+
+        // Test R3 with Int (primitive number) - p = 0.5 (median)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
+        ) shouldBe 2
+
+        // Test R3 with Int (primitive number) - p = 0.25 (first quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
+        ) shouldBe 1
+
+        // Test R3 with Int (primitive number) - p = 0.75 (third quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
+        ) shouldBe 2
+
+        // Test R1 with Int (primitive number) - p = 0.5 (median)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
+        ) shouldBe 2
+
+        // Test R1 with Int (primitive number) - p = 0.25 (first quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
+        ) shouldBe 1
+
+        // Test R1 with Int (primitive number) - p = 0.75 (third quartile)
+        sequenceOf(1, 4, 3, 2).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Int>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
+        ) shouldBe 3
+
+        // Test R3 with Double (primitive number) - p = 0.5 (median)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 2.0
+
+        // Test R3 with Double (primitive number) - p = 0.25 (first quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 1.0
+
+        // Test R3 with Double (primitive number) - p = 0.75 (third quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 2.0
+
+        // Test R1 with Double (primitive number) - p = 0.5 (median)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
+        ) shouldBe 2.0
+
+        // Test R1 with Double (primitive number) - p = 0.25 (first quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
+        ) shouldBe 1.0
+
+        // Test R1 with Double (primitive number) - p = 0.75 (third quartile)
+        sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
+        ) shouldBe 3.0
+
+        // Test with NaN values and skipNaN = false - p = 0.5 (median)
+        val nanResult = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        )
+        (nanResult as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = false - p = 0.25 (first quartile)
+        val nanResult25 = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        )
+        (nanResult25 as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = false - p = 0.75 (third quartile)
+        val nanResult75 = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        )
+        (nanResult75 as Double).isNaN() shouldBe true
+
+        // Test with NaN values and skipNaN = true - p = 0.5 (median)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 1.0
+
+        // Test with NaN values and skipNaN = true - p = 0.25 (first quartile)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 1.0
+
+        // Test with NaN values and skipNaN = true - p = 0.75 (third quartile)
+        sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+        ) shouldBe 2.0
+    }
+
+    @Test
+    fun `edge cases`() {
+        // Empty sequence - p = 0.1 (10th percentile)
+        sequenceOf<Double>().quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // Empty sequence - p = 0.5 (median)
+        sequenceOf<Double>().quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // Empty sequence - p = 0.25 (first quartile)
+        sequenceOf<Double>().quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // Empty sequence - p = 0.75 (third quartile)
+        sequenceOf<Double>().quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // Empty sequence - p = 0.9 (90th percentile)
+        sequenceOf<Double>().quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // Single element sequence - linear estimation - p = 0.1 (10th percentile)
+        sequenceOf(5.0).quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 5.0
+
+        // Single element sequence - linear estimation - p = 0.5 (median)
+        sequenceOf(5.0).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 5.0
+
+        // Single element sequence - linear estimation - p = 0.25 (first quartile)
+        sequenceOf(5.0).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 5.0
+
+        // Single element sequence - linear estimation - p = 0.75 (third quartile)
+        sequenceOf(5.0).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 5.0
+
+        // Single element sequence - linear estimation - p = 0.9 (90th percentile)
+        sequenceOf(5.0).quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe 5.0
+
+        // Single element sequence - constant estimation - p = 0.5 (median)
+        sequenceOf("test").quantileOrNull(
+            p = 0.5,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "test"
+
+        // Single element sequence - constant estimation - p = 0.25 (first quartile)
+        sequenceOf("test").quantileOrNull(
+            p = 0.25,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "test"
+
+        // Single element sequence - constant estimation - p = 0.75 (third quartile)
+        sequenceOf("test").quantileOrNull(
+            p = 0.75,
+            type = typeOf<String>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+        ) shouldBe "test"
+
+        // We don't test extreme low quantile values (p close to 0.0) as they can cause index calculation issues
+
+        // We don't test extreme high quantile values (p close to 1.0) as they can cause index calculation issues
+
+        // All NaN values with skipNaN = true - p = 0.1 (10th percentile)
+        sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // All NaN values with skipNaN = true - p = 0.5 (median)
+        sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // All NaN values with skipNaN = true - p = 0.25 (first quartile)
+        sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // All NaN values with skipNaN = true - p = 0.75 (third quartile)
+        sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // All NaN values with skipNaN = true - p = 0.9 (90th percentile)
+        sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = true,
+            method = QuantileEstimationMethod.R8,
+        ) shouldBe null
+
+        // All NaN values with skipNaN = false - p = 0.1 (10th percentile)
+        val result01 = sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.1,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (result01 as Double).isNaN() shouldBe true
+
+        // All NaN values with skipNaN = false - p = 0.5 (median)
+        val result = sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.5,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (result as Double).isNaN() shouldBe true
+
+        // All NaN values with skipNaN = false - p = 0.25 (first quartile)
+        val result25 = sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.25,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (result25 as Double).isNaN() shouldBe true
+
+        // All NaN values with skipNaN = false - p = 0.75 (third quartile)
+        val result75 = sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.75,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (result75 as Double).isNaN() shouldBe true
+
+        // All NaN values with skipNaN = false - p = 0.9 (90th percentile)
+        val result09 = sequenceOf(Double.NaN, Double.NaN).quantileOrNull(
+            p = 0.9,
+            type = typeOf<Double>(),
+            skipNaN = false,
+            method = QuantileEstimationMethod.R8,
+        )
+        (result09 as Double).isNaN() shouldBe true
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/QuantileTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/QuantileTests.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.statistics
 
+import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
+import org.apache.commons.statistics.descriptive.Quantile
 import org.jetbrains.kotlinx.dataframe.math.QuantileEstimationMethod
 import org.jetbrains.kotlinx.dataframe.math.quantileOrNull
 import org.junit.Test
@@ -16,7 +18,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.0
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.1)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Double - p = 0.5 (median)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -24,7 +28,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.5
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Double - p = 0.25 (first quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -32,7 +38,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.4166666666666665
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Double - p = 0.75 (third quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -40,7 +48,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 3.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Double - p = 0.9 (90th percentile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -48,7 +58,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 4.0
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.9)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Double - p = 0.1 (10th percentile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -56,7 +68,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.0
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.1)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Double - p = 0.5 (median)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -64,7 +78,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.8333333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Double - p = 0.25 (first quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -72,7 +88,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.0833333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Double - p = 0.75 (third quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -80,7 +98,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 2.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Double - p = 0.9 (90th percentile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
@@ -88,7 +108,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 3.0333333333333337
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.9)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Int - p = 0.5 (median)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -96,7 +118,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.5
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Int - p = 0.25 (first quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -104,7 +128,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.4166666666666665
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Int - p = 0.75 (third quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -112,7 +138,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 3.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Int - p = 0.5 (median)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -120,7 +148,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.8333333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Int - p = 0.25 (first quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -128,7 +158,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.0833333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Int - p = 0.75 (third quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
@@ -136,7 +168,9 @@ class QuantileTests {
             type = typeOf<Int>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 2.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Float - p = 0.5 (median)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -144,7 +178,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.5
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Float - p = 0.25 (first quartile)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -152,7 +188,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.4166666666666665
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Float - p = 0.75 (third quartile)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -160,7 +198,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 3.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Float - p = 0.5 (median)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -168,7 +208,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.8333333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Float - p = 0.25 (first quartile)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -176,7 +218,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.0833333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Float - p = 0.75 (third quartile)
         sequenceOf(1f, 4f, 3f, 2f).quantileOrNull(
@@ -184,7 +228,9 @@ class QuantileTests {
             type = typeOf<Float>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 2.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Long - p = 0.5 (median)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -192,7 +238,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.5
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Long - p = 0.25 (first quartile)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -200,7 +248,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.4166666666666665
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R8 with Long - p = 0.75 (third quartile)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -208,7 +258,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 3.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Long - p = 0.5 (median)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -216,7 +268,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.8333333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Long - p = 0.25 (first quartile)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -224,7 +278,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 1.0833333333333333
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test R7 with Long - p = 0.75 (third quartile)
         sequenceOf(1L, 4L, 3L, 2L).quantileOrNull(
@@ -232,7 +288,9 @@ class QuantileTests {
             type = typeOf<Long>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R7,
-        ) shouldBe 2.5833333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF7)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
 
         // Test with NaN values and skipNaN = false - p = 0.5 (median)
         val nanResult = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
@@ -267,7 +325,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.0
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.5)
+            .plusOrMinus(1e-10)
 
         // Test with NaN values and skipNaN = true - p = 0.25 (first quartile)
         sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
@@ -275,7 +335,9 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 1.1666666666666667
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.25)
+            .plusOrMinus(1e-10)
 
         // Test with NaN values and skipNaN = true - p = 0.75 (third quartile)
         sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
@@ -283,9 +345,12 @@ class QuantileTests {
             type = typeOf<Double>(),
             skipNaN = true,
             method = QuantileEstimationMethod.R8,
-        ) shouldBe 2.8333333333333335
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF8)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.75)
+            .plusOrMinus(1e-10)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun `constant estimation`() {
         // Test R3 with Char - p = 0.1 (10th percentile)
@@ -293,7 +358,7 @@ class QuantileTests {
             p = 0.1,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'a'
 
         // Test R3 with Char - p = 0.5 (median)
@@ -301,15 +366,15 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
-        ) shouldBe 'a'
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char, *>,
+        ) shouldBe 'b'
 
         // Test R3 with Char - p = 0.25 (first quartile)
         sequenceOf('a', 'c', 'b').quantileOrNull(
             p = 0.25,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'a'
 
         // Test R3 with Char - p = 0.75 (third quartile)
@@ -317,7 +382,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'b'
 
         // Test R3 with Char - p = 0.9 (90th percentile)
@@ -325,15 +390,15 @@ class QuantileTests {
             p = 0.9,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char>,
-        ) shouldBe 'b'
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Char, *>,
+        ) shouldBe 'c'
 
         // Test R1 with Char - p = 0.1 (10th percentile)
         sequenceOf('a', 'c', 'b').quantileOrNull(
             p = 0.1,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'a'
 
         // Test R1 with Char - p = 0.5 (median)
@@ -341,7 +406,7 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'b'
 
         // Test R1 with Char - p = 0.25 (first quartile)
@@ -349,7 +414,7 @@ class QuantileTests {
             p = 0.25,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'a'
 
         // Test R1 with Char - p = 0.75 (third quartile)
@@ -357,7 +422,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'c'
 
         // Test R1 with Char - p = 0.9 (90th percentile)
@@ -365,7 +430,7 @@ class QuantileTests {
             p = 0.9,
             type = typeOf<Char>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Char, *>,
         ) shouldBe 'c'
 
         // Test R3 with String - p = 0.5 (median)
@@ -373,15 +438,15 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
-        ) shouldBe "apple"
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
+        ) shouldBe "banana"
 
         // Test R3 with String - p = 0.25 (first quartile)
         sequenceOf("apple", "cherry", "banana").quantileOrNull(
             p = 0.25,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
         ) shouldBe "apple"
 
         // Test R3 with String - p = 0.75 (third quartile)
@@ -389,7 +454,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
         ) shouldBe "banana"
 
         // Test R1 with String - p = 0.5 (median)
@@ -397,7 +462,7 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String, *>,
         ) shouldBe "banana"
 
         // Test R1 with String - p = 0.25 (first quartile)
@@ -405,7 +470,7 @@ class QuantileTests {
             p = 0.25,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String, *>,
         ) shouldBe "apple"
 
         // Test R1 with String - p = 0.75 (third quartile)
@@ -413,7 +478,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<String, *>,
         ) shouldBe "cherry"
 
         // Test R3 with Int (primitive number) - p = 0.5 (median)
@@ -421,103 +486,121 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
-        ) shouldBe 2
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .toInt()
 
         // Test R3 with Int (primitive number) - p = 0.25 (first quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
             p = 0.25,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
-        ) shouldBe 1
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .toInt()
 
         // Test R3 with Int (primitive number) - p = 0.75 (third quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
             p = 0.75,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int>,
-        ) shouldBe 2
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .toInt()
 
         // Test R1 with Int (primitive number) - p = 0.5 (median)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
             p = 0.5,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
-        ) shouldBe 2
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
+            .toInt()
 
         // Test R1 with Int (primitive number) - p = 0.25 (first quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
             p = 0.25,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
-        ) shouldBe 1
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
+            .toInt()
 
         // Test R1 with Int (primitive number) - p = 0.75 (third quartile)
         sequenceOf(1, 4, 3, 2).quantileOrNull(
             p = 0.75,
             type = typeOf<Int>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int>,
-        ) shouldBe 3
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Int, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
+            .toInt()
 
         // Test R3 with Double (primitive number) - p = 0.5 (median)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.5,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 2.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
 
         // Test R3 with Double (primitive number) - p = 0.25 (first quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.25,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 1.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
 
         // Test R3 with Double (primitive number) - p = 0.75 (third quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.75,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 2.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
 
         // Test R1 with Double (primitive number) - p = 0.5 (median)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.5,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
-        ) shouldBe 2.0
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.5)
 
         // Test R1 with Double (primitive number) - p = 0.25 (first quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.25,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
-        ) shouldBe 1.0
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.25)
 
         // Test R1 with Double (primitive number) - p = 0.75 (third quartile)
         sequenceOf(1.0, 4.0, 3.0, 2.0).quantileOrNull(
             p = 0.75,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double>,
-        ) shouldBe 3.0
+            method = QuantileEstimationMethod.R1 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF1)
+            .evaluate(doubleArrayOf(1.0, 4.0, 3.0, 2.0), 0.75)
 
         // Test with NaN values and skipNaN = false - p = 0.5 (median)
         val nanResult = sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
             p = 0.5,
             type = typeOf<Double>(),
             skipNaN = false,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
         )
         (nanResult as Double).isNaN() shouldBe true
 
@@ -526,7 +609,7 @@ class QuantileTests {
             p = 0.25,
             type = typeOf<Double>(),
             skipNaN = false,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
         )
         (nanResult25 as Double).isNaN() shouldBe true
 
@@ -535,7 +618,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<Double>(),
             skipNaN = false,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
         )
         (nanResult75 as Double).isNaN() shouldBe true
 
@@ -544,24 +627,27 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 1.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.5)
 
         // Test with NaN values and skipNaN = true - p = 0.25 (first quartile)
         sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
             p = 0.25,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 1.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.25)
 
         // Test with NaN values and skipNaN = true - p = 0.75 (third quartile)
         sequenceOf(1.0, Double.NaN, 3.0, 2.0).quantileOrNull(
             p = 0.75,
             type = typeOf<Double>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double>,
-        ) shouldBe 2.0
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<Double, *>,
+        ) shouldBe Quantile.withDefaults().with(Quantile.EstimationMethod.HF3)
+            .evaluate(doubleArrayOf(1.0, 3.0, 2.0), 0.75)
     }
 
     @Test
@@ -651,7 +737,7 @@ class QuantileTests {
             p = 0.5,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
         ) shouldBe "test"
 
         // Single element sequence - constant estimation - p = 0.25 (first quartile)
@@ -659,7 +745,7 @@ class QuantileTests {
             p = 0.25,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
         ) shouldBe "test"
 
         // Single element sequence - constant estimation - p = 0.75 (third quartile)
@@ -667,7 +753,7 @@ class QuantileTests {
             p = 0.75,
             type = typeOf<String>(),
             skipNaN = true,
-            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String>,
+            method = QuantileEstimationMethod.R3 as QuantileEstimationMethod<String, *>,
         ) shouldBe "test"
 
         // We don't test extreme low quantile values (p close to 0.0) as they can cause index calculation issues

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/percentile.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/percentile.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.mapToColumn
 import org.jetbrains.kotlinx.dataframe.api.percentile
-import org.jetbrains.kotlinx.dataframe.api.rowPercentile
+import org.jetbrains.kotlinx.dataframe.api.rowPercentileOf
 import org.junit.Test
 
 @Suppress("ktlint:standard:argument-list-wrapping")
@@ -19,7 +19,7 @@ class PercentileTests {
             2, 6,
             7, 7,
         )
-        df.percentile(60.0, "a", "b") shouldBe 6
+        df.percentile(60.0, "a", "b") shouldBe 6.133333333333333
     }
 
     @Test
@@ -29,6 +29,7 @@ class PercentileTests {
             2, 4, 10,
             7, 7, 1,
         )
-        df.mapToColumn("", Infer.Type) { it.rowPercentile(25.0) } shouldBe columnOf(1, 2, 1)
+        df.mapToColumn("", Infer.Type) { it.rowPercentileOf<Int>(25.0) } shouldBe
+            columnOf(1, 2, 2)
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/percentile.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/statistics/percentile.kt
@@ -1,25 +1,64 @@
+@file:OptIn(ExperimentalTypeInference::class)
+
 package org.jetbrains.kotlinx.dataframe.statistics
 
+import io.kotest.matchers.doubles.shouldBeNaN
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.api.Infer
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.groupBy
 import org.jetbrains.kotlinx.dataframe.api.mapToColumn
 import org.jetbrains.kotlinx.dataframe.api.percentile
+import org.jetbrains.kotlinx.dataframe.api.percentileBy
+import org.jetbrains.kotlinx.dataframe.api.percentileByOrNull
+import org.jetbrains.kotlinx.dataframe.api.percentileFor
+import org.jetbrains.kotlinx.dataframe.api.percentileOf
+import org.jetbrains.kotlinx.dataframe.api.percentileOrNull
 import org.jetbrains.kotlinx.dataframe.api.rowPercentileOf
+import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.junit.Test
+import kotlin.experimental.ExperimentalTypeInference
+import kotlin.reflect.typeOf
 
 @Suppress("ktlint:standard:argument-list-wrapping")
 class PercentileTests {
 
+    val personsDf = dataFrameOf("name", "age", "city", "weight", "height", "yearsToRetirement")(
+        "Alice", 15, "London", 99.5, "1.85", 50,
+        "Bob", 20, "Paris", 140.0, "1.35", 45,
+        "Charlie", 100, "Dubai", 75.0, "1.95", 0,
+        "Rose", 1, "Moscow", 45.33, "0.79", 64,
+        "Dylan", 35, "London", 23.4, "1.83", 30,
+        "Eve", 40, "Paris", 56.72, "1.85", 25,
+        "Frank", 55, "Dubai", 78.9, "1.35", 10,
+        "Grace", 29, "Moscow", 67.8, "1.65", 36,
+        "Hank", 60, "Paris", 80.22, "1.75", 5,
+        "Isla", 22, "London", 75.1, "1.85", 43,
+    )
+
+    @Test
+    fun `percentileOf test`() {
+        val d = personsDf.groupBy("city").percentileOf(75.0, "newAge") { "age"<Int>() * 10 }
+        d["newAge"].type() shouldBe typeOf<Double>()
+    }
+
     @Test
     fun `percentile of two columns`() {
-        val df = dataFrameOf("a", "b")(
-            1, 4,
-            2, 6,
-            7, 7,
+        val df = dataFrameOf("a", "b", "c")(
+            1, 4, "a",
+            2, 6, "b",
+            7, 7, "c",
         )
         df.percentile(60.0, "a", "b") shouldBe 6.133333333333333
+        df.percentile(60.0) { "a"<Int>() and "b"<Int>() } shouldBe 6.133333333333333
+        df.percentileOrNull(60.0) { "a"<Int>() and "b"<Int>() } shouldBe 6.133333333333333
+        df.percentile(50.0, "c") shouldBe "b"
+
+        df.percentile<_, String>(50.0) { "c"<String>() } shouldBe "b"
+        df.percentileOrNull<_, String>(50.0) { "c"<String>() } shouldBe "b"
     }
 
     @Test
@@ -29,7 +68,236 @@ class PercentileTests {
             2, 4, 10,
             7, 7, 1,
         )
-        df.mapToColumn("", Infer.Type) { it.rowPercentileOf<Int>(25.0) } shouldBe
-            columnOf(1, 2, 2)
+        df.mapToColumn("", Infer.Type) { it.rowPercentileOf<Int>(25.0) } shouldBe columnOf(1, 2, 2)
+        df.mapToColumn("", Infer.Type) { it.rowPercentileOf<Int>(50.0) } shouldBe columnOf(3, 4, 7)
+        df.mapToColumn("", Infer.Type) { it.rowPercentileOf<Int>(75.0) } shouldBe columnOf(3, 9, 7)
+    }
+
+    @Test
+    fun `percentile with regular values`() {
+        val col = columnOf(5, 2, 8, 1, 9)
+        col.percentile(25.0) shouldBe 1.6666666666666665
+        col.percentile(50.0) shouldBe 5
+        col.percentile(75.0) shouldBe 8.333333333333332
+        col.percentile(90.0) shouldBe 9
+    }
+
+    @Test
+    fun `percentile with null`() {
+        val colWithNull = columnOf(5, 2, null, 1, 9)
+        colWithNull.percentile(25.0) shouldBe 1.4166666666666665
+        colWithNull.percentile(50.0) shouldBe 3.5
+        colWithNull.percentile(75.0) shouldBe 7.333333333333334
+    }
+
+    @Test
+    fun `percentile with different numeric types`() {
+        // Integer types
+        columnOf(5, 2, 8, 1, 9).percentile(50.0) shouldBe 5.0
+        columnOf(5L, 2L, 8L, 1L, 9L).percentile(50.0) shouldBe 5.0
+
+        // Floating point types
+        columnOf(5.0, 2.0, 8.0, 1.0, 9.0).percentile(50.0) shouldBe 5.0
+        columnOf(5.0f, 2.0f, 8.0f, 1.0f, 9.0f).percentile(50.0) shouldBe 5.0
+
+        // Test with different percentile values
+        columnOf(5, 2, 8, 1, 9).percentile(25.0) shouldBe 1.6666666666666665
+        columnOf(5, 2, 8, 1, 9).percentile(75.0) shouldBe 8.333333333333332
+    }
+
+    @Test
+    fun `percentile with empty column`() {
+        DataColumn.createValueColumn("", emptyList<Nothing>(), nothingType(false)).percentileOrNull(50.0).shouldBeNull()
+        DataColumn.createValueColumn("", emptyList<Nothing>(), nothingType(false)).percentileOrNull(25.0).shouldBeNull()
+        DataColumn.createValueColumn("", emptyList<Nothing>(), nothingType(false)).percentileOrNull(75.0).shouldBeNull()
+    }
+
+    @Test
+    fun `percentile with just nulls`() {
+        val column = DataColumn.createValueColumn<Int?>("", listOf(null, null), nothingType(true))
+        column.percentileOrNull(50.0).shouldBeNull()
+        column.percentileOrNull(25.0).shouldBeNull()
+        column.percentileOrNull(75.0).shouldBeNull()
+    }
+
+    @Test
+    fun `percentile with just NaNs`() {
+        columnOf(Double.NaN, Double.NaN).percentile(50.0).shouldBeNaN()
+        columnOf(Double.NaN, Double.NaN).percentileOrNull(50.0)!!.shouldBeNaN()
+
+        // With skipNaN=true and only NaN values, result should be null
+        columnOf(Double.NaN, Double.NaN).percentileOrNull(50.0, skipNaN = true).shouldBeNull()
+    }
+
+    @Test
+    fun `percentile with nans and nulls`() {
+        // Percentile functions should return NaN if any value is NaN
+        columnOf(5.0, 2.0, Double.NaN, 1.0, null).percentile(50.0).shouldBeNaN()
+
+        // With skipNaN=true, NaN values should be ignored
+        columnOf(5.0, 2.0, Double.NaN, 1.0, null).percentile(50.0, skipNaN = true) shouldBe 2.0
+        columnOf(5.0, 2.0, Double.NaN, 1.0, null).percentile(25.0, skipNaN = true) shouldBe 1.1666666666666667
+        columnOf(5.0, 2.0, Double.NaN, 1.0, null).percentile(75.0, skipNaN = true) shouldBe 4.5
+    }
+
+    @Test
+    fun `percentileBy with selector function`() {
+        // Test with a data class
+        data class Person(val name: String, val age: Int)
+
+        val people = columnOf(
+            Person("Charlie", 35),
+            Person("Bob", 25),
+            Person("Alice", 30),
+        )
+
+        // Find person with percentile age
+        people.percentileBy(0.0) { it.age } shouldBe Person("Bob", 25)
+        people.percentileBy(25.0) { it.age } shouldBe Person("Bob", 25)
+        people.percentileBy(50.0) { it.age } shouldBe Person("Alice", 30)
+        people.percentileBy(75.0) { it.age } shouldBe Person("Alice", 30)
+        people.percentileBy(100.0) { it.age } shouldBe Person("Charlie", 35)
+
+        // With null values
+        val peopleWithNull = columnOf(
+            Person("Alice", 30),
+            Person("Bob", 25),
+            null,
+            Person("Charlie", 35),
+        )
+
+        peopleWithNull.percentileBy(50.0) { it?.age ?: Int.MAX_VALUE } shouldBe Person("Alice", 30)
+        peopleWithNull.percentileByOrNull(50.0) { it?.age ?: Int.MAX_VALUE } shouldBe Person("Alice", 30)
+    }
+
+    @Test
+    fun `percentileOf with transformer function`() {
+        // Test with strings that can be converted to numbers
+        val strings = columnOf("5", "2", "8", "1", "9")
+        strings.percentileOf(50.0) { it.toInt() } shouldBe 5
+        strings.percentileOf(25.0) { it.toInt() } shouldBe 1.6666666666666665
+        strings.percentileOf(75.0) { it.toInt() } shouldBe 8.333333333333332
+    }
+
+    @Test
+    fun `percentileOf with transformer function with nulls`() {
+        val stringsWithNull = columnOf("5", "2", null, "1", "9")
+        stringsWithNull.percentileOf(50.0) { it?.toInt() } shouldBe 3.5
+        stringsWithNull.percentileOf(25.0) { it?.toInt() } shouldBe 1.4166666666666665
+        stringsWithNull.percentileOf(75.0) { it?.toInt() } shouldBe 7.333333333333334
+    }
+
+    @Test
+    fun `percentileOf with transformer function with NaNs`() {
+        // Percentile functions should return NaN if any value is NaN
+        val mixedValues = columnOf("5.0", "2.0", "NaN", "1.0", "9.0")
+        mixedValues.percentileOf(50.0) {
+            val num = it.toDoubleOrNull()
+            if (num == null || num.isNaN()) Double.NaN else num
+        }.shouldBeNaN()
+
+        // With skipNaN=true, NaN values should be ignored
+        mixedValues.percentileOf(50.0, skipNaN = true) {
+            val num = it.toDoubleOrNull()
+            if (num == null || num.isNaN()) Double.NaN else num
+        } shouldBe 3.5
+    }
+
+    @[Test Suppress("ktlint:standard:argument-list-wrapping")]
+    fun `rowPercentileOf with dataframe`() {
+        val df = dataFrameOf(
+            "a", "b", "c",
+        )(
+            1f, 2, 3,
+            4f, 5, 6,
+            7f, 8, 9,
+        )
+
+        // Find percentile value in each row
+        df[0].rowPercentileOf<Int>(25.0) shouldBe 2.0
+        df[0].rowPercentileOf<Int>(50.0) shouldBe 2.5
+        df[0].rowPercentileOf<Int>(75.0) shouldBe 3.0
+
+        df[1].rowPercentileOf<Float>(50.0) shouldBe 4.0
+        df[2].rowPercentileOf<Int>(50.0) shouldBe 8.5
+    }
+
+    @[Test Suppress("ktlint:standard:argument-list-wrapping")]
+    fun `dataframe percentile`() {
+        val df = dataFrameOf(
+            "a", "b", "c",
+        )(
+            1, 2f, 3.0,
+            4, 5f, 6.0,
+            7, 8f, 9.0,
+        )
+
+        // Get row with percentile values for each column
+        val percentiles50 = df.percentile(50.0)
+        percentiles50["a"] shouldBe 4
+        percentiles50["b"] shouldBe 5f
+        percentiles50["c"] shouldBe 6.0
+
+        val percentiles25 = df.percentile(25.0)
+        percentiles25["a"] shouldBe 1.5000000000000002
+        percentiles25["b"] shouldBe 2.5f
+        percentiles25["c"] shouldBe 3.5
+
+        val percentiles75 = df.percentile(75.0)
+        percentiles75["a"] shouldBe 6.5
+        percentiles75["b"] shouldBe 7.5f
+        percentiles75["c"] shouldBe 8.5
+
+        // Test percentile for specific columns
+        val percentileFor50 = df.percentileFor(50.0, "a", "c")
+        percentileFor50["a"] shouldBe 4
+        percentileFor50["c"] shouldBe 6.0
+    }
+
+    @[Test Suppress("ktlint:standard:argument-list-wrapping")]
+    fun `dataframe percentileBy and percentileOf`() {
+        val df = dataFrameOf(
+            "a", "b", "c",
+        )(
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        )
+
+        // Find row with percentile value of column "a"
+        val percentileByA50 = df.percentileBy(50.0, "a")
+        percentileByA50["a"] shouldBe 4
+        percentileByA50["b"] shouldBe 5
+        percentileByA50["c"] shouldBe 6
+
+        val percentileByA25 = df.percentileBy(25.0, "a")
+        percentileByA25["a"] shouldBe 1
+        percentileByA25["b"] shouldBe 2
+        percentileByA25["c"] shouldBe 3
+
+        val percentileByA75 = df.percentileBy(75.0, "a")
+        percentileByA75["a"] shouldBe 4
+        percentileByA75["b"] shouldBe 5
+        percentileByA75["c"] shouldBe 6
+
+        // Find percentile value of a + c for each row, [1+3, 4+6, 7+9] => [4, 10, 16]
+        df.percentileOf(50.0) { "a"<Int>() + "c"<Int>() } shouldBe 10.0
+        df.percentileOf(25.0) { "a"<Int>() + "c"<Int>() } shouldBe 5.0
+        df.percentileOf(75.0) { "a"<Int>() + "c"<Int>() } shouldBe 15.0
+    }
+
+    @[Test Suppress("ktlint:standard:argument-list-wrapping")]
+    fun `percentile with NaN values for floating point numbers`() {
+        // Test with Float.NaN values
+        val floatWithNaN = columnOf(5.0f, 2.0f, Float.NaN, 1.0f, 9.0f)
+        floatWithNaN.percentile(50.0).shouldBeNaN() // Percentile functions should return NaN if any value is NaN
+        floatWithNaN.percentile(50.0, skipNaN = true) shouldBe 3.5 // With skipNaN=true, NaN values should be ignored
+        floatWithNaN.percentile(25.0, skipNaN = true) shouldBe 1.4166666666666665
+        floatWithNaN.percentile(75.0, skipNaN = true) shouldBe 7.333333333333334
+
+        // Test with Double.NaN values
+        val doubleWithNaN = columnOf(5.0, 2.0, Double.NaN, 1.0, 9.0)
+        doubleWithNaN.percentile(50.0).shouldBeNaN() // Percentile functions should return NaN if any value is NaN
+        doubleWithNaN.percentile(50.0, skipNaN = true) shouldBe 3.5 // With skipNaN=true, NaN values should be ignored
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ fastDoubleParser = "2.0.1"
 commonsCsv = "1.12.0"
 commonsCompress = "1.27.1"
 commonsIo = "2.18.0"
+commonsStatistics = "1.1"
 serialization = "1.7.1"
 poi = "5.3.0"
 mariadb = "3.5.1"
@@ -74,6 +75,8 @@ fastDoubleParser = { group = "ch.randelshofer", name = "fastdoubleparser", versi
 commonsCsv = { group = "org.apache.commons", name = "commons-csv", version.ref = "commonsCsv" }
 commonsCompress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
 commonsIo = { group = "commons-io", name = "commons-io", version.ref = "commonsIo" }
+commonsStatisticsDescriptive = { group = "org.apache.commons", name = "commons-statistics-descriptive", version.ref = "commonsStatistics" }
+
 # Serialization
 serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }
 serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
Helps https://github.com/Kotlin/dataframe/issues/961

- rewrites percentile implementation using quantile implementation (R3 and R8) (https://github.com/Kotlin/dataframe/issues/1121)
- adds quantile implementation
  - based on https://en.wikipedia.org/wiki/Quantile
  - and Hyndman and Fan (1996) Sample Quantiles in Statistical Packages. The American Statistician, 50, 361-365. [doi.org/10.2307/2684934](https://www.jstor.org/stable/2684934)
  - Comparing output in tests with Apache Commons Statistics
  - Adds and tests R1, R3, R7, and R8. Will add others later when needed. Currently we only use R3 and R8. R3 for selecting, R8 for linear interpolation (as recommended by the H&F paper). Other statistics libraries often use R7 as default, so we can switch if needed.
  - Rewrote `median` to use R3 and R8 as well