### PR TITLE
Generate fields for markers in REPL so compiler plugin can extract the schema

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5775,7 +5775,7 @@ public final class org/jetbrains/kotlinx/dataframe/impl/io/FastDoubleParser {
 
 public final class org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl : org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema {
 	public fun <init> (Ljava/util/Map;)V
-	public fun compare (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;)Lorg/jetbrains/kotlinx/dataframe/schema/CompareResult;
+	public fun compare (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Z)Lorg/jetbrains/kotlinx/dataframe/schema/CompareResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getColumns ()Ljava/util/Map;
 	public fun hashCode ()I
@@ -6618,7 +6618,8 @@ public final class org/jetbrains/kotlinx/dataframe/schema/CompareResult$Companio
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema {
-	public abstract fun compare (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;)Lorg/jetbrains/kotlinx/dataframe/schema/CompareResult;
+	public abstract fun compare (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Z)Lorg/jetbrains/kotlinx/dataframe/schema/CompareResult;
+	public static synthetic fun compare$default (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/schema/CompareResult;
 	public abstract fun getColumns ()Ljava/util/Map;
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -81,7 +81,7 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
         val result = generator.generate(
             schema = schema,
             name = name,
-            fields = false,
+            fields = true,
             extensionProperties = true,
             isOpen = isOpen,
             visibility = MarkerVisibility.IMPLICIT_PUBLIC,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
@@ -7,23 +7,23 @@ import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
 public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>) : DataFrameSchema {
 
-    override fun compare(other: DataFrameSchema): CompareResult {
+    override fun compare(other: DataFrameSchema, strictlyEqualNestedSchemas: Boolean): CompareResult {
         require(other is DataFrameSchemaImpl)
         if (this === other) return CompareResult.Equals
         var result = CompareResult.Equals
         columns.forEach {
             val otherColumn = other.columns[it.key]
             if (otherColumn == null) {
-                result = result.combine(CompareResult.IsDerived)
+                result = result.combine(if (strictlyEqualNestedSchemas) CompareResult.None else CompareResult.IsDerived)
             } else {
-                result = result.combine(it.value.compare(otherColumn))
+                result = result.combine(it.value.compareStrictlyEqualNestedSchemas(otherColumn))
             }
             if (result == CompareResult.None) return CompareResult.None
         }
         other.columns.forEach {
             val thisField = columns[it.key]
             if (thisField == null) {
-                result = result.combine(CompareResult.IsSuper)
+                result = result.combine(if (strictlyEqualNestedSchemas) CompareResult.None else CompareResult.IsSuper)
                 if (result == CompareResult.None) return CompareResult.None
             }
         }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
@@ -4,5 +4,9 @@ public interface DataFrameSchema {
 
     public val columns: Map<String, ColumnSchema>
 
-    public fun compare(other: DataFrameSchema): CompareResult
+    /**
+     * By default generated markers for leafs aren't used as supertypes: @DataSchema(isOpen = false)
+     * strictlyEqualNestedSchemas = true takes this into account for internal codegen logic
+     */
+    public fun compare(other: DataFrameSchema, strictlyEqualNestedSchemas: Boolean = false): CompareResult
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -103,7 +103,12 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName { }
+            interface $typeName {
+                val age: Int
+                val city: String?
+                val name: String
+                val weight: Int?
+            }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -129,7 +134,12 @@ class CodeGenerationTests : BaseTest() {
         val expectedDeclaration =
             """
             @DataSchema
-            interface $typeName { }
+            interface $typeName {
+                val age: Int
+                val city: String?
+                val name: String
+                val weight: Int?
+            }
             
             """.trimIndent() + "\n" + expectedProperties(typeName, typeName)
 
@@ -149,7 +159,10 @@ class CodeGenerationTests : BaseTest() {
         val declaration1 =
             """
             @DataSchema(isOpen = false)
-            interface $type1 { }
+            interface $type1 {
+                val city: String?
+                val name: String
+            }
             
             val $dfName<$type1>.city: $dataCol<$stringName?> @JvmName("${type1}_city") get() = this["city"] as $dataCol<$stringName?>
             val $dfRowName<$type1>.city: $stringName? @JvmName("${type1}_city") get() = this["city"] as $stringName?
@@ -161,7 +174,11 @@ class CodeGenerationTests : BaseTest() {
         val declaration2 =
             """
             @DataSchema
-            interface $type2 { }
+            interface $type2 {
+                val age: Int
+                val nameAndCity: _DataFrameType1
+                val weight: Int?
+            }
             
             val $dfName<$type2>.age: $dataCol<$intName> @JvmName("${type2}_age") get() = this["age"] as $dataCol<$intName>
             val $dfRowName<$type2>.age: $intName @JvmName("${type2}_age") get() = this["age"] as $intName

--- a/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
+++ b/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
@@ -61,4 +61,13 @@ class CodeGenerationTests : DataFrameJupyterTest() {
             ab.a
         """.checkCompilation()
     }
+
+    @Test
+    fun `nested schema with isOpen = false is ignored in marker generation`() {
+        """
+        val df = dataFrameOf("col" to listOf("a"), "leaf" to listOf(dataFrameOf("a", "b")(1, 2).first()))
+        val df1 = df.convert { leaf }.asFrame { it.add("c") { 3 } }
+        df1.leaf.c
+        """.checkCompilation()
+    }
 }


### PR DESCRIPTION
without this change plugin cannot see schemas from previous cells, generated by REPL:
```
val df = DataFrame.read("...")
%%
val df1 = df.add("a") { 42 } 
// only df1.a is available here, because from plugin POV df has empty schema
```
After this PR generated markers (DataFrame<*T*>) will have unified structure, so schema can be extracted from both REPL and plugin generated ones