### PR TITLE
Add a common interface for exceptions that should be reported by the plugin

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5459,7 +5459,7 @@ public final class org/jetbrains/kotlinx/dataframe/exceptions/CellConversionExce
 	public final fun getRow ()Ljava/lang/Integer;
 }
 
-public final class org/jetbrains/kotlinx/dataframe/exceptions/ColumnNotFoundException : java/lang/RuntimeException {
+public final class org/jetbrains/kotlinx/dataframe/exceptions/ColumnNotFoundException : java/lang/RuntimeException, org/jetbrains/kotlinx/dataframe/exceptions/DataFrameException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getColumnName ()Ljava/lang/String;
 	public fun getMessage ()Ljava/lang/String;
@@ -5470,7 +5470,11 @@ public final class org/jetbrains/kotlinx/dataframe/exceptions/ColumnTypeMismatch
 	public final fun getColumn ()Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 }
 
-public final class org/jetbrains/kotlinx/dataframe/exceptions/DuplicateColumnNamesException : java/lang/IllegalArgumentException {
+public abstract interface class org/jetbrains/kotlinx/dataframe/exceptions/DataFrameException {
+	public abstract fun getMessage ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/exceptions/DuplicateColumnNamesException : java/lang/IllegalArgumentException, org/jetbrains/kotlinx/dataframe/exceptions/DataFrameException {
 	public fun <init> (Ljava/util/List;)V
 	public final fun getAllColumnNames ()Ljava/util/List;
 	public final fun getDuplicatedNames ()Ljava/util/List;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/ColumnNotFoundException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/ColumnNotFoundException.kt
@@ -1,4 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
 public class ColumnNotFoundException(public val columnName: String, public override val message: String) :
-    RuntimeException()
+    RuntimeException(),
+    DataFrameException

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/DataFrameException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/DataFrameException.kt
@@ -1,0 +1,8 @@
+package org.jetbrains.kotlinx.dataframe.exceptions
+
+/**
+ * If DataFrame function used by compiler plugin as implementation detail throws this exception, [message] will be reported as warning
+ */
+public interface DataFrameException {
+    public val message: String
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/DuplicateColumnNamesException.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/exceptions/DuplicateColumnNamesException.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.exceptions
 
-public class DuplicateColumnNamesException(public val allColumnNames: List<String>) : IllegalArgumentException() {
+public class DuplicateColumnNamesException(public val allColumnNames: List<String>) :
+    IllegalArgumentException(),
+    DataFrameException {
 
     public val duplicatedNames: List<String> = allColumnNames
         .groupBy { it }


### PR DESCRIPTION
Technically we can report any exception that happens inside interpret function. This interface is needed to gradually introduce warnings, to make sure that we have tests and message is reasonable, makes sense in compiler plugin context, ideally avoiding false positives