### PR TITLE
Deprecate predicate argument in single, colsInGroups, colsAtAnyDepth

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
@@ -65,8 +65,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
     /**
      * ## Cols At Any Depth
      *
-     * Returns all columns in [this\] at any depth (so also inside [Column Groups][ColumnGroup]) if they satisfy the
-     * optional given predicate.
+     * Returns all columns in [this\] at any depth (so also inside [Column Groups][ColumnGroup])
      *
      * This function can also be followed by another [ColumnSet] filter function like
      * [colsOf][ColumnsSelectionDsl.colsOf], [single][ColumnsSelectionDsl.single], or [valueCols][ColumnsSelectionDsl.valueCols].
@@ -74,7 +73,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * #### For example:
      * `// Depth-first search to a column containing the value "Alice"`
      *
-     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().`[first][ColumnsSelectionDsl.firstCol]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
+     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().`[filter][FilterColumnsSelectionDsl.filter]` { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() }.`[first][ColumnsSelectionDsl.firstCol]`() }`
      * {@include [LineBreak]}
      * `// The columns at any depth excluding the top-level`
      *
@@ -82,7 +81,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * {@include [LineBreak]}
      * `// All value- and frame columns at any depth`
      *
-     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]` { !it.`[isColumnGroup][DataColumn.isColumnGroup]` } }`
+     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().`[filter][FilterColumnsSelectionDsl.filter]` { !it.`[isColumnGroup][DataColumn.isColumnGroup]` } }`
      * {@include [LineBreak]}
      * `// All value columns at any depth nested under a column group named "myColGroup"`
      *
@@ -94,13 +93,13 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      *
      * #### Converting from deprecated syntax:
      *
-     * `dfs  { condition } -> `[colsAtAnyDepth][colsAtAnyDepth]` { condition }`
+     * `dfs  { condition } -> `[colsAtAnyDepth][colsAtAnyDepth]`().`[filter][FilterColumnsSelectionDsl.filter]` { condition }`
      *
-     * `allDfs(includeGroups = false) -> `[colsAtAnyDepth][colsAtAnyDepth]` { includeGroups || !it.`[isColumnGroup][DataColumn.isColumnGroup]`() }`
+     * `allDfs(includeGroups = false) -> `[colsAtAnyDepth][colsAtAnyDepth]`().`[filter][FilterColumnsSelectionDsl.filter]` { includeGroups || !it.`[isColumnGroup][DataColumn.isColumnGroup]`() }`
      *
      * `dfsOf<Type> { condition } -> `[colsAtAnyDepth][colsAtAnyDepth]`().`[colsOf][ColumnsSelectionDsl.colsOf]`<Type> { condition }`
      *
-     * [cols][ColumnsSelectionDsl.cols]` { condition }.`[recursively][recursively]`() -> `[colsAtAnyDepth][colsAtAnyDepth]` { condition }`
+     * [cols][ColumnsSelectionDsl.cols]` { condition }.`[recursively][recursively]`() -> `[colsAtAnyDepth][colsAtAnyDepth]`().`[filter][FilterColumnsSelectionDsl.filter]` { condition }`
      *
      * [first][ColumnsSelectionDsl.first]` { condition }.`[rec][rec]`() -> `[colsAtAnyDepth][colsAtAnyDepth]` { condition }.`[first][ColumnsSelectionDsl.first]`()`
      *
@@ -122,6 +121,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]`().`[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
      */
     @Interpretable("ColsAtAnyDepth0")
+    @Deprecated("", replaceWith = ReplaceWith("colsAtAnyDepth().filter(predicate)"))
     public fun ColumnSet<*>.colsAtAnyDepth(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         colsAtAnyDepthInternal(predicate)
 
@@ -129,13 +129,34 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * @include [CommonAtAnyDepthDocs]
      * @set [CommonAtAnyDepthDocs.Examples]
      *
-     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() }.`[first][ColumnsSelectionDsl.first]`() }`
+     * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]`().`[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().filter  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
+     */
+    @Interpretable("ColsAtAnyDepth0")
+    public fun ColumnSet<*>.colsAtAnyDepth(): ColumnSet<*> = colsAtAnyDepthInternal { true }
+
+    /**
+     * @include [CommonAtAnyDepthDocs]
+     * @set [CommonAtAnyDepthDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]` { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() }.`[first][ColumnsSelectionDsl.first]`() }`
      *
      * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]` { !it.`[isColumnGroup][DataColumn.isColumnGroup]` } }`
      */
     @Interpretable("ColsAtAnyDepth1")
+    @Deprecated("", replaceWith = ReplaceWith("colsAtAnyDepth().filter(predicate)"))
     public fun ColumnsSelectionDsl<*>.colsAtAnyDepth(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         asSingleColumn().colsAtAnyDepthInternal(predicate)
+
+    /**
+     * @include [CommonAtAnyDepthDocs]
+     * @set [CommonAtAnyDepthDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().filter  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() }.`[first][ColumnsSelectionDsl.first]`() }`
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().filter { !it.`[isColumnGroup][DataColumn.isColumnGroup]` } }`
+     */
+    @Interpretable("ColsAtAnyDepth1")
+    public fun ColumnsSelectionDsl<*>.colsAtAnyDepth(): ColumnSet<*> = asSingleColumn().colsAtAnyDepthInternal { true }
 
     /**
      * @include [CommonAtAnyDepthDocs]
@@ -144,6 +165,7 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColGroup.`[colsAtAnyDepth][SingleColumn.colsAtAnyDepth]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
      */
     @Interpretable("ColsAtAnyDepth2")
+    @Deprecated("", replaceWith = ReplaceWith("colsAtAnyDepth().filter(predicate)"))
     public fun SingleColumn<DataRow<*>>.colsAtAnyDepth(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         ensureIsColumnGroup().colsAtAnyDepthInternal(predicate)
 
@@ -151,10 +173,29 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      * @include [CommonAtAnyDepthDocs]
      * @set [CommonAtAnyDepthDocs.Examples]
      *
+     * `df.`[select][DataFrame.select]` { myColGroup.`[colsAtAnyDepth][SingleColumn.colsAtAnyDepth]`().filter  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
+     */
+    @Interpretable("ColsAtAnyDepth2")
+    public fun SingleColumn<DataRow<*>>.colsAtAnyDepth(): ColumnSet<*> =
+        ensureIsColumnGroup().colsAtAnyDepthInternal { true }
+
+    /**
+     * @include [CommonAtAnyDepthDocs]
+     * @set [CommonAtAnyDepthDocs.Examples]
+     *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsAtAnyDepth][String.colsAtAnyDepth]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
      */
+    @Deprecated("", replaceWith = ReplaceWith("colsAtAnyDepth().filter(predicate)"))
     public fun String.colsAtAnyDepth(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).colsAtAnyDepth(predicate)
+
+    /**
+     * @include [CommonAtAnyDepthDocs]
+     * @set [CommonAtAnyDepthDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsAtAnyDepth][String.colsAtAnyDepth]`().filter  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
+     */
+    public fun String.colsAtAnyDepth(): ColumnSet<*> = columnGroup(this).colsAtAnyDepth { true }
 
     /**
      * @include [CommonAtAnyDepthDocs]
@@ -175,8 +216,17 @@ public interface ColsAtAnyDepthColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
      */
+    @Deprecated("", replaceWith = ReplaceWith("colsAtAnyDepth().filter(predicate)"))
     public fun ColumnPath.colsAtAnyDepth(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).colsAtAnyDepth(predicate)
+
+    /**
+     * @include [CommonAtAnyDepthDocs]
+     * @set [CommonAtAnyDepthDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[colsAtAnyDepth][ColumnsSelectionDsl.colsAtAnyDepth]`().filter  { "Alice"  `[in][Iterable.contains]` it.`[values][DataColumn.values]`() } }`
+     */
+    public fun ColumnPath.colsAtAnyDepth(): ColumnSet<*> = columnGroup(this).colsAtAnyDepth { true }
 
     // endregion
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
@@ -65,7 +65,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
     /**
      * ## Cols in Groups
      *
-     * [colsInGroups][colsInGroups] is a function that returns all (optionally filtered) columns at the top-levels of
+     * [colsInGroups][colsInGroups] is a function that returns all columns at the top-levels of
      * all [column groups][ColumnGroup] in [this\]. This is useful if you want to select all columns that are
      * "one level deeper".
      *
@@ -87,11 +87,11 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * and
      *
-     * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnsSelectionDsl.colsInGroups]`  { "user"  `[in][String.contains]` it.`[name][DataColumn.name]` } }`
+     * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnsSelectionDsl.colsInGroups]`().`[nameContains][ColumnsSelectionDsl.nameContains]`("user") }`
      * {@include [LineBreak]}
      * Similarly, you can take the columns inside all [column groups][ColumnGroup] in a [ColumnSet]:
      * {@include [LineBreak]}
-     * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]`  { "my"  `[in][String.contains]` it.`[name][DataColumn.name]` }.`[colsInGroups][ColumnSet.colsInGroups]`() }`
+     * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]`().`[nameContains][ColumnsSelectionDsl.nameContains]`("my").`[colsInGroups][ColumnSet.colsInGroups]`() }`
      * {@include [LineBreak]}
      *
      * #### Examples of this overload:
@@ -100,8 +100,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * @see [ColumnsSelectionDsl.cols\]
      * @see [ColumnsSelectionDsl.colGroups\]
-     * @param [predicate\] An optional predicate to filter the cols by.
-     * @return A [TransformableColumnSet] containing the (filtered) cols.
+     * @return A [TransformableColumnSet] containing the cols.
      */
     private interface ColsInGroupsDocs {
 
@@ -117,8 +116,17 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[DataRow][DataRow]`<MyGroupType>>().`[colsInGroups][ColumnSet.colsInGroups]`() }`
      */
+    @Deprecated("", ReplaceWith("this.colsInGroups().filter(predicate)"))
     public fun ColumnSet<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
         transform { it.flatMap { it.cols().filter { predicate(it) } } }
+
+    /**
+     * @include [ColsInGroupsDocs]
+     * @set [ColsInGroupsDocs.EXAMPLE]
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[DataRow][DataRow]`<MyGroupType>>().`[colsInGroups][ColumnSet.colsInGroups]`() }`
+     */
+    public fun ColumnSet<*>.colsInGroups(): TransformableColumnSet<*> = transform { it.flatMap { it.cols() } }
 
     /**
      * @include [ColsInGroupsDocs]
@@ -128,8 +136,17 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnSet.colsInGroups]`() }`
      */
+    @Deprecated("", ReplaceWith("colsInGroups().filter(predicate)"))
     public fun ColumnsSelectionDsl<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
         asSingleColumn().colsInGroups(predicate)
+
+    /**
+     * @include [ColsInGroupsDocs]
+     * @set [ColsInGroupsDocs.EXAMPLE]
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnSet.colsInGroups]`() }`
+     */
+    public fun ColumnsSelectionDsl<*>.colsInGroups(): TransformableColumnSet<*> = asSingleColumn().colsInGroups()
 
     /**
      * @include [ColsInGroupsDocs]
@@ -139,6 +156,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsInGroups][SingleColumn.colsInGroups]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
+    @Deprecated("", ReplaceWith("this.colsInGroups().filter(predicate)"))
     public fun SingleColumn<DataRow<*>>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
         ensureIsColumnGroup().allColumnsInternal().colsInGroups(predicate)
 
@@ -146,10 +164,28 @@ public interface ColsInGroupsColumnsSelectionDsl {
      * @include [ColsInGroupsDocs]
      * @set [ColsInGroupsDocs.EXAMPLE]
      *
+     * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsInGroups][SingleColumn.colsInGroups]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
+     */
+    public fun SingleColumn<DataRow<*>>.colsInGroups(): TransformableColumnSet<*> =
+        ensureIsColumnGroup().allColumnsInternal().colsInGroups()
+
+    /**
+     * @include [ColsInGroupsDocs]
+     * @set [ColsInGroupsDocs.EXAMPLE]
+     *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsInGroups][String.colsInGroups]`() }`
      */
+    @Deprecated("", ReplaceWith("colsInGroups().filter(predicate)"))
     public fun String.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
         columnGroup(this).colsInGroups(predicate)
+
+    /**
+     * @include [ColsInGroupsDocs]
+     * @set [ColsInGroupsDocs.EXAMPLE]
+     *
+     * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsInGroups][String.colsInGroups]`() }`
+     */
+    public fun String.colsInGroups(): TransformableColumnSet<*> = columnGroup(this).colsInGroups()
 
     /**
      * @include [ColsInGroupsDocs]
@@ -172,8 +208,17 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[colsInGroups][ColumnPath.colsInGroups]`() }`
      */
+    @Deprecated("", ReplaceWith("colsInGroups().filter(predicate)"))
     public fun ColumnPath.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
         columnGroup(this).colsInGroups(predicate)
+
+    /**
+     * @include [ColsInGroupsDocs]
+     * @set [ColsInGroupsDocs.EXAMPLE]
+     *
+     * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[colsInGroups][ColumnPath.colsInGroups]`() }`
+     */
+    public fun ColumnPath.colsInGroups(): TransformableColumnSet<*> = columnGroup(this).colsInGroups()
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
@@ -96,9 +96,9 @@ public interface SingleColumnsSelectionDsl {
 
     /**
      * ## Single (Col)
-     * Returns the single column from [this\] that adheres to the optional given [condition\].
-     * If no column adheres to the given [condition\], [NoSuchElementException] is thrown.
-     * If multiple columns adhere to it, [IllegalArgumentException] is thrown.
+     * Returns the single column from [this\].
+     * If there is no column, [NoSuchElementException] is thrown.
+     * If there are multiple columns, [IllegalArgumentException] is thrown.
      *
      * This function operates solely on columns at the top-level.
      *
@@ -108,18 +108,17 @@ public interface SingleColumnsSelectionDsl {
      *
      * #### Examples:
      *
-     * `df.`[select][DataFrame.select]`  {  `[single][ColumnsSelectionDsl.single]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("order") } }`
+     * `df.`[select][DataFrame.select]`  { `[nameStartsWith][ColumnsSelectionDsl.nameStartsWith]`("order").`[single][ColumnsSelectionDsl.single]`() }`
      *
-     * `df.`[select][DataFrame.select]` { "myColumnGroup".`[singleCol][String.singleCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("order") } }`
+     * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsNameStartsWith][ColumnNameFiltersColumnsSelectionDsl.colsNameStartsWith]`("order").`[singleCol][String.singleCol]`() }`
      *
      * #### Examples for this overload:
      *
      * {@get [Examples]}
      *
-     * @param [condition\] The optional [ColumnFilter] condition that the column must adhere to.
-     * @return A [SingleColumn] containing the single column that adheres to the given [condition\].
-     * @throws [NoSuchElementException\] if no column adheres to the given [condition\].
-     * @throws [IllegalArgumentException\] if more than one column adheres to the given [condition\].
+     * @return A [SingleColumn] containing the single column.
+     * @throws [NoSuchElementException\] if there are no columns in [this\].
+     * @throws [IllegalArgumentException\] if there is more than one column in [this\].
      */
     private interface CommonSingleDocs {
 
@@ -135,8 +134,19 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[single][ColumnSet.single]`() }`
      */
     @Interpretable("Single0")
+    @Deprecated("", ReplaceWith("this.filter(condition).single()"))
     public fun <C> ColumnSet<C>.single(condition: ColumnFilter<C> = { true }): TransformableSingleColumn<C> =
         singleInternal(condition)
+
+    /**
+     * @include [CommonSingleDocs]
+     * @set [CommonSingleDocs.Examples]
+     * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[String][String]`>().nameStartsWith("year").`[single][ColumnSet.single]`() }`
+     *
+     * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[single][ColumnSet.single]`() }`
+     */
+    @Interpretable("Single0")
+    public fun <C> ColumnSet<C>.single(): TransformableSingleColumn<C> = singleInternal { true }
 
     /**
      * @include [CommonSingleDocs]
@@ -145,8 +155,18 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[single][ColumnsSelectionDsl.single]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
     @Interpretable("Single1")
+    @Deprecated("", ReplaceWith("cols().filter(condition).single()"))
     public fun ColumnsSelectionDsl<*>.single(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
         asSingleColumn().singleCol(condition)
+
+    /**
+     * @include [CommonSingleDocs]
+     * @set [CommonSingleDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]`  { nameStartsWith("year").`[single][ColumnsSelectionDsl.single]`() }`
+     */
+    @Interpretable("Single1")
+    public fun ColumnsSelectionDsl<*>.single(): TransformableSingleColumn<*> = asSingleColumn().singleCol { true }
 
     /**
      * @include [CommonSingleDocs]
@@ -155,16 +175,35 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[singleCol][SingleColumn.singleCol]`() }`
      */
     @Interpretable("Single2")
+    @Deprecated("", ReplaceWith("this.cols().filter(condition).single()"))
     public fun SingleColumn<DataRow<*>>.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
         this.ensureIsColumnGroup().asColumnSet().single(condition)
 
     /**
      * @include [CommonSingleDocs]
      * @set [CommonSingleDocs.Examples]
+     *
+     * `df.`[select][DataFrame.select]` { myColumnGroup.`[singleCol][SingleColumn.singleCol]`() }`
+     */
+    @Interpretable("Single2")
+    public fun SingleColumn<DataRow<*>>.singleCol(): TransformableSingleColumn<*> =
+        this.ensureIsColumnGroup().asColumnSet().single()
+
+    /**
+     * @include [CommonSingleDocs]
+     * @set [CommonSingleDocs.Examples]
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[singleCol][String.singleCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
+    @Deprecated("", ReplaceWith("this.cols().filter(condition).single()"))
     public fun String.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
         columnGroup(this).singleCol(condition)
+
+    /**
+     * @include [CommonSingleDocs]
+     * @set [CommonSingleDocs.Examples]
+     * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsNameStartsWith][ColumnNameFiltersColumnsSelectionDsl.colsNameStartsWith]`("year").`[singleCol][String.singleCol]`() }`
+     */
+    public fun String.singleCol(): TransformableSingleColumn<*> = columnGroup(this).singleCol()
 
     /**
      * @include [CommonSingleDocs]

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/corr.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/corr.kt
@@ -26,7 +26,9 @@ internal fun <T, C, R> Corr<T, C>.corrImpl(otherColumns: ColumnsSelector<T, R>):
             // extract nested number columns from ColumnGroups
             if (it.isColumnGroup()) {
                 val groupPath = it.path
-                df.getColumnsWithPaths { groupPath.colsAtAnyDepth { it.isSuitableForCorr() } }.map { it.cast() }
+                df.getColumnsWithPaths {
+                    groupPath.colsAtAnyDepth().filter { it.isSuitableForCorr() }
+                }.map { it.cast() }
             } else {
                 listOf(it)
             }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/join.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/join.kt
@@ -67,10 +67,10 @@ internal fun <A, B> DataFrame<A>.joinImpl(
         val rightCol = rightJoinColumns[i]
         if (leftCol.isColumnGroup() && rightCol.isColumnGroup()) {
             val leftColumns = getColumnsWithPaths {
-                leftCol.colsAtAnyDepth { !it.isColumnGroup() }
+                leftCol.colsAtAnyDepth().filter { !it.isColumnGroup() }
             }
             val rightColumns = other.getColumnsWithPaths {
-                rightCol.colsAtAnyDepth { !it.isColumnGroup() }
+                rightCol.colsAtAnyDepth().filter { !it.isColumnGroup() }
             }
 
             val leftPrefixLength = leftCol.path.size

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
@@ -71,7 +71,7 @@ class MoveTests {
     @Test
     fun `select recursively`() {
         val selected = grouped.select {
-            it["a"].asColumnGroup().colsAtAnyDepth { !it.isColumnGroup() }
+            it["a"].asColumnGroup().colsAtAnyDepth().filter { !it.isColumnGroup() }
         }
         selected.columnNames() shouldBe listOf("b", "d")
     }
@@ -80,7 +80,7 @@ class MoveTests {
     fun `columnsWithPath in selector`() {
         val selected = grouped.getColumnsWithPaths { it["a"] }
         val actual = grouped.getColumnsWithPaths {
-            selected.map { it.asColumnGroup().colsAtAnyDepth { !it.isColumnGroup() } }.toColumnSet()
+            selected.map { it.asColumnGroup().colsAtAnyDepth().filter { !it.isColumnGroup() } }.toColumnSet()
         }
         actual.map { it.path.joinToString(".") } shouldBe listOf("a.b", "a.c.d")
     }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Access.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Access.kt
@@ -793,7 +793,7 @@ class Access : TestBase() {
         df.select { name.allCols() }
 
         // traversal of columns at any depth from here excluding ColumnGroups
-        df.select { name.colsAtAnyDepth { !it.isColumnGroup() } }
+        df.select { name.colsAtAnyDepth().filter { !it.isColumnGroup() } }
 
         // SampleEnd
     }
@@ -831,7 +831,7 @@ class Access : TestBase() {
         df.select { name.allCols() }
 
         // traversal of columns at any depth from here excluding ColumnGroups
-        df.select { name.colsAtAnyDepth { !it.isColumnGroup() } }
+        df.select { name.colsAtAnyDepth().filter { !it.isColumnGroup() } }
         // SampleEnd
     }
 
@@ -900,7 +900,7 @@ class Access : TestBase() {
         df.select { "name".allCols() }
 
         // traversal of columns at any depth from here excluding ColumnGroups
-        df.select { "name".colsAtAnyDepth { !it.isColumnGroup() } }
+        df.select { "name".colsAtAnyDepth().filter { !it.isColumnGroup() } }
         // SampleEnd
     }
 


### PR DESCRIPTION
As we discussed, predicate makes compiler plugin support of these functions unreliable. Deprecation suggests to use filter, updates some examples to use nameStartsWith