### PR TITLE
Fixed issue on Top 12 German Companies sample

### DIFF
--- a/examples/notebooks/top_12_german_companies/top_12_german_companies.ipynb
+++ b/examples/notebooks/top_12_german_companies/top_12_german_companies.ipynb
@@ -6552,10 +6552,10 @@
    "source": [
     "// Group data by sector to compute average and standard deviations of ROA and ROE\n",
     "val roeAndRoaDf = companiesDf.groupBy { sector }.aggregate {\n",
-    "    ROA.mean() into \"Avg ROA\"\n",
-    "    ROA.std() into \"Std ROA\"\n",
-    "    ROE.mean() into \"Avg ROE\"\n",
-    "    ROE.std() into \"Std ROE\"\n",
+    "    (ROA.map { it.toString().replace(\".\", \"\").toDouble() }).mean() into \"Avg ROA\"\n",
+    "    (ROA.map { it.toString().replace(\".\", \"\").toDouble() }).std() into \"Std ROA\"\n",
+    "    (ROE.map { it.toString().replace(\".\", \"\").toDouble() }).mean() into \"Avg ROE\"\n",
+    "    (ROE.map { it.toString().replace(\".\", \"\").toDouble() }).std() into \"Std ROE\"\n",
     "}\n",
     "\n",
     "roeAndRoaDf"


### PR DESCRIPTION
This PR modifies the handling of the ROA and ROE columns in the 12 German Companies example to address formatting issues. The values were initially strings with periods (e.g., 12.5), which caused incorrect calculations. This PR removes the periods and converts the values to Double to ensure accurate computation of the mean and standard deviation.