### PR TITLE
Potential bug fix for nested types codegen jupyter

### DIFF
--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -158,7 +158,7 @@ class CodeGenerationTests : BaseTest() {
         val type2 = ReplCodeGeneratorImpl.markerInterfacePrefix
         val declaration1 =
             """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface $type1 {
                 val city: String?
                 val name: String

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt
@@ -277,7 +277,7 @@ class ReplCodeGenTests : BaseTest() {
         val c = repl.process(Test5.df, Test5::df)
         c.declarations shouldBe
             """
-            @DataSchema(isOpen = false)
+            @DataSchema
             interface _DataFrameType3 {
                 val a: Int
                 val c: Int

--- a/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
+++ b/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/CodeGenerationTests.kt
@@ -70,4 +70,27 @@ class CodeGenerationTests : DataFrameJupyterTest() {
         df1.leaf.c
         """.checkCompilation()
     }
+
+    // https://github.com/Kotlin/dataframe/issues/1222
+    @Test
+    fun `reusing marker with nullable column`() {
+        @Language("kt")
+        val _1 = """
+            val df1 = dataFrameOf("group" to columnOf("a" to columnOf(1, null, 3)))
+            val df2 = dataFrameOf("group" to columnOf("a" to columnOf(1, 2, 3)))
+            df1.group.a
+            df2.group.a
+            """.checkCompilation()
+    }
+
+    @Test
+    fun `not reusing marker with non-nullable column`() {
+        @Language("kt")
+        val _1 = """
+            val df1 = dataFrameOf("group" to columnOf("a" to columnOf(1, 2, 3)))
+            val df2 = dataFrameOf("group" to columnOf("a" to columnOf(1, null, 3)))
+            df1.group.a
+            df2.group.a
+            """.checkCompilation()
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1222

Made it so that nested types in jupyter codegen follow their parent's openness. This makes it so that:
```kt
val df1 = dataFrameOf(
    "group" to columnOf(
        "a" to columnOf(1, null, 3),
    )
)
val df2 = dataFrameOf(
    "group" to columnOf(
        "a" to columnOf(1, 2, 3),
    )
)
```
produces something like:
```kt
// for df1

@DataSchema(isOpen = true)
interface _DataFrameType1 {
    val a: Int?
}

@DataSchema
interface _DataFrameType {
    val group: _DataFrameType1
}

// for df2

@DataSchema(isOpen = true)
interface _DataFrameType3 : _DataFrameType1 { // now the non-nullable variant extends the nullable variant
    override val a: Int // requires override
}

@DataSchema
interface _DataFrameType2 : _DataFrameType {
    override val group: _DataFrameType3
}
```

However, the old behavior (whenever a schema is generated, nested types, such as inside column groups and frame cols are generated with isOpen = false, even if the data schema itself has isOpen = true) has been like this since at least [2021](https://github.com/Kotlin/dataframe/commit/56155264e0454e9b47245193e774fd87b322d718#diff-e8077b565373f8f859df71a7675fdeb42c0c152878a21140923c3d9e10bd697bR65).

This change makes [this test](https://github.com/Kotlin/dataframe/blob/5f5f6a1c253e609666bcb1f0665342d7fa132f08/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/ReplCodeGenTests.kt#L270) fail, which indicates to me that it might have been done intentionally. @koperagen could you maybe explain a bit more about this behavior now that we know it can cause bugs like these?