### PR TITLE
`DataFrameSchema.generateCode()`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2401,7 +2401,12 @@ public final class org/jetbrains/kotlinx/dataframe/api/GatherKt {
 public final class org/jetbrains/kotlinx/dataframe/api/GenerateCodeKt {
 	public static final fun generateCode (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/String;ZZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;)Ljava/lang/String;
 	public static synthetic fun generateCode$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/String;ZZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun generateCodeForSchema (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Ljava/lang/String;ZZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;)Ljava/lang/String;
+	public static synthetic fun generateCodeForSchema$default (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Ljava/lang/String;ZZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun generateDataClassesForSchema (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Ljava/lang/String;ZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;ZLorg/jetbrains/kotlinx/dataframe/codeGen/NameNormalizer;)Ljava/lang/String;
+	public static synthetic fun generateDataClassesForSchema$default (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Ljava/lang/String;ZLorg/jetbrains/kotlinx/dataframe/codeGen/MarkerVisibility;ZLorg/jetbrains/kotlinx/dataframe/codeGen/NameNormalizer;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun generateInterfaces (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun generateInterfacesForSchema (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun getDefault (Lorg/jetbrains/kotlinx/dataframe/codeGen/NameNormalizer$Companion;)Lorg/jetbrains/kotlinx/dataframe/codeGen/NameNormalizer;
 	public static final fun toCodeString (Ljava/lang/String;)Ljava/lang/String;
 }


### PR DESCRIPTION
expands generateCode etc. with the support of being called in DataFrameSchema as well. Keeps original api the same

Fixes https://github.com/Kotlin/dataframe/issues/1195