### PR TITLE
Remove mandatory mariadb dependency from jdbc

### DIFF
--- a/dataframe-jdbc/build.gradle.kts
+++ b/dataframe-jdbc/build.gradle.kts
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     api(projects.core)
-    implementation(libs.mariadb)
     implementation(libs.kotlinLogging)
+    testImplementation(libs.mariadb)
     testImplementation(libs.sqlite)
     testImplementation(libs.postgresql)
     testImplementation(libs.mysql)


### PR DESCRIPTION
We recommend in the documentation to add it to user projects: https://kotlin.github.io/dataframe/readsqldatabases.html#getting-started-with-reading-from-sql-database-in-gradle-project

Seems like it was added for testing and left in `implementation` by accident. @zaleslaw do you remember? If it's needed for some reason, we can just close the PR