### PR TITLE
Add more specific explodeLists overload that helps to avoid unnecessary cast

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2380,6 +2380,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/Gather {
 
 public final class org/jetbrains/kotlinx/dataframe/api/GatherKt {
 	public static final fun explodeLists (Lorg/jetbrains/kotlinx/dataframe/api/Gather;)Lorg/jetbrains/kotlinx/dataframe/api/Gather;
+	public static final fun explodeListsTyped (Lorg/jetbrains/kotlinx/dataframe/api/Gather;)Lorg/jetbrains/kotlinx/dataframe/api/Gather;
 	public static final fun gather (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/api/Gather;
 	public static final fun gather (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/api/Gather;
 	public static final fun gather (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/api/Gather;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -71,6 +71,19 @@ public fun <T, C, K, R> Gather<T, C, K, R>.explodeLists(): Gather<T, C, K, R> =
         explode = true,
     )
 
+@JvmName("explodeListsTyped")
+@Interpretable("GatherExplodeLists")
+public fun <T, C, K, R> Gather<T, List<C>, K, R>.explodeLists(): Gather<T, C, K, R> =
+    Gather(
+        df = df,
+        columns = columns,
+        filter = filter,
+        keyType = keyType,
+        keyTransform = keyTransform,
+        valueTransform = valueTransform,
+        explode = true,
+    ) as Gather<T, C, K, R>
+
 @Interpretable("GatherMap")
 public inline fun <T, C, reified K, R> Gather<T, C, *, R>.mapKeys(
     noinline transform: (String) -> K,

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -187,4 +187,19 @@ class GatherTests {
             "b", 5,
         )
     }
+
+    @Test
+    fun `gather explode lists typed`() {
+        val df = dataFrameOf("list" to columnOf(listOf(1, 2, 3)))
+            .gather { "list"<List<Int>>() }
+            .explodeLists()
+            .mapValues { listOf(it) }
+            .into("key", "value")
+
+        df shouldBe dataFrameOf("key", "value")(
+            "list", listOf(1),
+            "list", listOf(2),
+            "list", listOf(3),
+        )
+    }
 }


### PR DESCRIPTION
Without this change, code would have to look like:
```
val df = dataFrameOf("list" to columnOf(listOf(1, 2, 3)))
            .gather { "list"<List<Int>>() }
            .explodeLists()
            .cast<Int>()
            .mapValues { listOf(it) }
            .into("key", "value")
```
Or even worse, without the cast it will be a Classcast exception in `.mapValues { listOf(it) }` 
With this change, at least for simple case where all selected columns are List, cast won't be needed.