### PR TITLE
Removed types = ["TABLE"] argument from readAllSqlTables

### DIFF
--- a/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
+++ b/dataframe-jdbc/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/readJdbc.kt
@@ -643,7 +643,7 @@ public fun DataFrame.Companion.readAllSqlTables(
     val determinedDbType = dbType ?: extractDBTypeFromConnection(connection)
 
     // exclude a system and other tables without data, but it looks like it is supported badly for many databases
-    val tables = metaData.getTables(catalogue, null, null, arrayOf("TABLE"))
+    val tables = metaData.getTables(catalogue, null, null, null)
 
     val dataFrames = mutableMapOf<String, AnyFrame>()
 


### PR DESCRIPTION
In other databases like DuckDB, this type is actually "BASE TABLE" instead of "TABLE", making the function return 0 results. Setting it to `null` makes the integration do its default behavior, which usually is no filtering at all.