### PR TITLE
Parse String to UUID #1006

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -49,7 +49,6 @@ import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.Temporal
 import java.time.temporal.TemporalQuery
 import java.util.Locale
-import java.util.UUID
 import kotlin.properties.Delegates
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -57,6 +56,8 @@ import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import kotlin.time.Duration
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import java.time.Duration as JavaDuration
 import java.time.Instant as JavaInstant
 import java.time.LocalDate as JavaLocalDate
@@ -427,6 +428,7 @@ internal object Parsers : GlobalParserOptions {
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     internal val parsersOrder = listOf(
         // Int
         stringParser<Int> { it.toIntOrNull() },
@@ -493,13 +495,13 @@ internal object Parsers : GlobalParserOptions {
         // Boolean
         stringParser<Boolean> { it.toBooleanOrNull() },
         // UUID
-        stringParser<UUID> { str ->
+        stringParser<Uuid> { str ->
 
             val uuidRegex = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 
             if (uuidRegex.matches(str)) {
                 try {
-                    UUID.fromString(str)
+                    Uuid.parse(str)
                 } catch (e: IllegalArgumentException) {
                     null
                 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlinx.dataframe.impl.catchSilent
 import org.jetbrains.kotlinx.dataframe.type
 import org.junit.Test
 import java.util.Locale
-import java.util.UUID
 import kotlin.random.Random
 import kotlin.reflect.typeOf
 import kotlin.time.Duration
@@ -30,6 +29,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import java.time.Duration as JavaDuration
 import java.time.Instant as JavaInstant
 
@@ -483,26 +484,27 @@ class ParseTests {
         df.parse()
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     @Test
-    fun `parse valid UUID`() {
-        val uuidString = "550e8400-e29b-41d4-a716-446655440000"
-        val column by columnOf(uuidString)
+    fun `parse valid Uuid`() {
+        val validUUID = "550e8400-e29b-41d4-a716-446655440000"
+        val column by columnOf(validUUID)
         val parsed = column.parse()
 
-        parsed.type() shouldBe typeOf<UUID>()
-        (parsed[0] as UUID).toString() shouldBe uuidString
+        parsed.type() shouldBe typeOf<Uuid>()
+        (parsed[0] as Uuid).toString() shouldBe validUUID // Change UUID to Uuid
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     @Test
-    fun `parse invalid UUID`(){
-            val invalidUUID = "this is not a UUID"
-            val column = columnOf(invalidUUID)
-            val parsed = column.tryParse() // tryParse as string is not formatted.
+    fun `parse invalid Uuid`() {
+        val invalidUUID = "this is not a UUID"
+        val column = columnOf(invalidUUID)
+        val parsed = column.tryParse() // tryParse as string is not formatted.
 
-            parsed.type() shouldNotBe typeOf<UUID>()
-            parsed.type() shouldBe typeOf<String>()
+        parsed.type() shouldNotBe typeOf<Uuid>()
+        parsed.type() shouldBe typeOf<String>()
     }
-
 
     /**
      * Asserts that all elements of the iterable are equal to each other


### PR DESCRIPTION
## Summary
Implements UUID parsing support for DataColumn.parse() as per open issue #1006

## Changes
- Added UUID parser to `parsersOrder` list in `main/../parse.kt` using `java.util.UUID.fromString()` with exception handling
- Added test cases in `test/../parse.kt`:
  - Valid UUID strings are parsed to UUID objects
  - Invalid UUID strings remain String type

## Testing
- Both positive and negative test cases pass
- Unable to run full test suite due to Java version compatibility issue with simple-git plugin (unrelated to this change)