### PR TITLE
Removing `recursively()` remnants from public api

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -368,8 +368,8 @@ public final class org/jetbrains/kotlinx/dataframe/api/AggregateKt {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/AllColumnsSelectionDsl {
-	public fun all (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun all (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun all (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun all (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allAfter (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allAfter (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allAfter (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
@@ -390,10 +390,10 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/AllColumnsSe
 	public fun allBefore (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allBefore (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allBefore (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun allCols (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun allCols (Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun allCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun allCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun allCols (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun allCols (Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun allCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun allCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allColsAfter (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allColsAfter (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun allColsAfter (Ljava/lang/String;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
@@ -682,8 +682,6 @@ public final class org/jetbrains/kotlinx/dataframe/api/CastKt {
 	public static final fun cast (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnsResolver;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnsResolver;
 	public static final fun cast (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 	public static final fun cast (Lorg/jetbrains/kotlinx/dataframe/columns/ValueColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/ValueColumn;
-	public static final fun cast (Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static final fun cast (Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
 	public static final fun castFrameColumn (Lorg/jetbrains/kotlinx/dataframe/columns/FrameColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/FrameColumn;
 }
 
@@ -852,18 +850,18 @@ public final class org/jetbrains/kotlinx/dataframe/api/ColGroupKt {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl {
-	public fun colGroups (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colGroups (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun colGroups (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colGroups (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColGroupsColumnsSelectionDsl$Grammar {
@@ -913,48 +911,48 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsAtAnyDep
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl {
 	public fun cols (Ljava/lang/String;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Ljava/lang/String;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Ljava/lang/String;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun cols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun cols$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun colsUnTyped (Ljava/lang/String;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun colsUnTyped (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun colsUnTyped (Ljava/lang/String;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
@@ -976,39 +974,39 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsColumnsS
 	public fun colsUnTyped (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun colsUnTyped (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Ljava/lang/String;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lkotlin/reflect/KProperty;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lkotlin/reflect/KProperty;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;I[I)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 	public fun get (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun get$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsColumnsSelectionDsl$Grammar {
@@ -1024,23 +1022,23 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsColumnsS
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl {
-	public fun colsInGroups (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun colsInGroups (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsInGroups (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsInGroups$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsInGroupsColumnsSelectionDsl$Grammar {
@@ -1081,18 +1079,18 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsOfColumn
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl {
-	public fun colsOfKind (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsOfKind (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun colsOfKind (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsOfKind (Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsOfKind (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOfKind$default (Lorg/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsOfKindColumnsSelectionDsl$Grammar {
@@ -1108,12 +1106,12 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColsOfKindCo
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/ColsOfKt {
-	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static final fun colsOf (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsOf$default (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/ColumnDelegate {
@@ -1211,48 +1209,48 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColumnMatch 
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl {
-	public fun colsNameContains (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Ljava/lang/String;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lkotlin/reflect/KProperty;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameEndsWith (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameEndsWith (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameStartsWith (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameStartsWith (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun colsNameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameEndsWith (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameStartsWith (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun nameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun nameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun colsNameContains (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Ljava/lang/String;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lkotlin/reflect/KProperty;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameContains (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameEndsWith (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameEndsWith (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameStartsWith (Ljava/lang/String;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameStartsWith (Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun colsNameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Ljava/lang/String;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lkotlin/reflect/KProperty;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun colsNameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameContains (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/text/Regex;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameContains$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameEndsWith (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameEndsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameEndsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameStartsWith (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun nameStartsWith (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;Z)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun nameStartsWith$default (Lorg/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Ljava/lang/CharSequence;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ColumnNameFiltersColumnsSelectionDsl$Grammar {
@@ -2129,7 +2127,7 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ExprColumnsS
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FilterColumnsSelectionDsl {
-	public fun filter (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun filter (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FilterColumnsSelectionDsl$Grammar {
@@ -2148,18 +2146,18 @@ public final class org/jetbrains/kotlinx/dataframe/api/FilterKt {
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl {
-	public fun first (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun first (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun first$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun first$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun firstCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun firstCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun firstCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun firstCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
+	public fun first (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun first (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun first$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun first$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun firstCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun firstCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun firstCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun firstCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun firstCol$default (Lorg/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FirstColumnsSelectionDsl$Grammar {
@@ -2335,18 +2333,18 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/FrameColColu
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl {
-	public fun frameCols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun frameCols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun frameCols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun frameCols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun frameCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun frameCols$default (Lorg/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/FrameColsColumnsSelectionDsl$Grammar {
@@ -2699,18 +2697,18 @@ public final class org/jetbrains/kotlinx/dataframe/api/KeyValueProperty_Extensio
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl {
-	public fun last (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun last (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun last$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun last$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun lastCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun lastCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun lastCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun lastCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
+	public fun last (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun last (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun last$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun last$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun lastCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun lastCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun lastCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun lastCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun lastCol$default (Lorg/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/LastColumnsSelectionDsl$Grammar {
@@ -3956,22 +3954,22 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/SimplifyColu
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl {
-	public fun single (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun single (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun single (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun single (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun single$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun single$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
-	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn;
+	public fun single (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun single (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun single (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun single (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun single$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun single$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public fun singleCol (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
+	public static synthetic fun singleCol$default (Lorg/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/SingleColumnsSelectionDsl$Grammar {
@@ -4600,18 +4598,18 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/ValueColColu
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl {
-	public fun valueCols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun valueCols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
-	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet;
+	public fun valueCols (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun valueCols (Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public fun valueCols (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lkotlin/reflect/KProperty;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/api/ColumnsSelectionDsl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
+	public static synthetic fun valueCols$default (Lorg/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl;Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnSet;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/ValueColsColumnsSelectionDsl$Grammar {
@@ -5936,14 +5934,6 @@ public final class org/jetbrains/kotlinx/dataframe/impl/columns/ConstructorsKt {
 
 public final class org/jetbrains/kotlinx/dataframe/impl/columns/DataColumnInternalKt {
 	public static final fun forceResolve (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
-}
-
-public abstract interface class org/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet : org/jetbrains/kotlinx/dataframe/columns/ColumnSet {
-	public abstract fun transformResolve (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnResolutionContext;Lorg/jetbrains/kotlinx/dataframe/impl/columns/ColumnsResolverTransformer;)Ljava/util/List;
-}
-
-public abstract interface class org/jetbrains/kotlinx/dataframe/impl/columns/TransformableSingleColumn : org/jetbrains/kotlinx/dataframe/columns/SingleColumn {
-	public abstract fun transformResolveSingle (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnResolutionContext;Lorg/jetbrains/kotlinx/dataframe/impl/columns/ColumnsResolverTransformer;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnWithPath;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/columns/UtilsKt {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
@@ -266,7 +266,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("All0")
-    public fun <C> ColumnSet<C>.all(): TransformableColumnSet<C> = allColumnsInternal() as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.all(): ColumnSet<C> = allColumnsInternal().cast()
 
     /**
      * @include [CommonAllDocs]
@@ -275,7 +275,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      * `df.`[select][DataFrame.select]`  {  `[all][ColumnsSelectionDsl.all]`() }`
      */
     @Interpretable("All1")
-    public fun ColumnsSelectionDsl<*>.all(): TransformableColumnSet<*> = asSingleColumn().allColumnsInternal()
+    public fun ColumnsSelectionDsl<*>.all(): ColumnSet<*> = asSingleColumn().allColumnsInternal()
 
     /**
      * @include [CommonAllDocs]
@@ -284,8 +284,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      * `df.`[select][DataFrame.select]` { myGroup.`[allCols][SingleColumn.allCols]`() }`
      */
     @Interpretable("All2")
-    public fun SingleColumn<DataRow<*>>.allCols(): TransformableColumnSet<*> =
-        ensureIsColumnGroup().allColumnsInternal()
+    public fun SingleColumn<DataRow<*>>.allCols(): ColumnSet<*> = ensureIsColumnGroup().allColumnsInternal()
 
     /**
      * @include [CommonAllDocs]
@@ -293,7 +292,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      *
      * `df.`[select][DataFrame.select]` { "myGroupCol".`[allCols][String.allCols]`() }`
      */
-    public fun String.allCols(): TransformableColumnSet<*> = columnGroup(this).allCols()
+    public fun String.allCols(): ColumnSet<*> = columnGroup(this).allCols()
 
     /**
      * @include [CommonAllDocs]
@@ -303,7 +302,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.allCols(): TransformableColumnSet<*> = columnGroup(this).allCols()
+    public fun KProperty<*>.allCols(): ColumnSet<*> = columnGroup(this).allCols()
 
     /**
      * @include [CommonAllDocs]
@@ -311,7 +310,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroup"].`[allCols][ColumnPath.allCols]`() }`
      */
-    public fun ColumnPath.allCols(): TransformableColumnSet<*> = columnGroup(this).allCols()
+    public fun ColumnPath.allCols(): ColumnSet<*> = columnGroup(this).allCols()
 
     // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
@@ -19,8 +19,6 @@ import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
 import org.jetbrains.kotlinx.dataframe.impl.api.convertToImpl
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableSingleColumn
 import kotlin.reflect.typeOf
 
 @Check
@@ -93,10 +91,6 @@ public fun <C> ColumnSet<*>.cast(): ColumnSet<C> = this as ColumnSet<C>
 public fun <C> ColumnsResolver<*>.cast(): ColumnsResolver<C> = this as ColumnsResolver<C>
 
 public fun <C> SingleColumn<*>.cast(): SingleColumn<C> = this as SingleColumn<C>
-
-public fun <C> TransformableColumnSet<*>.cast(): TransformableColumnSet<C> = this as TransformableColumnSet<C>
-
-public fun <C> TransformableSingleColumn<*>.cast(): TransformableSingleColumn<C> = this as TransformableSingleColumn<C>
 
 public fun <C> ColumnReference<*>.cast(): ColumnReference<C> = this as ColumnReference<C>
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.AccessApi
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
 import kotlin.reflect.KProperty
 
 // region ColumnsSelectionDsl
@@ -110,7 +109,7 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups0")
-    public fun ColumnSet<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): TransformableColumnSet<AnyRow> =
+    public fun ColumnSet<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
         columnGroupsInternal(filter)
 
     /**
@@ -122,9 +121,8 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups1")
-    public fun ColumnsSelectionDsl<*>.colGroups(
-        filter: Predicate<ColumnGroup<*>> = { true },
-    ): TransformableColumnSet<AnyRow> = asSingleColumn().columnGroupsInternal(filter)
+    public fun ColumnsSelectionDsl<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+        asSingleColumn().columnGroupsInternal(filter)
 
     /**
      * @include [CommonColGroupsDocs]
@@ -135,9 +133,8 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColGroup.`[colGroups][SingleColumn.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups2")
-    public fun SingleColumn<DataRow<*>>.colGroups(
-        filter: Predicate<ColumnGroup<*>> = { true },
-    ): TransformableColumnSet<AnyRow> = this.ensureIsColumnGroup().columnGroupsInternal(filter)
+    public fun SingleColumn<DataRow<*>>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+        this.ensureIsColumnGroup().columnGroupsInternal(filter)
 
     /**
      * @include [CommonColGroupsDocs]
@@ -147,7 +144,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[colGroups][String.colGroups]`() }`
      */
-    public fun String.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): TransformableColumnSet<AnyRow> =
+    public fun String.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
         columnGroup(this).colGroups(filter)
 
     /**
@@ -158,7 +155,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColGroup.`[colGroups][KProperty.colGroups]`() }`
      */
-    public fun KProperty<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): TransformableColumnSet<AnyRow> =
+    public fun KProperty<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
         columnGroup(this).colGroups(filter)
 
     /**
@@ -167,19 +164,19 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[colGroups][ColumnPath.colGroups]`() }`
      */
-    public fun ColumnPath.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): TransformableColumnSet<AnyRow> =
+    public fun ColumnPath.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
         columnGroup(this).colGroups(filter)
 }
 
 /**
- * Returns a TransformableColumnSet containing the column groups that satisfy the given filter.
+ * Returns a ColumnSet containing the column groups that satisfy the given filter.
  *
  * @param filter The filter function to apply on each column group. Must accept a ColumnGroup object and return a Boolean.
- * @return A [TransformableColumnSet] containing the column groups that satisfy the filter.
+ * @return A [ColumnSet] containing the column groups that satisfy the filter.
  */
 @Suppress("UNCHECKED_CAST")
 internal inline fun ColumnsResolver<*>.columnGroupsInternal(
     crossinline filter: (ColumnGroup<*>) -> Boolean,
-): TransformableColumnSet<AnyRow> = colsInternal { it.isColumnGroup() && filter(it) } as TransformableColumnSet<AnyRow>
+): ColumnSet<AnyRow> = colsInternal { it.isColumnGroup() && filter(it) }.cast()
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
@@ -244,12 +244,11 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
 
     /** @include [ColumnSetColsPredicateDocs] */
     @Suppress("UNCHECKED_CAST")
-    public fun <C> ColumnSet<C>.cols(predicate: ColumnFilter<C> = { true }): TransformableColumnSet<C> =
-        colsInternal(predicate as ColumnFilter<*>) as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.cols(predicate: ColumnFilter<C> = { true }): ColumnSet<C> =
+        colsInternal(predicate as ColumnFilter<*>).cast()
 
     /** @include [ColumnSetColsPredicateDocs] */
-    public operator fun <C> ColumnSet<C>.get(predicate: ColumnFilter<C> = { true }): TransformableColumnSet<C> =
-        cols(predicate)
+    public operator fun <C> ColumnSet<C>.get(predicate: ColumnFilter<C> = { true }): ColumnSet<C> = cols(predicate)
 
     /**
      * @include [CommonColsDocs.Predicate]
@@ -270,11 +269,11 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface ColumnsSelectionDslColsPredicateDocs
 
     /** @include [ColumnsSelectionDslColsPredicateDocs] */
-    public fun ColumnsSelectionDsl<*>.cols(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun ColumnsSelectionDsl<*>.cols(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         this.asSingleColumn().colsInternal(predicate)
 
     /** @include [ColumnsSelectionDslColsPredicateDocs] */
-    public operator fun ColumnsSelectionDsl<*>.get(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public operator fun ColumnsSelectionDsl<*>.get(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         cols(predicate)
 
     /**
@@ -295,15 +294,14 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface SingleColumnAnyRowColsPredicateDocs
 
     /** @include [SingleColumnAnyRowColsPredicateDocs] */
-    public fun SingleColumn<DataRow<*>>.cols(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun SingleColumn<DataRow<*>>.cols(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         this.ensureIsColumnGroup().colsInternal(predicate)
 
     /**
      * @include [SingleColumnAnyRowColsPredicateDocs]
      */
-    public operator fun SingleColumn<DataRow<*>>.get(
-        predicate: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> = cols(predicate)
+    public operator fun SingleColumn<DataRow<*>>.get(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
+        cols(predicate)
 
     /**
      * @include [CommonColsDocs.Predicate]
@@ -320,11 +318,10 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface StringColsPredicateDocs
 
     /** @include [StringColsPredicateDocs] */
-    public fun String.cols(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
-        columnGroup(this).cols(predicate)
+    public fun String.cols(predicate: ColumnFilter<*> = { true }): ColumnSet<*> = columnGroup(this).cols(predicate)
 
     /** @include [StringColsPredicateDocs] */
-    public operator fun String.get(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> = cols(predicate)
+    public operator fun String.get(predicate: ColumnFilter<*> = { true }): ColumnSet<*> = cols(predicate)
 
     /**
      * @include [CommonColsDocs.Predicate]
@@ -345,14 +342,13 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     /** @include [KPropertyColsPredicateDocs] */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.cols(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun KProperty<*>.cols(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).cols(predicate)
 
     /** @include [KPropertyColsPredicateDocs] */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public operator fun KProperty<*>.get(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
-        cols(predicate)
+    public operator fun KProperty<*>.get(predicate: ColumnFilter<*> = { true }): ColumnSet<*> = cols(predicate)
 
     /**
      * @include [CommonColsDocs.Predicate]
@@ -367,12 +363,10 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     private interface ColumnPathPredicateDocs
 
     /** @include [ColumnPathPredicateDocs] */
-    public fun ColumnPath.cols(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
-        columnGroup(this).cols(predicate)
+    public fun ColumnPath.cols(predicate: ColumnFilter<*> = { true }): ColumnSet<*> = columnGroup(this).cols(predicate)
 
     /** @include [ColumnPathPredicateDocs] */
-    public operator fun ColumnPath.get(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
-        cols(predicate)
+    public operator fun ColumnPath.get(predicate: ColumnFilter<*> = { true }): ColumnSet<*> = cols(predicate)
 
     // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsInGroups.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.columns.transform
 import org.jetbrains.kotlinx.dataframe.util.COLS_IN_GROUPS
 import org.jetbrains.kotlinx.dataframe.util.COLS_IN_GROUPS_REPLACE
@@ -101,7 +100,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * @see [ColumnsSelectionDsl.cols\]
      * @see [ColumnsSelectionDsl.colGroups\]
-     * @return A [TransformableColumnSet] containing the cols.
+     * @return A [ColumnSet] containing the cols.
      */
     private interface ColsInGroupsDocs {
 
@@ -122,7 +121,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
         replaceWith = ReplaceWith(COLS_IN_GROUPS_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun ColumnSet<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun ColumnSet<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         transform { it.flatMap { it.cols().filter { predicate(it) } } }
 
     /**
@@ -131,7 +130,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]`  {  `[colsOf][ColumnsSelectionDsl.colsOf]`<`[DataRow][DataRow]`<MyGroupType>>().`[colsInGroups][ColumnSet.colsInGroups]`() }`
      */
-    public fun ColumnSet<*>.colsInGroups(): TransformableColumnSet<*> = transform { it.flatMap { it.cols() } }
+    public fun ColumnSet<*>.colsInGroups(): ColumnSet<*> = transform { it.flatMap { it.cols() } }
 
     /**
      * @include [ColsInGroupsDocs]
@@ -146,7 +145,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
         replaceWith = ReplaceWith(COLS_IN_GROUPS_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun ColumnsSelectionDsl<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun ColumnsSelectionDsl<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         asSingleColumn().colsInGroups(predicate)
 
     /**
@@ -155,7 +154,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]`  {  `[colsInGroups][ColumnSet.colsInGroups]`() }`
      */
-    public fun ColumnsSelectionDsl<*>.colsInGroups(): TransformableColumnSet<*> = asSingleColumn().colsInGroups()
+    public fun ColumnsSelectionDsl<*>.colsInGroups(): ColumnSet<*> = asSingleColumn().colsInGroups()
 
     /**
      * @include [ColsInGroupsDocs]
@@ -170,7 +169,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
         replaceWith = ReplaceWith(COLS_IN_GROUPS_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun SingleColumn<DataRow<*>>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun SingleColumn<DataRow<*>>.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         ensureIsColumnGroup().allColumnsInternal().colsInGroups(predicate)
 
     /**
@@ -179,7 +178,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[colsInGroups][SingleColumn.colsInGroups]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
-    public fun SingleColumn<DataRow<*>>.colsInGroups(): TransformableColumnSet<*> =
+    public fun SingleColumn<DataRow<*>>.colsInGroups(): ColumnSet<*> =
         ensureIsColumnGroup().allColumnsInternal().colsInGroups()
 
     /**
@@ -193,7 +192,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
         replaceWith = ReplaceWith(COLS_IN_GROUPS_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun String.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun String.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).colsInGroups(predicate)
 
     /**
@@ -202,7 +201,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsInGroups][String.colsInGroups]`() }`
      */
-    public fun String.colsInGroups(): TransformableColumnSet<*> = columnGroup(this).colsInGroups()
+    public fun String.colsInGroups(): ColumnSet<*> = columnGroup(this).colsInGroups()
 
     /**
      * @include [ColsInGroupsDocs]
@@ -214,7 +213,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun KProperty<*>.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).colsInGroups(predicate)
 
     /**
@@ -228,7 +227,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
         replaceWith = ReplaceWith(COLS_IN_GROUPS_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun ColumnPath.colsInGroups(predicate: ColumnFilter<*> = { true }): TransformableColumnSet<*> =
+    public fun ColumnPath.colsInGroups(predicate: ColumnFilter<*> = { true }): ColumnSet<*> =
         columnGroup(this).colsInGroups(predicate)
 
     /**
@@ -237,7 +236,7 @@ public interface ColsInGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[colsInGroups][ColumnPath.colsInGroups]`() }`
      */
-    public fun ColumnPath.colsInGroups(): TransformableColumnSet<*> = columnGroup(this).colsInGroups()
+    public fun ColumnPath.colsInGroups(): ColumnSet<*> = columnGroup(this).colsInGroups()
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
@@ -183,7 +183,7 @@ public interface ColsOfColumnsSelectionDsl {
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.FilterParam]
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.Return]
  */
-public fun <C> ColumnSet<*>.colsOf(type: KType, filter: ColumnFilter<C> = { true }): TransformableColumnSet<C> =
+public fun <C> ColumnSet<*>.colsOf(type: KType, filter: ColumnFilter<C> = { true }): ColumnSet<C> =
     colsOfInternal(type, filter)
 
 /**
@@ -197,9 +197,8 @@ public fun <C> ColumnSet<*>.colsOf(type: KType, filter: ColumnFilter<C> = { true
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.Return]
  */
 @Interpretable("ColsOf1")
-public inline fun <reified C> ColumnSet<*>.colsOf(
-    noinline filter: ColumnFilter<C> = { true },
-): TransformableColumnSet<C> = colsOf(typeOf<C>(), filter)
+public inline fun <reified C> ColumnSet<*>.colsOf(noinline filter: ColumnFilter<C> = { true }): ColumnSet<C> =
+    colsOf(typeOf<C>(), filter)
 
 /**
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs]
@@ -209,10 +208,8 @@ public inline fun <reified C> ColumnSet<*>.colsOf(
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.FilterParam]
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.Return]
  */
-public fun <C> ColumnsSelectionDsl<*>.colsOf(
-    type: KType,
-    filter: ColumnFilter<C> = { true },
-): TransformableColumnSet<C> = asSingleColumn().colsOf(type, filter)
+public fun <C> ColumnsSelectionDsl<*>.colsOf(type: KType, filter: ColumnFilter<C> = { true }): ColumnSet<C> =
+    asSingleColumn().colsOf(type, filter)
 
 /**
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs]
@@ -225,7 +222,7 @@ public fun <C> ColumnsSelectionDsl<*>.colsOf(
 @Interpretable("ColsOf0")
 public inline fun <reified C> ColumnsSelectionDsl<*>.colsOf(
     noinline filter: ColumnFilter<C> = { true },
-): TransformableColumnSet<C> = asSingleColumn().colsOf(typeOf<C>(), filter)
+): ColumnSet<C> = asSingleColumn().colsOf(typeOf<C>(), filter)
 
 /**
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs]
@@ -237,10 +234,8 @@ public inline fun <reified C> ColumnsSelectionDsl<*>.colsOf(
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.FilterParam]
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs.Return]
  */
-public fun <C> SingleColumn<DataRow<*>>.colsOf(
-    type: KType,
-    filter: ColumnFilter<C> = { true },
-): TransformableColumnSet<C> = ensureIsColumnGroup().colsOfInternal(type, filter)
+public fun <C> SingleColumn<DataRow<*>>.colsOf(type: KType, filter: ColumnFilter<C> = { true }): ColumnSet<C> =
+    ensureIsColumnGroup().colsOfInternal(type, filter)
 
 /**
  * @include [ColsOfColumnsSelectionDsl.CommonColsOfDocs]
@@ -255,7 +250,7 @@ public fun <C> SingleColumn<DataRow<*>>.colsOf(
 @Interpretable("ColsOf2")
 public inline fun <reified C> SingleColumn<DataRow<*>>.colsOf(
     noinline filter: ColumnFilter<C> = { true },
-): TransformableColumnSet<C> = colsOf(typeOf<C>(), filter)
+): ColumnSet<C> = colsOf(typeOf<C>(), filter)
 
 /**
  * If this [ColumnsResolver] is a [SingleColumn], it

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOfKind.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOfKind.kt
@@ -118,7 +118,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> =
+    ): ColumnSet<*> =
         columnsOfKindInternal(
             kinds = headPlusArray(kind, others).toSet(),
             filter = filter,
@@ -134,7 +134,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> =
+    ): ColumnSet<*> =
         asSingleColumn().columnsOfKindInternal(
             kinds = headPlusArray(kind, others).toSet(),
             filter = filter,
@@ -150,7 +150,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> =
+    ): ColumnSet<*> =
         this.ensureIsColumnGroup().columnsOfKindInternal(
             kinds = headPlusArray(kind, others).toSet(),
             filter = filter,
@@ -166,7 +166,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
+    ): ColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
 
     /**
      * @include [CommonColsOfKindDocs]
@@ -180,7 +180,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
+    ): ColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
 
     /**
      * @include [CommonColsOfKindDocs]
@@ -192,7 +192,7 @@ public interface ColsOfKindColumnsSelectionDsl {
         kind: ColumnKind,
         vararg others: ColumnKind,
         filter: ColumnFilter<*> = { true },
-    ): TransformableColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
+    ): ColumnSet<*> = columnGroup(this).colsOfKind(kind, *others, filter = filter)
 
     // endregion
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnNameFilters.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/columnNameFilters.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
 import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
 import kotlin.reflect.KProperty
 
@@ -150,10 +149,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("NameContains0")
-    public fun <C> ColumnSet<C>.nameContains(
-        text: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<C> = colsInternal { it.name.contains(text, ignoreCase) } as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.nameContains(text: CharSequence, ignoreCase: Boolean = false): ColumnSet<C> =
+        colsInternal { it.name.contains(text, ignoreCase) }.cast()
 
     /**
      * @include [NameContainsTextDocs]
@@ -162,10 +159,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[nameContains][ColumnsSelectionDsl.colsNameContains]`("my") }`
      */
     @Interpretable("NameContains1")
-    public fun ColumnsSelectionDsl<*>.nameContains(
-        text: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = asSingleColumn().colsNameContains(text, ignoreCase)
+    public fun ColumnsSelectionDsl<*>.nameContains(text: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        asSingleColumn().colsNameContains(text, ignoreCase)
 
     /**
      * @include [NameContainsTextDocs]
@@ -177,7 +172,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
     public fun SingleColumn<DataRow<*>>.colsNameContains(
         text: CharSequence,
         ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.contains(text, ignoreCase) }
+    ): ColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.contains(text, ignoreCase) }
 
     /**
      * @include [NameContainsTextDocs]
@@ -185,7 +180,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameContains][String.colsNameContains]`("my") }`
      */
-    public fun String.colsNameContains(text: CharSequence, ignoreCase: Boolean = false): TransformableColumnSet<*> =
+    public fun String.colsNameContains(text: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
         columnGroup(this).colsNameContains(text, ignoreCase)
 
     /**
@@ -196,10 +191,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.colsNameContains(
-        text: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameContains(text, ignoreCase)
+    public fun KProperty<*>.colsNameContains(text: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameContains(text, ignoreCase)
 
     /**
      * @include [NameContainsTextDocs]
@@ -207,10 +200,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameContains][ColumnPath.colsNameContains]`("my") }`
      */
-    public fun ColumnPath.colsNameContains(
-        text: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameContains(text, ignoreCase)
+    public fun ColumnPath.colsNameContains(text: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameContains(text, ignoreCase)
 
     /**
      * @include [CommonNameContainsDocs]
@@ -226,8 +217,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[nameContains][ColumnSet.nameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
     @Suppress("UNCHECKED_CAST")
-    public fun <C> ColumnSet<C>.nameContains(regex: Regex): TransformableColumnSet<C> =
-        colsInternal { it.name.contains(regex) } as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.nameContains(regex: Regex): ColumnSet<C> =
+        colsInternal { it.name.contains(regex) }.cast()
 
     /**
      * @include [NameContainsRegexDocs]
@@ -235,7 +226,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]`  {  `[nameContains][ColumnsSelectionDsl.nameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
-    public fun ColumnsSelectionDsl<*>.nameContains(regex: Regex): TransformableColumnSet<*> =
+    public fun ColumnsSelectionDsl<*>.nameContains(regex: Regex): ColumnSet<*> =
         asSingleColumn().colsNameContains(regex)
 
     /**
@@ -244,7 +235,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { someGroupCol.`[colsNameContains][SingleColumn.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
-    public fun SingleColumn<DataRow<*>>.colsNameContains(regex: Regex): TransformableColumnSet<*> =
+    public fun SingleColumn<DataRow<*>>.colsNameContains(regex: Regex): ColumnSet<*> =
         this.ensureIsColumnGroup().colsInternal { it.name.contains(regex) }
 
     /**
@@ -253,8 +244,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameContains][String.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
-    public fun String.colsNameContains(regex: Regex): TransformableColumnSet<*> =
-        columnGroup(this).colsNameContains(regex)
+    public fun String.colsNameContains(regex: Regex): ColumnSet<*> = columnGroup(this).colsNameContains(regex)
 
     /**
      * @include [NameContainsRegexDocs]
@@ -264,8 +254,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.colsNameContains(regex: Regex): TransformableColumnSet<*> =
-        columnGroup(this).colsNameContains(regex)
+    public fun KProperty<*>.colsNameContains(regex: Regex): ColumnSet<*> = columnGroup(this).colsNameContains(regex)
 
     /**
      * @include [NameContainsRegexDocs]
@@ -273,8 +262,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameContains][ColumnPath.colsNameContains]`(`[Regex][Regex]`("order-[0-9]+")) }`
      */
-    public fun ColumnPath.colsNameContains(regex: Regex): TransformableColumnSet<*> =
-        columnGroup(this).colsNameContains(regex)
+    public fun ColumnPath.colsNameContains(regex: Regex): ColumnSet<*> = columnGroup(this).colsNameContains(regex)
 
     // endregion
 
@@ -359,10 +347,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("NameStartsWith0")
-    public fun <C> ColumnSet<C>.nameStartsWith(
-        prefix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<C> = colsInternal { it.name.startsWith(prefix, ignoreCase) } as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.nameStartsWith(prefix: CharSequence, ignoreCase: Boolean = false): ColumnSet<C> =
+        colsInternal { it.name.startsWith(prefix, ignoreCase) }.cast()
 
     /**
      * @include [CommonNameStartsWithDocs]
@@ -371,10 +357,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[nameStartsWith][ColumnsSelectionDsl.nameStartsWith]`("order-") }`
      */
     @Interpretable("NameStartsWith1")
-    public fun ColumnsSelectionDsl<*>.nameStartsWith(
-        prefix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = asSingleColumn().colsNameStartsWith(prefix, ignoreCase)
+    public fun ColumnsSelectionDsl<*>.nameStartsWith(prefix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        asSingleColumn().colsNameStartsWith(prefix, ignoreCase)
 
     /**
      * @include [CommonNameStartsWithDocs]
@@ -386,7 +370,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
     public fun SingleColumn<DataRow<*>>.colsNameStartsWith(
         prefix: CharSequence,
         ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.startsWith(prefix, ignoreCase) }
+    ): ColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.startsWith(prefix, ignoreCase) }
 
     /**
      * @include [CommonNameStartsWithDocs]
@@ -394,10 +378,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameStartsWith][String.colsNameStartsWith]`("order-") }`
      */
-    public fun String.colsNameStartsWith(
-        prefix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
+    public fun String.colsNameStartsWith(prefix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
 
     /**
      * @include [CommonNameStartsWithDocs]
@@ -407,10 +389,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.colsNameStartsWith(
-        prefix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
+    public fun KProperty<*>.colsNameStartsWith(prefix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
 
     /**
      * @include [CommonNameStartsWithDocs]
@@ -418,10 +398,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameStartsWith][ColumnPath.colsNameStartsWith]`("order-") }`
      */
-    public fun ColumnPath.colsNameStartsWith(
-        prefix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
+    public fun ColumnPath.colsNameStartsWith(prefix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameStartsWith(prefix, ignoreCase)
 
     // endregion
 
@@ -450,10 +428,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("NameEndsWith0")
-    public fun <C> ColumnSet<C>.nameEndsWith(
-        suffix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<C> = colsInternal { it.name.endsWith(suffix, ignoreCase) } as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.nameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): ColumnSet<C> =
+        colsInternal { it.name.endsWith(suffix, ignoreCase) }.cast()
 
     /**
      * @include [CommonNameEndsWithDocs]
@@ -462,10 +438,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[nameEndsWith][ColumnsSelectionDsl.nameEndsWith]`("-order") }`
      */
     @Interpretable("NameEndsWith1")
-    public fun ColumnsSelectionDsl<*>.nameEndsWith(
-        suffix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = asSingleColumn().colsNameEndsWith(suffix, ignoreCase)
+    public fun ColumnsSelectionDsl<*>.nameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        asSingleColumn().colsNameEndsWith(suffix, ignoreCase)
 
     /**
      * @include [CommonNameEndsWithDocs]
@@ -477,7 +451,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
     public fun SingleColumn<DataRow<*>>.colsNameEndsWith(
         suffix: CharSequence,
         ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.endsWith(suffix, ignoreCase) }
+    ): ColumnSet<*> = this.ensureIsColumnGroup().colsInternal { it.name.endsWith(suffix, ignoreCase) }
 
     /**
      * @include [CommonNameEndsWithDocs]
@@ -485,7 +459,7 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "someGroupCol".`[colsNameEndsWith][String.colsNameEndsWith]`("-order") }`
      */
-    public fun String.colsNameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): TransformableColumnSet<*> =
+    public fun String.colsNameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
         columnGroup(this).colsNameEndsWith(suffix, ignoreCase)
 
     /**
@@ -496,10 +470,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.colsNameEndsWith(
-        suffix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameEndsWith(suffix, ignoreCase)
+    public fun KProperty<*>.colsNameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameEndsWith(suffix, ignoreCase)
 
     /**
      * @include [CommonNameEndsWithDocs]
@@ -507,10 +479,8 @@ public interface ColumnNameFiltersColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["someGroupCol"].`[colsNameEndsWith][ColumnPath.colsNameEndsWith]`("-order") }`
      */
-    public fun ColumnPath.colsNameEndsWith(
-        suffix: CharSequence,
-        ignoreCase: Boolean = false,
-    ): TransformableColumnSet<*> = columnGroup(this).colsNameEndsWith(suffix, ignoreCase)
+    public fun ColumnPath.colsNameEndsWith(suffix: CharSequence, ignoreCase: Boolean = false): ColumnSet<*> =
+        columnGroup(this).colsNameEndsWith(suffix, ignoreCase)
 
     // endregion
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/filter.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/filter.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
 import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.getTrueIndices
 import org.jetbrains.kotlinx.dataframe.indices
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
@@ -158,8 +157,8 @@ public interface FilterColumnsSelectionDsl {
      * @see [ColumnsSelectionDsl.cols]
      */
     @Suppress("UNCHECKED_CAST")
-    public fun <C> ColumnSet<C>.filter(predicate: ColumnFilter<C>): TransformableColumnSet<C> =
-        colsInternal(predicate as ColumnFilter<*>) as TransformableColumnSet<C>
+    public fun <C> ColumnSet<C>.filter(predicate: ColumnFilter<C>): ColumnSet<C> =
+        colsInternal(predicate as ColumnFilter<*>).cast()
 }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/first.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
 import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableSingleColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.singleOrNullWithTransformerImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.transform
 import org.jetbrains.kotlinx.dataframe.nrow
@@ -176,7 +175,7 @@ public interface FirstColumnsSelectionDsl {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("First0")
-    public fun <C> ColumnSet<C>.first(condition: ColumnFilter<C> = { true }): TransformableSingleColumn<C> =
+    public fun <C> ColumnSet<C>.first(condition: ColumnFilter<C> = { true }): SingleColumn<C> =
         (allColumnsInternal() as TransformableColumnSet<C>)
             .transform { listOf(it.first(condition)) }
             .singleOrNullWithTransformerImpl()
@@ -188,7 +187,7 @@ public interface FirstColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[first][ColumnsSelectionDsl.first]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
     @Interpretable("First1")
-    public fun ColumnsSelectionDsl<*>.first(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnsSelectionDsl<*>.first(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         asSingleColumn().firstCol(condition)
 
     /**
@@ -198,7 +197,7 @@ public interface FirstColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[firstCol][SingleColumn.firstCol]`() }`
      */
     @Interpretable("First2")
-    public fun SingleColumn<DataRow<*>>.firstCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun SingleColumn<DataRow<*>>.firstCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         this.ensureIsColumnGroup().asColumnSet().first(condition)
 
     /**
@@ -206,7 +205,7 @@ public interface FirstColumnsSelectionDsl {
      * @set [CommonFirstDocs.Examples]
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[firstCol][String.firstCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
-    public fun String.firstCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun String.firstCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).firstCol(condition)
 
     /**
@@ -218,7 +217,7 @@ public interface FirstColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.firstCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun KProperty<*>.firstCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).firstCol(condition)
 
     /**
@@ -226,7 +225,7 @@ public interface FirstColumnsSelectionDsl {
      * @set [CommonFirstDocs.Examples]
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[firstCol][ColumnPath.firstCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
-    public fun ColumnPath.firstCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnPath.firstCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).firstCol(condition)
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/frameCols.kt
@@ -112,9 +112,8 @@ public interface FrameColsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[frameCols][ColumnsSelectionDsl.frameCols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("FrameCols0")
-    public fun ColumnSet<*>.frameCols(
-        filter: Predicate<FrameColumn<*>> = { true },
-    ): TransformableColumnSet<DataFrame<*>> = frameColumnsInternal(filter)
+    public fun ColumnSet<*>.frameCols(filter: Predicate<FrameColumn<*>> = { true }): ColumnSet<DataFrame<*>> =
+        frameColumnsInternal(filter)
 
     /**
      * @include [CommonFrameColsDocs]
@@ -127,7 +126,7 @@ public interface FrameColsColumnsSelectionDsl {
     @Interpretable("FrameCols1")
     public fun ColumnsSelectionDsl<*>.frameCols(
         filter: Predicate<FrameColumn<*>> = { true },
-    ): TransformableColumnSet<DataFrame<*>> = asSingleColumn().frameColumnsInternal(filter)
+    ): ColumnSet<DataFrame<*>> = asSingleColumn().frameColumnsInternal(filter)
 
     /**
      * @include [CommonFrameColsDocs]
@@ -140,7 +139,7 @@ public interface FrameColsColumnsSelectionDsl {
     @Interpretable("FrameCols2")
     public fun SingleColumn<DataRow<*>>.frameCols(
         filter: Predicate<FrameColumn<*>> = { true },
-    ): TransformableColumnSet<DataFrame<*>> = this.ensureIsColumnGroup().frameColumnsInternal(filter)
+    ): ColumnSet<DataFrame<*>> = this.ensureIsColumnGroup().frameColumnsInternal(filter)
 
     /**
      * @include [CommonFrameColsDocs]
@@ -150,7 +149,7 @@ public interface FrameColsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[frameCols][String.frameCols]`() }`
      */
-    public fun String.frameCols(filter: Predicate<FrameColumn<*>> = { true }): TransformableColumnSet<DataFrame<*>> =
+    public fun String.frameCols(filter: Predicate<FrameColumn<*>> = { true }): ColumnSet<DataFrame<*>> =
         columnGroup(this).frameCols(filter)
 
     /**
@@ -165,9 +164,8 @@ public interface FrameColsColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.frameCols(
-        filter: Predicate<FrameColumn<*>> = { true },
-    ): TransformableColumnSet<DataFrame<*>> = columnGroup(this).frameCols(filter)
+    public fun KProperty<*>.frameCols(filter: Predicate<FrameColumn<*>> = { true }): ColumnSet<DataFrame<*>> =
+        columnGroup(this).frameCols(filter)
 
     /**
      * @include [CommonFrameColsDocs]
@@ -175,9 +173,8 @@ public interface FrameColsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[frameCols][ColumnPath.frameCols]`() }`
      */
-    public fun ColumnPath.frameCols(
-        filter: Predicate<FrameColumn<*>> = { true },
-    ): TransformableColumnSet<DataFrame<*>> = columnGroup(this).frameCols(filter)
+    public fun ColumnPath.frameCols(filter: Predicate<FrameColumn<*>> = { true }): ColumnSet<DataFrame<*>> =
+        columnGroup(this).frameCols(filter)
 }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/last.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSe
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
 import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
-import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableSingleColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.singleOrNullWithTransformerImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.transform
 import org.jetbrains.kotlinx.dataframe.nrow
@@ -172,7 +171,7 @@ public interface LastColumnsSelectionDsl {
      */
     @Suppress("UNCHECKED_CAST")
     @Interpretable("Last0")
-    public fun <C> ColumnSet<C>.last(condition: ColumnFilter<C> = { true }): TransformableSingleColumn<C> =
+    public fun <C> ColumnSet<C>.last(condition: ColumnFilter<C> = { true }): SingleColumn<C> =
         (allColumnsInternal() as TransformableColumnSet<C>)
             .transform { listOf(it.last(condition)) }
             .singleOrNullWithTransformerImpl()
@@ -184,7 +183,7 @@ public interface LastColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[last][ColumnsSelectionDsl.last]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
     @Interpretable("Last1")
-    public fun ColumnsSelectionDsl<*>.last(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnsSelectionDsl<*>.last(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         asSingleColumn().lastCol(condition)
 
     /**
@@ -194,7 +193,7 @@ public interface LastColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[lastCol][SingleColumn.lastCol]`() }`
      */
     @Interpretable("Last2")
-    public fun SingleColumn<DataRow<*>>.lastCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun SingleColumn<DataRow<*>>.lastCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         this.ensureIsColumnGroup().asColumnSet().last(condition)
 
     /**
@@ -202,7 +201,7 @@ public interface LastColumnsSelectionDsl {
      * @set [CommonLastDocs.Examples]
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[lastCol][String.lastCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
-    public fun String.lastCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun String.lastCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).lastCol(condition)
 
     /**
@@ -214,7 +213,7 @@ public interface LastColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.lastCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun KProperty<*>.lastCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).lastCol(condition)
 
     /**
@@ -222,7 +221,7 @@ public interface LastColumnsSelectionDsl {
      * @set [CommonLastDocs.Examples]
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[lastCol][ColumnPath.lastCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
-    public fun ColumnPath.lastCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnPath.lastCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).lastCol(condition)
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/single.kt
@@ -142,7 +142,7 @@ public interface SingleColumnsSelectionDsl {
         replaceWith = ReplaceWith(SINGLE_SET_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun <C> ColumnSet<C>.single(condition: ColumnFilter<C> = { true }): TransformableSingleColumn<C> =
+    public fun <C> ColumnSet<C>.single(condition: ColumnFilter<C> = { true }): SingleColumn<C> =
         singleInternal(condition)
 
     /**
@@ -153,7 +153,7 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colsOf][SingleColumn.colsOf]`<`[Int][Int]`>().`[single][ColumnSet.single]`() }`
      */
     @Interpretable("Single0")
-    public fun <C> ColumnSet<C>.single(): TransformableSingleColumn<C> = singleInternal { true }
+    public fun <C> ColumnSet<C>.single(): SingleColumn<C> = singleInternal { true }
 
     /**
      * @include [CommonSingleDocs]
@@ -167,7 +167,7 @@ public interface SingleColumnsSelectionDsl {
         replaceWith = ReplaceWith(SINGLE_PLAIN_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun ColumnsSelectionDsl<*>.single(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnsSelectionDsl<*>.single(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         asSingleColumn().singleCol(condition)
 
     /**
@@ -177,7 +177,7 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  { nameStartsWith("year").`[single][ColumnsSelectionDsl.single]`() }`
      */
     @Interpretable("Single1")
-    public fun ColumnsSelectionDsl<*>.single(): TransformableSingleColumn<*> = asSingleColumn().singleCol { true }
+    public fun ColumnsSelectionDsl<*>.single(): SingleColumn<*> = asSingleColumn().singleCol { true }
 
     /**
      * @include [CommonSingleDocs]
@@ -191,7 +191,7 @@ public interface SingleColumnsSelectionDsl {
         replaceWith = ReplaceWith(SINGLE_COL_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun SingleColumn<DataRow<*>>.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun SingleColumn<DataRow<*>>.singleCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         this.ensureIsColumnGroup().asColumnSet().single(condition)
 
     /**
@@ -201,8 +201,7 @@ public interface SingleColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColumnGroup.`[singleCol][SingleColumn.singleCol]`() }`
      */
     @Interpretable("Single2")
-    public fun SingleColumn<DataRow<*>>.singleCol(): TransformableSingleColumn<*> =
-        this.ensureIsColumnGroup().asColumnSet().single()
+    public fun SingleColumn<DataRow<*>>.singleCol(): SingleColumn<*> = this.ensureIsColumnGroup().asColumnSet().single()
 
     /**
      * @include [CommonSingleDocs]
@@ -214,7 +213,7 @@ public interface SingleColumnsSelectionDsl {
         replaceWith = ReplaceWith(SINGLE_COL_REPLACE),
         level = DeprecationLevel.WARNING,
     )
-    public fun String.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun String.singleCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).singleCol(condition)
 
     /**
@@ -222,7 +221,7 @@ public interface SingleColumnsSelectionDsl {
      * @set [CommonSingleDocs.Examples]
      * `df.`[select][DataFrame.select]` { "myColumnGroup".`[colsNameStartsWith][ColumnNameFiltersColumnsSelectionDsl.colsNameStartsWith]`("year").`[singleCol][String.singleCol]`() }`
      */
-    public fun String.singleCol(): TransformableSingleColumn<*> = columnGroup(this).singleCol()
+    public fun String.singleCol(): SingleColumn<*> = columnGroup(this).singleCol()
 
     /**
      * @include [CommonSingleDocs]
@@ -233,7 +232,7 @@ public interface SingleColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun KProperty<*>.singleCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).singleCol(condition)
 
     /**
@@ -241,7 +240,7 @@ public interface SingleColumnsSelectionDsl {
      * @set [CommonSingleDocs.Examples]
      * `df.`[select][DataFrame.select]` { "pathTo"["myColumnGroup"].`[singleCol][ColumnPath.singleCol]` { it.`[name][ColumnReference.name]`().`[startsWith][String.startsWith]`("year") } }`
      */
-    public fun ColumnPath.singleCol(condition: ColumnFilter<*> = { true }): TransformableSingleColumn<*> =
+    public fun ColumnPath.singleCol(condition: ColumnFilter<*> = { true }): SingleColumn<*> =
         columnGroup(this).singleCol(condition)
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCols.kt
@@ -112,7 +112,7 @@ public interface ValueColsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[valueCols][ColumnsSelectionDsl.valueCols]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ValueCols0")
-    public fun ColumnSet<*>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): TransformableColumnSet<*> =
+    public fun ColumnSet<*>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
         valueColumnsInternal(filter)
 
     /**
@@ -124,9 +124,8 @@ public interface ValueColsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[valueCols][ColumnsSelectionDsl.valueCols]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
     @Interpretable("ValueCols1")
-    public fun ColumnsSelectionDsl<*>.valueCols(
-        filter: Predicate<ValueColumn<*>> = { true },
-    ): TransformableColumnSet<*> = asSingleColumn().valueColumnsInternal(filter)
+    public fun ColumnsSelectionDsl<*>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
+        asSingleColumn().valueColumnsInternal(filter)
 
     /**
      * @include [CommonValueColsDocs]
@@ -137,9 +136,8 @@ public interface ValueColsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColGroup.`[valueCols][SingleColumn.valueCols]` { it.`[any][ColumnWithPath.any]` { it == "Alice" } } }`
      */
     @Interpretable("ValueCols2")
-    public fun SingleColumn<DataRow<*>>.valueCols(
-        filter: Predicate<ValueColumn<*>> = { true },
-    ): TransformableColumnSet<*> = this.ensureIsColumnGroup().valueColumnsInternal(filter)
+    public fun SingleColumn<DataRow<*>>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
+        this.ensureIsColumnGroup().valueColumnsInternal(filter)
 
     /**
      * @include [CommonValueColsDocs]
@@ -149,7 +147,7 @@ public interface ValueColsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[valueCols][String.valueCols]`() }`
      */
-    public fun String.valueCols(filter: Predicate<ValueColumn<*>> = { true }): TransformableColumnSet<*> =
+    public fun String.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
         columnGroup(this).valueCols(filter)
 
     /**
@@ -164,7 +162,7 @@ public interface ValueColsColumnsSelectionDsl {
      */
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
-    public fun KProperty<*>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): TransformableColumnSet<*> =
+    public fun KProperty<*>.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
         columnGroup(this).valueCols(filter)
 
     /**
@@ -173,7 +171,7 @@ public interface ValueColsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[valueCols][ColumnPath.valueCols]`() }`
      */
-    public fun ColumnPath.valueCols(filter: Predicate<ValueColumn<*>> = { true }): TransformableColumnSet<*> =
+    public fun ColumnPath.valueCols(filter: Predicate<ValueColumn<*>> = { true }): ColumnSet<*> =
         columnGroup(this).valueCols(filter)
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/TransformableColumnSet.kt
@@ -22,8 +22,8 @@ import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
  * @see [TransformableSingleColumn]
  * @see [SingleColumn]
  */
-public interface TransformableColumnSet<out C> : ColumnSet<C> {
-    public fun transformResolve(
+internal interface TransformableColumnSet<out C> : ColumnSet<C> {
+    fun transformResolve(
         context: ColumnResolutionContext,
         transformer: ColumnsResolverTransformer,
     ): List<ColumnWithPath<C>>
@@ -43,8 +43,8 @@ public interface TransformableColumnSet<out C> : ColumnSet<C> {
  * @see [TransformableColumnSet]
  * @see [ColumnsResolver]
  */
-public interface TransformableSingleColumn<out C> : SingleColumn<C> {
-    public fun transformResolveSingle(
+internal interface TransformableSingleColumn<out C> : SingleColumn<C> {
+    fun transformResolveSingle(
         context: ColumnResolutionContext,
         transformer: ColumnsResolverTransformer,
     ): ColumnWithPath<C>?
@@ -55,10 +55,11 @@ public interface TransformableSingleColumn<out C> : SingleColumn<C> {
  * This contains implementations for both [transform][ColumnSet.transform] and
  * [transformSingle][SingleColumn.transformSingle] and can be passed around.
  */
-public interface ColumnsResolverTransformer {
-    public fun transform(columnsResolver: ColumnsResolver<*>): ColumnsResolver<*>
+@PublishedApi
+internal interface ColumnsResolverTransformer {
+    fun transform(columnsResolver: ColumnsResolver<*>): ColumnsResolver<*>
 
-    public fun transformSet(columnSet: ColumnSet<*>): ColumnsResolver<*>
+    fun transformSet(columnSet: ColumnSet<*>): ColumnsResolver<*>
 
-    public fun transformSingle(singleColumn: SingleColumn<*>): ColumnsResolver<*>
+    fun transformSingle(singleColumn: SingleColumn<*>): ColumnsResolver<*>
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/Utils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/Utils.kt
@@ -199,6 +199,7 @@ internal inline fun <A, B> ColumnsResolver<A>.transform(
                 .resolve(context)
                 .let(converter)
 
+        @Suppress("UNCHECKED_CAST")
         override fun transformResolve(
             context: ColumnResolutionContext,
             transformer: ColumnsResolverTransformer,

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/colsAtAnyDepth.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.asColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableColumnSet
+import org.jetbrains.kotlinx.dataframe.impl.columns.TransformableSingleColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.atAnyDepthImpl
 import org.jetbrains.kotlinx.dataframe.impl.columns.transform
 import org.jetbrains.kotlinx.dataframe.impl.columns.tree.flattenRecursively
@@ -53,7 +54,10 @@ class AtAnyDepth : TestBase() {
     fun `first, last, and single`() {
         listOf(
             dfGroup.select { name.firstName.firstName },
-            dfGroup.select { first { col -> col.any { it == "Alice" } }.atAnyDepthImpl() },
+            dfGroup.select {
+                (first { col -> col.any { it == "Alice" } } as TransformableSingleColumn<*>)
+                    .atAnyDepthImpl()
+            },
             dfGroup.select { colsAtAnyDepth().first { col -> col.any { it == "Alice" } } },
             dfGroup.select { colsAtAnyDepth().filter { col -> col.any { it == "Alice" } }.first() },
             dfGroup.select { colsAtAnyDepth().last { col -> col.any { it == "Alice" } } },


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1037

Making Transformable column resolvers internal and removing them from the public api

