### PR TITLE
Flatten navigation of Modify operations

### DIFF
--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -91,73 +91,61 @@
             </toc-element>
         </toc-element>
         <toc-element topic="modify.md">
-            <toc-element topic="sliceRows.md">
-                <toc-element topic="xs.md"/>
-            </toc-element>
+            <toc-element topic="add.md"/>
+            <toc-element topic="adjustSchema.md"/>
+            <toc-element topic="append.md"/>
+            <toc-element topic="cast.md"/>
+            <toc-element topic="concat.md"/>
+            <toc-element topic="convert.md"/>
+            <toc-element topic="convertTo.md"/>
+            <toc-element topic="distinct.md"/>
+            <toc-element topic="drop.md"/>
+            <toc-element topic="duplicate.md"/>
+            <toc-element topic="explode.md"/>
+            <toc-element topic="fill.md"/>
+            <toc-element topic="filter.md"/>
+            <toc-element topic="flatten.md"/>
+            <toc-element topic="gather.md"/>
+            <toc-element topic="group.md"/>
+            <toc-element topic="groupBy.md"/>
+            <toc-element topic="implode.md"/>
+            <toc-element topic="inferType.md"/>
+            <toc-element topic="insert.md"/>
+            <toc-element topic="join.md"/>
+            <toc-element topic="joinWith.md"/>
+            <toc-element topic="map.md"/>
+            <toc-element topic="merge.md"/>
+            <toc-element topic="move.md"/>
+            <toc-element topic="parse.md"/>
+            <toc-element topic="pivot.md"/>
+            <toc-element topic="remove.md"/>
+            <toc-element topic="rename.md"/>
+            <toc-element topic="reorder.md"/>
+            <toc-element topic="replace.md"/>
+            <toc-element topic="reverse.md"/>
             <toc-element topic="select.md"/>
-            <toc-element topic="filterRows.md">
-                <toc-element topic="filter.md"/>
-                <toc-element topic="drop.md"/>
-                <toc-element topic="distinct.md"/>
-            </toc-element>
-            <toc-element topic="reorderRows.md">
-                <toc-element topic="sortBy.md"/>
-                <toc-element topic="shuffle.md"/>
-                <toc-element topic="reverse.md"/>
-            </toc-element>
-            <toc-element topic="groupByConcat.md">
-                <toc-element topic="groupBy.md"/>
-                <toc-element topic="concat.md"/>
-            </toc-element>
-            <toc-element topic="updateConvert.md">
-                <toc-element topic="update.md">
-                    <toc-element topic="fill.md"/>
-                </toc-element>
-                <toc-element topic="convert.md">
-                    <toc-element topic="parse.md"/>
-                    <toc-element topic="unfold.md"/>
-                </toc-element>
-                <toc-element topic="inferType.md"/>
-            </toc-element>
-            <toc-element topic="splitMerge.md">
-                <toc-element topic="split.md"/>
-                <toc-element topic="merge.md"/>
-            </toc-element>
-            <toc-element topic="addRemove.md">
-                <toc-element topic="add.md"/>
-                <toc-element topic="map.md"/>
-                <toc-element topic="remove.md"/>
-            </toc-element>
-            <toc-element topic="moveRename.md">
-                <toc-element topic="move.md"/>
-                <toc-element topic="rename.md"/>
-                <toc-element topic="reorder.md"/>
-            </toc-element>
-            <toc-element topic="groupUngroupFlatten.md">
-                <toc-element topic="group.md"/>
-                <toc-element topic="ungroup.md"/>
-                <toc-element topic="flatten.md"/>
-            </toc-element>
-            <toc-element topic="insertReplace.md">
-                <toc-element topic="insert.md"/>
-                <toc-element topic="replace.md"/>
-            </toc-element>
-            <toc-element topic="explodeImplode.md">
-                <toc-element topic="explode.md"/>
-                <toc-element topic="implode.md"/>
-            </toc-element>
-            <toc-element topic="pivotGather.md">
-                <toc-element topic="pivot.md"/>
-                <toc-element topic="gather.md"/>
-            </toc-element>
-            <toc-element topic="appendDuplicate.md">
-                <toc-element topic="append.md"/>
-                <toc-element topic="duplicate.md"/>
-            </toc-element>
-            <toc-element topic="adjustSchema.md">
-                <toc-element topic="cast.md"/>
-                <toc-element topic="convertTo.md"/>
-            </toc-element>
+            <toc-element topic="shuffle.md"/>
+            <toc-element topic="sliceRows.md"/>
+            <toc-element topic="sortBy.md"/>
+            <toc-element topic="split.md"/>
+            <toc-element topic="toList.md"/>
+            <toc-element topic="unfold.md"/>
+            <toc-element topic="ungroup.md"/>
+            <toc-element topic="update.md"/>
+            <toc-element topic="xs.md"/>
+            <toc-element topic="addRemove.md" hidden="true"/>
+            <toc-element topic="sliceRows.md" hidden="true"/>
+            <toc-element topic="filterRows.md" hidden="true"/>
+            <toc-element topic="reorderRows.md" hidden="true"/>
+            <toc-element topic="groupByConcat.md" hidden="true"/>
+            <toc-element topic="updateConvert.md" hidden="true"/>
+            <toc-element topic="splitMerge.md" hidden="true"/>
+            <toc-element topic="moveRename.md" hidden="true"/>
+            <toc-element topic="groupUngroupFlatten.md" hidden="true"/>
+            <toc-element topic="insertReplace.md" hidden="true"/>
+            <toc-element topic="explodeImplode.md" hidden="true"/>
+            <toc-element topic="pivotGather.md" hidden="true"/>
+            <toc-element topic="appendDuplicate.md" hidden="true"/>
         </toc-element>
         <toc-element toc-title="Statistics">
             <toc-element topic="summaryStatistics.md">

--- a/docs/StardustDocs/topics/add.md
+++ b/docs/StardustDocs/topics/add.md
@@ -8,6 +8,8 @@ Original [`DataFrame`](DataFrame.md) is not modified.
 `add` appends columns to the end of the dataframe by default.
 If you want to add a single column to a specific position in the dataframe, use [insert](insert.md).
 
+**Related operations**: [](addRemove.md)
+
 ## Create a new column and add it to [`DataFrame`](DataFrame.md)
 
 ```text

--- a/docs/StardustDocs/topics/addRemove.md
+++ b/docs/StardustDocs/topics/addRemove.md
@@ -1,5 +1,5 @@
 [//]: # (title: Add / map / remove columns)
 
 * [`add`](add.md) columns to [`DataFrame`](DataFrame.md)
-* [`map`](map.md) columns to new [`DataFrame`](DataFrame.md) or [`DataColumn`](DataColumn.md)
+* [`map`](map.md) columns to new [`DataFrame`](DataFrame.md), [`DataColumn`](DataColumn.md) or `List`
 * [`remove`](remove.md) columns from [`DataFrame`](DataFrame.md)

--- a/docs/StardustDocs/topics/append.md
+++ b/docs/StardustDocs/topics/append.md
@@ -7,3 +7,5 @@ df.append (
     "John", 17, 
     "Bill", 30)
 ```
+
+**Related operations**: [](appendDuplicate.md)

--- a/docs/StardustDocs/topics/cast.md
+++ b/docs/StardustDocs/topics/cast.md
@@ -7,6 +7,8 @@ Changes the type argument of the [`DataFrame`](DataFrame.md) instance without ch
 cast<T>(verify = false)
 ```
 
+Related operations: [](adjustSchema.md)
+
 **Parameters:**
 * `verify: Boolean = false` —
   when `true`, the function throws an exception if the [`DataFrame`](DataFrame.md) instance doesn't match the given schema. 

--- a/docs/StardustDocs/topics/concat.md
+++ b/docs/StardustDocs/topics/concat.md
@@ -4,6 +4,8 @@
 
 Returns a [`DataFrame`](DataFrame.md) with the union of rows from several given [`DataFrame`](DataFrame.md) objects.
 
+**Related operations**: [](multipleDataFrames.md)
+
 `concat` is available for:
 
 [`DataFrame`](DataFrame.md):

--- a/docs/StardustDocs/topics/convert.md
+++ b/docs/StardustDocs/topics/convert.md
@@ -13,6 +13,8 @@ colExpression = DataFrame.(DataColumn) -> DataColumn
 frameExpression: DataFrame.(DataFrame) -> DataFrame
 ```
 
+**Related operations**: [](updateConvert.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation and
 [row expressions](DataRow.md#row-expressions) for how to provide new values.
 

--- a/docs/StardustDocs/topics/convertTo.md
+++ b/docs/StardustDocs/topics/convertTo.md
@@ -7,6 +7,8 @@
 convertTo<Schema>(excessiveColumns = ExcessiveColumns.Keep)
 ```
 
+**Related operations**: [](adjustSchema.md)
+
 Customization DSL:
 * `convert`—how specific column types should be converted
 * `parser`—how to parse strings into custom types

--- a/docs/StardustDocs/topics/distinct.md
+++ b/docs/StardustDocs/topics/distinct.md
@@ -5,6 +5,8 @@
 Removes duplicate rows.
 The rows in the resulting [`DataFrame`](DataFrame.md) are in the same order as they were in the original [`DataFrame`](DataFrame.md).
 
+Related operations: [](filterRows.md)
+
 <!---FUN distinct-->
 
 ```kotlin

--- a/docs/StardustDocs/topics/drop.md
+++ b/docs/StardustDocs/topics/drop.md
@@ -1,8 +1,10 @@
-[//]: # (title: drop)
+[//]: # (title: drop / dropNulls / dropNaNs / dropNA)
 
 <!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Access-->
 
 Removes all rows that satisfy [row condition](DataRow.md#row-conditions)
+
+**Related operations**: [](filterRows.md)
 
 <!---FUN dropWhere-->
 <tabs>

--- a/docs/StardustDocs/topics/duplicate.md
+++ b/docs/StardustDocs/topics/duplicate.md
@@ -7,6 +7,9 @@ DataRow.duplicate(n): DataFrame
 
 Returns [`FrameColumn`](DataColumn.md#framecolumn) with original [`DataFrame`](DataFrame.md) repeated `n` times. 
 Resulting [`FrameColumn`](DataColumn.md#framecolumn) will have an empty [`name`](DataColumn.md#properties).
+
+**Related operations**: [](appendDuplicate.md)
+
 ```text
 DataFrame.duplicate(n): FrameColumn
 ```

--- a/docs/StardustDocs/topics/explode.md
+++ b/docs/StardustDocs/topics/explode.md
@@ -8,6 +8,8 @@ Splits list-like values in given columns and spreads them vertically. Values in 
 explode(dropEmpty = true) [ { columns } ]
 ```
 
+**Reverse operation:** [`implode`](implode.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 **Parameters:**
@@ -17,8 +19,6 @@ See [column selectors](ColumnSelectors.md) for how to select the columns for thi
 * [`DataFrame`](DataFrame.md)
 * [`FrameColumn`](DataColumn.md#framecolumn)
 * `DataColumn<Collection>`
-
-**Reverse operation:** [`implode`](implode.md)
 
 Exploded columns will change their types:
 * `List<T>` to `T`

--- a/docs/StardustDocs/topics/fill.md
+++ b/docs/StardustDocs/topics/fill.md
@@ -4,6 +4,8 @@
 
 Replace missing values.
 
+**Related operations**: [](updateConvert.md)
+
 ## fillNulls
 
 Replaces `null` values with given value or expression. 

--- a/docs/StardustDocs/topics/filter.md
+++ b/docs/StardustDocs/topics/filter.md
@@ -4,6 +4,8 @@
 
 Returns [`DataFrame`](DataFrame.md) with rows that satisfy [row condition](DataRow.md#row-conditions)
 
+**Related operations**: [](filterRows.md)
+
 <!---FUN filter-->
 <tabs>
 <tab title="Properties">

--- a/docs/StardustDocs/topics/flatten.md
+++ b/docs/StardustDocs/topics/flatten.md
@@ -11,6 +11,8 @@ flatten  [ { columns } ]
 Columns will keep their original names after flattening.
 Potential column name clashes are resolved by adding minimal possible name prefix from ancestor columns.
 
+**Related operations**: [](groupUngroupFlatten.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN flatten-->

--- a/docs/StardustDocs/topics/group.md
+++ b/docs/StardustDocs/topics/group.md
@@ -11,7 +11,7 @@ group { columns }
 groupNameExpression = DataColumn.(DataColumn) -> String
 ```
 
-**Reverse operation:** [`ungroup`](ungroup.md)
+**Reverse operation:** [`ungroup`](ungroup.md), [`flatten`](flatten.md)
 
 It is a special case of [`move`](move.md) operation.
 

--- a/docs/StardustDocs/topics/insert.md
+++ b/docs/StardustDocs/topics/insert.md
@@ -16,6 +16,8 @@ Similar to [add](add.md), but supports column positioning.
 
 Create new column based on existing columns and insert it into [`DataFrame`](DataFrame.md):
 
+**Related operations**: [](insertReplace.md)
+
 <!---FUN insert-->
 <tabs>
 <tab title="Properties">

--- a/docs/StardustDocs/topics/join.md
+++ b/docs/StardustDocs/topics/join.md
@@ -19,6 +19,8 @@ interface JoinDsl: LeftDataFrame {
 
 `joinColumns` is a [column selector](ColumnSelectors.md) that defines column mapping for join:
 
+Related operations: [](multipleDataFrames.md)
+
 <!---FUN joinWithMatch-->
 <tabs>
 <tab title="Properties">

--- a/docs/StardustDocs/topics/map.md
+++ b/docs/StardustDocs/topics/map.md
@@ -5,6 +5,8 @@
 Creates [`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/), [DataFrame](DataFrame.md) or [DataColumn](DataColumn.md) 
 with values computed from rows of original [DataFrame](DataFrame.md).
 
+**Related operations**: [](addRemove.md)
+
 **Map into `List`:**
 
 ```text

--- a/docs/StardustDocs/topics/merge.md
+++ b/docs/StardustDocs/topics/merge.md
@@ -15,6 +15,8 @@ merge { columns }
 merger: (DataRow).List<T> -> Any
 ```
 
+**Related operations**: [](splitMerge.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN merge-->

--- a/docs/StardustDocs/topics/move.md
+++ b/docs/StardustDocs/topics/move.md
@@ -11,6 +11,8 @@ move { columns }
 pathSelector: DataFrame.(DataColumn) -> ColumnPath
 ```
 
+**Related operations**: [](moveRename.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 Can be used to change column hierarchy by providing `ColumnPath` for every moved column.

--- a/docs/StardustDocs/topics/parse.md
+++ b/docs/StardustDocs/topics/parse.md
@@ -9,6 +9,8 @@ This parsing operation is sometimes executed implicitly, for example, when [read
 [type converting from `String` columns](convert.md).
 You can recognize this by the `locale` or `parserOptions` arguments in these functions.
 
+Related operations: [](updateConvert.md)
+
 <!---FUN parseAll-->
 
 ```kotlin

--- a/docs/StardustDocs/topics/remove.md
+++ b/docs/StardustDocs/topics/remove.md
@@ -8,6 +8,8 @@ Returns [`DataFrame`](DataFrame.md) without selected columns.
 remove { columns }
 ```
 
+Related operations: [](addRemove.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN remove-->

--- a/docs/StardustDocs/topics/rename.md
+++ b/docs/StardustDocs/topics/rename.md
@@ -11,6 +11,8 @@ df.rename { columns }.into { nameExpression }
 nameExpression = (DataColumn) -> String
 ```
 
+**Related operations**: [](moveRename.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN rename-->

--- a/docs/StardustDocs/topics/reorder.md
+++ b/docs/StardustDocs/topics/reorder.md
@@ -12,6 +12,8 @@ reorder { columns }
 columnExpression: DataColumn.(DataColumn) -> Value
 ```
 
+**Related operations**: [](moveRename.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN reorder-->

--- a/docs/StardustDocs/topics/replace.md
+++ b/docs/StardustDocs/topics/replace.md
@@ -10,6 +10,8 @@ replace { columns }
 columnExpression: DataFrame.(DataColumn) -> DataColumn
 ```
 
+**Related operations**: [](insertReplace.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN replace-->

--- a/docs/StardustDocs/topics/reverse.md
+++ b/docs/StardustDocs/topics/reverse.md
@@ -4,6 +4,8 @@
 
 Returns [`DataFrame`](DataFrame.md) with rows in reversed order.
 
+**Related operations**: [](reorderRows.md)
+
 <!---FUN reverse-->
 
 ```kotlin

--- a/docs/StardustDocs/topics/select.md
+++ b/docs/StardustDocs/topics/select.md
@@ -49,4 +49,6 @@ df.select("age", "weight")
 <inline-frame src="resources/org.jetbrains.kotlinx.dataframe.samples.api.Access.select.html" width="100%"/>
 <!---END-->
 
+**Related operations**: [remove](remove.md)
+
 See [column selectors](ColumnSelectors.md)

--- a/docs/StardustDocs/topics/shuffle.md
+++ b/docs/StardustDocs/topics/shuffle.md
@@ -4,6 +4,8 @@
 
 Returns [`DataFrame`](DataFrame.md) with randomly reordered rows.
 
+**Related operations**: [](reorderRows.md)
+
 <!---FUN shuffle-->
 
 ```kotlin

--- a/docs/StardustDocs/topics/sortBy.md
+++ b/docs/StardustDocs/topics/sortBy.md
@@ -8,6 +8,8 @@ By default, columns are sorted in ascending order with `null` values going first
 * `.desc` — changes column sort order from ascending to descending
 * `.nullsLast` — forces `null` values to be placed at the end of the order
 
+**Related operations**: [](reorderRows.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 <!---FUN sortBy-->

--- a/docs/StardustDocs/topics/split.md
+++ b/docs/StardustDocs/topics/split.md
@@ -20,6 +20,8 @@ The following types of columns can be split easily:
 * `List`: splits into elements, no `by` required!
 * [`DataFrame`](DataFrame.md): splits into rows, no `by` required!
 
+**Related operations**: [](splitMerge.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 
 ## Split in place

--- a/docs/StardustDocs/topics/toList.md
+++ b/docs/StardustDocs/topics/toList.md
@@ -9,6 +9,8 @@ of data class instances by current [`DataFrame`](DataFrame.md) type argument.
 toList()
 ```
 
+**More info**: [](collectionsInterop.md)
+
 Type of data class is defined by current type argument of [`DataFrame`](DataFrame.md). If this type argument is not data class, exception will be thrown.
 
 Data class properties are matched with [`DataFrame`](DataFrame.md) columns by name. If property type differs from column type [type conversion](convert.md) will be performed. If no automatic type conversion was found, exception will be thrown. 

--- a/docs/StardustDocs/topics/update.md
+++ b/docs/StardustDocs/topics/update.md
@@ -17,6 +17,8 @@ rowColExpression: (DataRow, DataColumn) -> NewValue
 frameExpression: DataFrame.(DataFrame) -> DataFrame
 ```
 
+**Related operations**: [](updateConvert.md)
+
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation and
 [row expressions](DataRow.md#row-expressions) for how to specify the new values.
 

--- a/docs/StardustDocs/topics/updateConvert.md
+++ b/docs/StardustDocs/topics/updateConvert.md
@@ -4,4 +4,7 @@ Both [`update`](update.md) and [`convert`](convert.md) can be used to change col
 
 Difference between these operations:
 * `convert` allows changing the type of the column, `update` doesn't
+* `parse` is a special case of `convert` to convert String into different types automatically based on its contents
+* `unfold` is a special case of `convert` to convert `DataColumn` of objects into `ColumnGroup` based on properties of objects.
 * `update` allows filtering cells to be updated, `convert` doesn't
+* [`fill`](fill.md) is a special case of `update` to replace missing values


### PR DESCRIPTION
The core idea is to embed all meta-information about "related" or "opposite" operations on the pages, so navigation can be simple and sorted

https://github.com/Kotlin/dataframe/issues/1292