### PR TITLE
Replace static initialization of defaultTimeZone with getter 

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convert.kt
@@ -725,7 +725,7 @@ internal fun Instant.toLocalDate(zone: TimeZone = defaultTimeZone) = toLocalDate
 
 internal fun Instant.toLocalTime(zone: TimeZone = defaultTimeZone) = toLocalDateTime(zone).time
 
-internal val defaultTimeZone = TimeZone.currentSystemDefault()
+internal val defaultTimeZone get() = TimeZone.currentSystemDefault()
 
 internal fun Number.toBigDecimal(): BigDecimal =
     when (this) {


### PR DESCRIPTION
With defaultTimeZone initialized statically, any call to ConvertKt, even not related to TZ, triggers loading kotlinx.datetime dependency. We use ConvertKt in plugin, but including this dependency is not desirable