### PR TITLE
Add deprecated filterNotNull for discoverability of dropNulls

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3494,6 +3494,7 @@ public final class org/jetbrains/kotlinx/dataframe/api/NullsKt {
 	public static final fun fillNulls (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/api/Update;
 	public static final fun fillNulls (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/api/Update;
 	public static final fun fillNulls (Lorg/jetbrains/kotlinx/dataframe/DataFrame;[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/api/Update;
+	public static final fun filterNotNull (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/api/ParseKt {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -383,6 +383,15 @@ public fun <T> DataFrame<T>.dropNulls(whereAllNull: Boolean = false, columns: Co
     }
 }
 
+@Refine
+@Interpretable("DropNulls0")
+@Deprecated(
+    "DataFrame conventional name for filterNot* functions is drop*",
+    ReplaceWith("dropNulls(columns = columns)"),
+    DeprecationLevel.ERROR,
+)
+public fun <T> DataFrame<T>.filterNotNull(columns: ColumnsSelector<T, *>): DataFrame<T> = dropNulls(columns = columns)
+
 /**
  * @include [CommonDropNullsFunctionDoc]
  * This overload operates on all columns in the [DataFrame].

--- a/docs/StardustDocs/topics/drop.md
+++ b/docs/StardustDocs/topics/drop.md
@@ -27,7 +27,7 @@ df.drop { it["weight"] == null || it["city"] == null }
 
 ## dropNulls
 
-Remove rows with `null` values
+Remove rows with `null` values. This is a DataFrame equivalent of `filterNotNull`.
 
 See [column selectors](ColumnSelectors.md) for how to select the columns for this operation.
 


### PR DESCRIPTION
We discussed that `dropNulls` is not obvious for people familiar with `filterNotNull` from Kotlin Collections and decided to keep our convention but add a few pointers