### PR TITLE
Hide `mapToColumn` in CS DSL in favor of `expr`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/expr.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.documentation.ColumnExpression
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
+import kotlin.reflect.typeOf
 
 // region ColumnsSelectionDsl
 
@@ -65,6 +66,6 @@ public inline fun <T, reified R> ColumnsSelectionDsl<T>.expr(
     name: String = "",
     infer: Infer = Infer.Nulls,
     noinline expression: AddExpression<T, R>,
-): DataColumn<R> = mapToColumn(name, infer, expression)
+): DataColumn<R> = mapToColumn(name, typeOf<R>(), infer, expression)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.impl.columnName
 import org.jetbrains.kotlinx.dataframe.impl.columns.createComputedColumnReference
 import org.jetbrains.kotlinx.dataframe.impl.columns.newColumn
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
+import org.jetbrains.kotlinx.dataframe.util.UNIFIED_SIMILAR_CS_API
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -70,6 +71,16 @@ public inline fun <T, R> DataColumn<T>.mapIndexed(
 
 public inline fun <T, R> DataFrame<T>.map(transform: RowExpression<T, R>): List<R> = rows().map { transform(it, it) }
 
+public inline fun <T, reified R> DataFrame<T>.mapToColumn(
+    name: String,
+    infer: Infer = Infer.Nulls,
+    noinline body: AddExpression<T, R>,
+): DataColumn<R> = mapToColumn(name, typeOf<R>(), infer, body)
+
+@Deprecated(
+    UNIFIED_SIMILAR_CS_API,
+    replaceWith = ReplaceWith("expr(name, infer, body)", "org.jetbrains.kotlinx.dataframe.api.Infer"),
+)
 public inline fun <T, reified R> ColumnsContainer<T>.mapToColumn(
     name: String,
     infer: Infer = Infer.Nulls,
@@ -92,7 +103,8 @@ public inline fun <T, reified R> ColumnsContainer<T>.mapToColumn(
     noinline body: AddExpression<T, R>,
 ): DataColumn<R> = mapToColumn(column, typeOf<R>(), infer, body)
 
-public fun <T, R> ColumnsContainer<T>.mapToColumn(
+@PublishedApi
+internal fun <T, R> ColumnsContainer<T>.mapToColumn(
     name: String,
     type: KType,
     infer: Infer = Infer.Nulls,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -189,6 +189,7 @@ internal const val GENERATE_CODE_REPLACE2 =
 
 internal const val GENERATE_INTERFACES = "This function is just here for binary compatibility. $MESSAGE_1_1"
 
+internal const val UNIFIED_SIMILAR_CS_API = "Deprecated duplicated functionality. $MESSAGE_1_1"
 // endregion
 
 // region keep across releases


### PR DESCRIPTION
fixes #1105