### PR TITLE
Add Hibernate example with H2 in-memory database to idea-examples

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,6 +157,7 @@ val modulesUsingJava11 = with(projects) {
         dataframeJupyter,
         dataframeGeo,
         examples.ideaExamples.titanic,
+        examples.ideaExamples.unsupportedDataSources,
         tests,
         plugins.dataframeGradlePlugin,
     )

--- a/examples/idea-examples/unsupported-data-sources/build.gradle.kts
+++ b/examples/idea-examples/unsupported-data-sources/build.gradle.kts
@@ -25,6 +25,14 @@ dependencies {
     implementation(libs.exposed.json)
     implementation(libs.exposed.money)
 
+    // Hibernate + H2 + HikariCP (for Hibernate example)
+    implementation(libs.hibernate.core)
+    implementation(libs.hibernate.hikaricp)
+    implementation(libs.hikaricp)
+
+    implementation(libs.h2db)
+    implementation(libs.sl4jsimple)
+
     // (kotlin) spark support
     implementation(libs.kotlin.spark)
     compileOnly(libs.spark)

--- a/examples/idea-examples/unsupported-data-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/hibernate/entities.kt
+++ b/examples/idea-examples/unsupported-data-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/hibernate/entities.kt
@@ -1,0 +1,100 @@
+package org.jetbrains.kotlinx.dataframe.examples.hibernate
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.jetbrains.kotlinx.dataframe.annotations.ColumnName
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+
+@Entity
+@Table(name = "Albums")
+class AlbumsEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "AlbumId")
+    var albumId: Int? = null,
+
+    @Column(name = "Title", length = 160, nullable = false)
+    var title: String = "",
+
+    @Column(name = "ArtistId", nullable = false)
+    var artistId: Int = 0,
+)
+
+@Entity
+@Table(name = "Artists")
+class ArtistsEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ArtistId")
+    var artistId: Int? = null,
+
+    @Column(name = "Name", length = 120, nullable = false)
+    var name: String = "",
+)
+
+@Entity
+@Table(name = "Customers")
+class CustomersEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CustomerId")
+    var customerId: Int? = null,
+
+    @Column(name = "FirstName", length = 40, nullable = false)
+    var firstName: String = "",
+
+    @Column(name = "LastName", length = 20, nullable = false)
+    var lastName: String = "",
+
+    @Column(name = "Company", length = 80)
+    var company: String? = null,
+
+    @Column(name = "Address", length = 70)
+    var address: String? = null,
+
+    @Column(name = "City", length = 40)
+    var city: String? = null,
+
+    @Column(name = "State", length = 40)
+    var state: String? = null,
+
+    @Column(name = "Country", length = 40)
+    var country: String? = null,
+
+    @Column(name = "PostalCode", length = 10)
+    var postalCode: String? = null,
+
+    @Column(name = "Phone", length = 24)
+    var phone: String? = null,
+
+    @Column(name = "Fax", length = 24)
+    var fax: String? = null,
+
+    @Column(name = "Email", length = 60, nullable = false)
+    var email: String = "",
+
+    @Column(name = "SupportRepId")
+    var supportRepId: Int? = null,
+)
+
+// DataFrame schema to get typed accessors similar to Exposed example
+@DataSchema
+data class DfCustomers(
+    @ColumnName("Address") val address: String?,
+    @ColumnName("City") val city: String?,
+    @ColumnName("Company") val company: String?,
+    @ColumnName("Country") val country: String?,
+    @ColumnName("CustomerId") val customerId: Int,
+    @ColumnName("Email") val email: String,
+    @ColumnName("Fax") val fax: String?,
+    @ColumnName("FirstName") val firstName: String,
+    @ColumnName("LastName") val lastName: String,
+    @ColumnName("Phone") val phone: String?,
+    @ColumnName("PostalCode") val postalCode: String?,
+    @ColumnName("State") val state: String?,
+    @ColumnName("SupportRepId") val supportRepId: Int?,
+)

--- a/examples/idea-examples/unsupported-data-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/hibernate/main.kt
+++ b/examples/idea-examples/unsupported-data-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/hibernate/main.kt
@@ -1,0 +1,221 @@
+package org.jetbrains.kotlinx.dataframe.examples.hibernate
+
+import jakarta.persistence.Tuple
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaDelete
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Root
+import org.hibernate.SessionFactory
+import org.hibernate.cfg.Configuration
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.api.asSequence
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.jetbrains.kotlinx.dataframe.api.describe
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.print
+import org.jetbrains.kotlinx.dataframe.api.sortByDesc
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.size
+
+/**
+ * Example showing Kotlin DataFrame with Hibernate ORM + H2 in-memory DB.
+ * Mirrors logic from the Exposed example: load data, convert to DataFrame, group/describe, write back.
+ */
+fun main() {
+    val sessionFactory: SessionFactory = buildSessionFactory()
+
+    sessionFactory.insertSampleData()
+
+    val df = sessionFactory.loadCustomersAsDataFrame()
+
+    // Pure Hibernate + Criteria API approach for counting customers per country
+    println("=== Hibernate + Criteria API Approach ===")
+    sessionFactory.countCustomersPerCountryWithHibernate()
+
+    println("\n=== DataFrame Approach ===")
+    df.analyzeAndPrintResults()
+
+    sessionFactory.replaceCustomersFromDataFrame(df)
+
+    sessionFactory.close()
+}
+
+private fun SessionFactory.insertSampleData() {
+    withTransaction { session ->
+        // a few artists and albums (minimal, not used further; just demo schema)
+        val artist1 = ArtistsEntity(name = "AC/DC")
+        val artist2 = ArtistsEntity(name = "Queen")
+        session.persist(artist1)
+        session.persist(artist2)
+
+        session.persist(AlbumsEntity(title = "High Voltage", artistId = 1))
+        session.persist(AlbumsEntity(title = "Back in Black", artistId = 1))
+        session.persist(AlbumsEntity(title = "A Night at the Opera", artistId = 2))
+
+        // customers we'll analyze using DataFrame
+        session.persist(
+            CustomersEntity(
+                firstName = "John",
+                lastName = "Doe",
+                email = "john.doe@example.com",
+                country = "USA",
+            ),
+        )
+        session.persist(
+            CustomersEntity(
+                firstName = "Jane",
+                lastName = "Smith",
+                email = "jane.smith@example.com",
+                country = "USA",
+            ),
+        )
+        session.persist(
+            CustomersEntity(
+                firstName = "Alice",
+                lastName = "Wang",
+                email = "alice.wang@example.com",
+                country = "Canada",
+            ),
+        )
+    }
+}
+
+private fun SessionFactory.loadCustomersAsDataFrame(): DataFrame<DfCustomers> {
+    return withSession { session ->
+        val criteriaBuilder: CriteriaBuilder = session.criteriaBuilder
+        val criteriaQuery: CriteriaQuery<CustomersEntity> = criteriaBuilder.createQuery(CustomersEntity::class.java)
+        val root: Root<CustomersEntity> = criteriaQuery.from(CustomersEntity::class.java)
+        criteriaQuery.select(root)
+
+        session.createQuery(criteriaQuery)
+            .list()
+            .map { c ->
+                DfCustomers(
+                    address = c.address,
+                    city = c.city,
+                    company = c.company,
+                    country = c.country,
+                    customerId = c.customerId ?: -1,
+                    email = c.email,
+                    fax = c.fax,
+                    firstName = c.firstName,
+                    lastName = c.lastName,
+                    phone = c.phone,
+                    postalCode = c.postalCode,
+                    state = c.state,
+                    supportRepId = c.supportRepId,
+                )
+            }
+            .toDataFrame()
+    }
+}
+
+/**
+ * **Hibernate + Criteria API:**
+ * - ✅ Database-level aggregation (efficient)
+ * - ✅ Type-safe queries
+ * - ❌ Verbose syntax
+ * - ❌ Limited to SQL-like operations
+ */
+private fun SessionFactory.countCustomersPerCountryWithHibernate() {
+    withSession { session ->
+        val criteriaBuilder: CriteriaBuilder = session.criteriaBuilder
+        val query: CriteriaQuery<Tuple> = criteriaBuilder.createTupleQuery()
+        val root: Root<CustomersEntity> = query.from(CustomersEntity::class.java)
+
+        // Select country and count of customers, grouped by country, ordered by count DESC
+        query.multiselect(
+            root.get<String>("country").alias("country"),
+            criteriaBuilder.count(root.get<Long>("customerId")).alias("customerCount")
+        )
+        query.groupBy(root.get<String>("country"))
+        query.orderBy(
+            criteriaBuilder.desc(criteriaBuilder.count(root.get<Long>("customerId")))
+        )
+
+        val results = session.createQuery(query).list()
+        results.forEach { tuple ->
+            val country = tuple.get("country", String::class.java)
+            val count = tuple.get("customerCount", Long::class.java)
+            println("$country: $count customers")
+        }
+    }
+}
+
+/**
+ * **DataFrame approach: **
+ * - ✅ Rich analytical operations
+ * - ✅ Fluent, readable API
+ * - ✅ Flexible data transformations
+ * - ❌ In-memory processing (less efficient for large datasets)
+ */
+private fun DataFrame<DfCustomers>.analyzeAndPrintResults() {
+    println(size())
+
+    // same operation as Exposed example: customers per country
+    groupBy { country }.count()
+        .sortByDesc { "count"<Int>() }
+        .print(columnTypes = true, borders = true)
+
+    // general statistics
+    describe()
+        .print(columnTypes = true, borders = true)
+}
+
+private fun SessionFactory.replaceCustomersFromDataFrame(df: DataFrame<DfCustomers>) {
+    withTransaction { session ->
+        val criteriaBuilder: CriteriaBuilder = session.criteriaBuilder
+        val criteriaDelete: CriteriaDelete<CustomersEntity> =
+            criteriaBuilder.createCriteriaDelete(CustomersEntity::class.java)
+        criteriaDelete.from(CustomersEntity::class.java)
+
+        session.createMutationQuery(criteriaDelete).executeUpdate()
+    }
+
+    withTransaction { session ->
+        df.asSequence().forEach { row ->
+            session.persist(row.toCustomersEntity())
+        }
+    }
+}
+
+private fun DataRow<DfCustomers>.toCustomersEntity(): CustomersEntity {
+    return CustomersEntity(
+        customerId = null, // let DB generate
+        firstName = this["FirstName"] as String,
+        lastName = this["LastName"] as String,
+        company = this["Company"] as String?,
+        address = this["Address"] as String?,
+        city = this["City"] as String?,
+        state = this["State"] as String?,
+        country = this["Country"] as String?,
+        postalCode = this["PostalCode"] as String?,
+        phone = this["Phone"] as String?,
+        fax = this["Fax"] as String?,
+        email = this["Email"] as String,
+        supportRepId = this["SupportRepId"] as Int?,
+    )
+}
+
+private inline fun <T> SessionFactory.withSession(block: (session: org.hibernate.Session) -> T): T {
+    return openSession().use(block)
+}
+
+private inline fun SessionFactory.withTransaction(block: (session: org.hibernate.Session) -> Unit) {
+    withSession { session ->
+        session.beginTransaction()
+        try {
+            block(session)
+            session.transaction.commit()
+        } catch (e: Exception) {
+            session.transaction.rollback()
+            throw e
+        }
+    }
+}
+
+private fun buildSessionFactory(): SessionFactory {
+    // Load configuration from resources/hibernate/hibernate.cfg.xml
+    return Configuration().configure("hibernate/hibernate.cfg.xml").buildSessionFactory()
+}

--- a/examples/idea-examples/unsupported-data-sources/src/main/resources/hibernate/hibernate.cfg.xml
+++ b/examples/idea-examples/unsupported-data-sources/src/main/resources/hibernate/hibernate.cfg.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 5.3//EN"
+        "http://hibernate.org/dtd/hibernate-configuration-5.3.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <!-- H2 in-memory -->
+        <property name="hibernate.connection.driver_class">org.h2.Driver</property>
+        <property name="hibernate.connection.url">jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"></property>
+
+        <!-- Connection pool: HikariCP via Hibernate integration -->
+        <property name="hibernate.connection.provider_class">org.hibernate.hikaricp.internal.HikariCPConnectionProvider</property>
+        <property name="hibernate.hikari.maximumPoolSize">5</property>
+
+        <!-- Hibernate Dialect -->
+        <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
+
+        <!-- Automatic schema generation -->
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <!-- Logging -->
+        <property name="hibernate.show_sql">true</property>
+        <property name="hibernate.format_sql">true</property>
+
+        <!-- Mappings -->
+        <mapping class="org.jetbrains.kotlinx.dataframe.examples.hibernate.CustomersEntity"/>
+        <mapping class="org.jetbrains.kotlinx.dataframe.examples.hibernate.ArtistsEntity"/>
+        <mapping class="org.jetbrains.kotlinx.dataframe.examples.hibernate.AlbumsEntity"/>
+    </session-factory>
+</hibernate-configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,8 @@ jts = "1.20.0"
 
 kandy = "0.8.1-dev-66"
 exposed = "1.0.0-beta-2"
+hibernate = "6.5.2.Final"
+hikari = "5.1.0"
 
 # check the versions down in the [libraries] section too!
 kotlin-spark = "1.2.4"
@@ -172,6 +174,10 @@ exposed-jdbc = { group = "org.jetbrains.exposed", name = "exposed-jdbc", version
 exposed-kotlin-datetime = { group = "org.jetbrains.exposed", name = "exposed-kotlin-datetime", version.ref = "exposed" }
 exposed-json = { group = "org.jetbrains.exposed", name = "exposed-json", version.ref = "exposed" }
 exposed-money = { group = "org.jetbrains.exposed", name = "exposed-money", version.ref = "exposed" }
+
+hibernate-core = { group = "org.hibernate.orm", name = "hibernate-core", version.ref = "hibernate" }
+hibernate-hikaricp = { group = "org.hibernate.orm", name = "hibernate-hikaricp", version.ref = "hibernate" }
+hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikari" }
 
 kotlin-spark = { group = "org.jetbrains.kotlinx.spark", name = "kotlin-spark-api_3.3.2_2.13", version.ref = "kotlin-spark" }
 spark = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark" }


### PR DESCRIPTION
This commit introduces a new example demonstrating the integration of Kotlin DataFrame with Hibernate ORM and H2 in-memory database. It includes setup for Hibernate, entity mappings, and analytical operations using DataFrame. Dependencies and configuration for Hibernate and H2 are updated accordingly.

Closes #1363 