### PR TITLE
Fixed reading Parquet file on Windows

### DIFF
--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReading.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReading.kt
@@ -223,7 +223,15 @@ public fun DataFrame.Companion.readParquet(
     vararg paths: Path,
     nullability: NullabilityOptions = NullabilityOptions.Infer,
     batchSize: Long = ARROW_PARQUET_DEFAULT_BATCH_SIZE,
-): AnyFrame = readArrowDatasetImpl(paths.map { "file:$it" }.toTypedArray(), FileFormat.PARQUET, nullability, batchSize)
+): AnyFrame =
+    readArrowDatasetImpl(
+        paths.map {
+            it.toUri().toString()
+        }.toTypedArray(),
+        FileFormat.PARQUET,
+        nullability,
+        batchSize,
+    )
 
 /**
  * Read [Parquet](https://parquet.apache.org/) data from existing [files] by using [Arrow Dataset](https://arrow.apache.org/docs/java/dataset.html)
@@ -235,7 +243,7 @@ public fun DataFrame.Companion.readParquet(
 ): AnyFrame =
     readArrowDatasetImpl(
         files.map {
-            "file:${it.toPath()}"
+            it.toURI().toString()
         }.toTypedArray(),
         FileFormat.PARQUET,
         nullability,

--- a/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
+++ b/dataframe-arrow/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/arrowReadingImpl.kt
@@ -432,12 +432,12 @@ private fun resolveArrowDatasetUris(fileUris: Array<String>): Array<String> =
                 tempFile.deleteOnExit()
                 url.openStream().use { input ->
                     Files.copy(input, tempFile.toPath())
-                    "file:${tempFile.toPath()}"
+                    tempFile.toURI().toString()
                 }
             }
 
             !it.startsWith("file:", true) && File(it).exists() -> {
-                "file:$it"
+                File(it).toURI().toString()
             }
 
             else -> it

--- a/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
+++ b/dataframe-arrow/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/ArrowKtTest.kt
@@ -48,12 +48,11 @@ import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.net.URI
 import java.net.URL
 import java.nio.channels.Channels
-import java.nio.file.FileSystems
 import java.sql.DriverManager
 import java.util.Locale
+import kotlin.io.path.toPath
 import kotlin.reflect.typeOf
 
 internal class ArrowKtTest {
@@ -658,9 +657,11 @@ internal class ArrowKtTest {
 
     @Test
     fun testReadParquetPath() {
-        val resourceLocation = testResource("test.arrow.parquet").path
-        val resourcePath = FileSystems.getDefault().getPath(resourceLocation)
+        val resourceUrl = testResource("test.arrow.parquet")
+        val resourcePath = resourceUrl.toURI().toPath()
+
         val dataFrame = DataFrame.readParquet(resourcePath)
+
         dataFrame.rowsCount() shouldBe 300
         assertEstimations(
             exampleFrame = dataFrame,
@@ -672,9 +673,11 @@ internal class ArrowKtTest {
 
     @Test
     fun testReadParquetFile() {
-        val resourceLocation = testResource("test.arrow.parquet").path
-        val resourcePath = FileSystems.getDefault().getPath(resourceLocation)
+        val resourceUrl = testResource("test.arrow.parquet")
+        val resourcePath = resourceUrl.toURI().toPath()
+
         val dataFrame = DataFrame.readParquet(resourcePath.toFile())
+
         dataFrame.rowsCount() shouldBe 300
         assertEstimations(
             exampleFrame = dataFrame,
@@ -686,9 +689,11 @@ internal class ArrowKtTest {
 
     @Test
     fun testReadParquetStringPath() {
-        val resourceLocation = testResource("test.arrow.parquet").path
-        val resourcePath = FileSystems.getDefault().getPath(resourceLocation)
+        val resourceUrl = testResource("test.arrow.parquet")
+        val resourcePath = resourceUrl.toURI().toPath()
+
         val dataFrame = DataFrame.readParquet("$resourcePath")
+
         dataFrame.rowsCount() shouldBe 300
         assertEstimations(
             exampleFrame = dataFrame,
@@ -700,10 +705,12 @@ internal class ArrowKtTest {
 
     @Test
     fun testReadParquetUrl() {
-        val resourceLocation = testResource("test.arrow.parquet").path
-        val resourcePath = FileSystems.getDefault().getPath(resourceLocation)
-        val fileUrl = URI.create("file:$resourcePath").toURL()
+        val resourceUrl = testResource("test.arrow.parquet")
+        val resourcePath = resourceUrl.toURI().toPath()
+        val fileUrl = resourcePath.toUri().toURL()
+
         val dataFrame = DataFrame.readParquet(fileUrl)
+
         dataFrame.rowsCount() shouldBe 300
         assertEstimations(
             exampleFrame = dataFrame,
@@ -715,9 +722,11 @@ internal class ArrowKtTest {
 
     @Test
     fun testReadMultipleParquetFiles() {
-        val resourceLocation = testResource("test.arrow.parquet").path
-        val resourcePath = FileSystems.getDefault().getPath(resourceLocation)
+        val resourceUrl = testResource("test.arrow.parquet")
+        val resourcePath = resourceUrl.toURI().toPath()
+
         val dataFrame = DataFrame.readParquet(resourcePath, resourcePath, resourcePath)
+
         dataFrame.rowsCount() shouldBe 900
     }
 }


### PR DESCRIPTION
Updated file path handling to use `toURI().toString`

This commit replaces string concatenation for file paths with the more robust `toURI().toString` across various methods and tests. This improves consistency and ensures proper URI formatting.

Fixes #1378