### PR TITLE
Migrate usages of deprecated API in implementation & warning fixes

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
@@ -117,7 +117,7 @@ public fun <T, C, R> MergeWithTransform<T, C, R>.into(path: ColumnPath): DataFra
         res = res
             .removeImpl(allowMissingColumns = true) { path }
             .df
-            .move(mergePath).into { path }
+            .move { mergePath }.into { path }
     }
     return res
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.typeOf
 
 public fun <T> DataRow<T>.transpose(): DataFrame<NameValuePair<*>> {
     val valueColumn = DataColumn.createByInference(NameValuePair<*>::value.columnName, values)
-    val nameColumn = owner.columnNames().toValueColumn(NameValuePair<*>::name)
+    val nameColumn = owner.columnNames().toValueColumn(NameValuePair<*>::name.name)
     return dataFrameOf(nameColumn, valueColumn).cast()
 }
 
@@ -25,7 +25,7 @@ public inline fun <reified T> AnyRow.transposeTo(): DataFrame<NameValuePair<T>> 
 internal fun <T> AnyRow.transposeTo(type: KType): DataFrame<NameValuePair<T>> {
     val convertedValues = values.map { it?.convertTo(type) as T? }
     val valueColumn = DataColumn.createByInference(NameValuePair<T>::value.columnName, convertedValues)
-    val nameColumn = owner.columnNames().toValueColumn(NameValuePair<T>::name)
+    val nameColumn = owner.columnNames().toValueColumn(NameValuePair<T>::name.name)
     return dataFrameOf(nameColumn, valueColumn).cast()
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
@@ -72,7 +72,7 @@ public fun <T> DataFrame<T>.valueCounts(
         .asColumnGroup(rows)
         .asDataColumn()
         .valueCounts(sort, ascending, dropNA, countName)
-        .ungroup(rows)
+        .ungroup { rows }
         .cast()
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.pathOf
 import org.jetbrains.kotlinx.dataframe.api.remove
 import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.AggregatableInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.GroupByReceiverImpl

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/flatten.kt
@@ -32,7 +32,7 @@ internal fun <T, C> DataFrame<T>.flattenImpl(
     fun getRootPrefix(path: ColumnPath) =
         (1 until path.size).asSequence().map { path.take(it) }.first { rootPrefixes.contains(it) }
 
-    val result = move { rootPrefixes.toColumnSet().colsAtAnyDepth { !it.isColumnGroup() } }
+    val result = move { rootPrefixes.toColumnSet().colsAtAnyDepth().filter { !it.isColumnGroup() } }
         .into {
             val targetPath = getRootPrefix(it.path).dropLast(1)
             val nameGen = nameGenerators[targetPath]!!

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/gather.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/gather.kt
@@ -62,13 +62,13 @@ internal fun <T, C, K, R> Gather<T, C, K, R>.gatherImpl(
 
         // explode keys and values
         df = when {
-            keysColumn != null && valuesColumn != null -> df.explode(keysColumn, valuesColumn)
-            else -> df.explode(keysColumn ?: valuesColumn!!)
+            keysColumn != null && valuesColumn != null -> df.explode { keysColumn and valuesColumn }
+            else -> df.explode { keysColumn ?: valuesColumn!! }
         }
 
         // explode values in lists
         if (explode && valuesColumn != null) {
-            df = df.explode(valuesColumn)
+            df = df.explode { valuesColumn }
         }
     } else {
         val nameAndValue = column<List<Pair<K, Any?>>>("nameAndValue")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/parse.kt
@@ -348,7 +348,7 @@ internal object Parsers : GlobalParserOptions {
     private val readJsonStrAnyFrame: ((text: String) -> AnyFrame)? by lazy {
         try {
             val klass = Class.forName("org.jetbrains.kotlinx.dataframe.io.JsonKt")
-            val typeClashTactic = Class.forName("org.jetbrains.kotlinx.dataframe.io.JSON\$TypeClashTactic")
+            val typeClashTactic = Class.forName($$"org.jetbrains.kotlinx.dataframe.io.JSON$TypeClashTactic")
             val readJsonStr = klass.getMethod(
                 "readJsonStr",
                 // this =

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/reorder.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/reorder.kt
@@ -71,7 +71,7 @@ internal fun <T, C, V : Comparable<V>> Reorder<T, C>.reorderImpl(
             df = if (parentPath.isEmpty()) {
                 newGroup.cast()
             } else {
-                df.replace(parentPath).with { newGroup.asColumnGroup(it.name()) }
+                df.replace { parentPath }.with { newGroup.asColumnGroup(it.name()) }
             }
         }
     return df

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -255,8 +255,8 @@ class ParseTests {
         testSuccess(90_500.milliseconds, "PT1M30.500S")
 
         // with sign
-        testSuccess(-1.days + 15.minutes, "-PT23H45M", "PT-23H-45M", "+PT-24H+15M")
-        testSuccess(-1.days - 15.minutes, "-PT24H15M", "PT-24H-15M", "-PT25H-45M")
+        testSuccess((-1).days + 15.minutes, "-PT23H45M", "PT-23H-45M", "+PT-24H+15M")
+        testSuccess((-1).days - 15.minutes, "-PT24H15M", "PT-24H-15M", "-PT25H-45M")
         testSuccess(Duration.ZERO, "PT0S", "P1DT-24H", "+PT-1H+60M", "-PT1M-60S")
 
         // infinite

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/sortGroupedDataframe.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/sortGroupedDataframe.kt
@@ -57,7 +57,7 @@ class SortGroupedDataframeTests {
         groupBy.keys[0].print()
 
         val df1 = groupBy.updateGroups {
-            val missingValues = State.values().asList().toDataFrame {
+            val missingValues = State.entries.toDataFrame {
                 "state" from { it }
             }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Analyze.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Analyze.kt
@@ -447,7 +447,7 @@ class Analyze : TestBase() {
 
     @Test
     @TransformDataFrameExpressions
-    fun columnsFor_aсcessors() {
+    fun columnsFor_accessors() {
         // SampleStart
         val name by columnGroup()
         val firstName by name.column<String>()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -552,7 +552,7 @@ class DataFrameTests : BaseTest() {
 
     @Test
     fun `drop nulls 1`() {
-        fun AnyFrame.check() = rows().forEach { get("weight") shouldNotBe null }
+        fun AnyFrame.check() = rows().forEach { it["weight"] shouldNotBe null }
 
         typed.dropNulls(typed.weight).check()
         typed.dropNulls { weight }.check()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/TypeProjectionTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/types/TypeProjectionTests.kt
@@ -8,40 +8,45 @@ import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.impl.columns.ColumnGroupWithParent
 import org.jetbrains.kotlinx.dataframe.impl.commonType
 import org.jetbrains.kotlinx.dataframe.impl.createTypeUsing
+import org.jetbrains.kotlinx.dataframe.types.TypeProjectionTests.TypeInferenceTest1.Test1A
+import org.jetbrains.kotlinx.dataframe.types.TypeProjectionTests.TypeInferenceTest1.Test1X
+import org.jetbrains.kotlinx.dataframe.types.TypeProjectionTests.TypeInferenceTest2.B
+import org.jetbrains.kotlinx.dataframe.types.TypeProjectionTests.TypeInferenceTest2.Test2A
+import org.jetbrains.kotlinx.dataframe.types.TypeProjectionTests.TypeInferenceTest2.Test2X
 import org.junit.Test
 import kotlin.reflect.typeOf
 
 class TypeProjectionTests {
     class TypeInferenceTest1 {
-        interface A<T>
+        interface Test1A<T>
 
-        interface X<T> : A<List<T>>
+        interface Test1X<T> : Test1A<List<T>>
+    }
 
-        @Test
-        fun test() {
-            X::class.createTypeUsing<A<List<Int>>>() shouldBe typeOf<X<Int>>()
-            A::class.createTypeUsing<X<Int>>() shouldBe typeOf<A<List<Int>>>()
-        }
+    @Test
+    fun test1() {
+        Test1X::class.createTypeUsing<Test1A<List<Int>>>() shouldBe typeOf<Test1X<Int>>()
+        Test1A::class.createTypeUsing<Test1X<Int>>() shouldBe typeOf<Test1A<List<Int>>>()
     }
 
     class TypeInferenceTest2 {
-        interface A<out T>
+        interface Test2A<out T>
 
-        interface B<T> : A<A<T>>
+        interface B<T> : Test2A<Test2A<T>>
 
-        interface C<T> : A<B<T>>
+        interface C<T> : Test2A<B<T>>
 
         interface D<T>
 
-        interface X<T : Number, V : Number> :
+        interface Test2X<T : Number, V : Number> :
             C<T>,
             D<V>
+    }
 
-        @Test
-        fun test() {
-            X::class.createTypeUsing<A<A<A<Int>>>>() shouldBe typeOf<X<Int, *>>()
-            A::class.createTypeUsing<X<Double, Int>?>() shouldBe typeOf<A<B<Double>>?>()
-        }
+    @Test
+    fun test2() {
+        Test2X::class.createTypeUsing<Test2A<Test2A<Test2A<Int>>>>() shouldBe typeOf<Test2X<Int, *>>()
+        Test2A::class.createTypeUsing<Test2X<Double, Int>?>() shouldBe typeOf<Test2A<B<Double>>?>()
     }
 
     @Test

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameJdbcSymbolProcessorTest.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameJdbcSymbolProcessorTest.kt
@@ -30,7 +30,7 @@ class DataFrameJdbcSymbolProcessorTest {
             import org.jetbrains.kotlinx.dataframe.* 
             """.trimIndent()
 
-        const val GENERATED_FILE = "HelloJdbc${'$'}Extensions.kt"
+        const val GENERATED_FILE = $$"HelloJdbc$Extensions.kt"
 
         @JvmStatic
         @BeforeClass

--- a/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
+++ b/plugins/symbol-processor/src/test/kotlin/org/jetbrains/dataframe/ksp/DataFrameSymbolProcessorTest.kt
@@ -26,7 +26,7 @@ class DataFrameSymbolProcessorTest {
             import org.jetbrains.kotlinx.dataframe.* 
             """.trimIndent()
 
-        const val GENERATED_FILE = "Hello${'$'}Extensions.kt"
+        const val GENERATED_FILE = $$"Hello$Extensions.kt"
     }
 
     @Before
@@ -1187,11 +1187,11 @@ class DataFrameSymbolProcessorTest {
                 it.forAtLeastOne { it shouldContain "Pet" }
                 it.forAtLeastOne { it shouldContain "Error" }
             }
-            result.inspectLines("org.example.Petstore.Pet\$Extensions.kt") {
+            result.inspectLines($$"org.example.Petstore.Pet$Extensions.kt") {
                 it.forAtLeastOne { it shouldContain "tag" }
                 it.forAtLeastOne { it shouldContain "id" }
             }
-            result.inspectLines("org.example.Petstore.Error\$Extensions.kt") {
+            result.inspectLines($$"org.example.Petstore.Error$Extensions.kt") {
                 it.forAtLeastOne { it shouldContain "message" }
                 it.forAtLeastOne { it shouldContain "code" }
             }
@@ -1307,11 +1307,11 @@ class DataFrameSymbolProcessorTest {
                 it.forAtLeastOne { it shouldContain "readJson" }
                 it.forAtLeastOne { it shouldContain "readJsonStr" }
             }
-            result.inspectLines("org.example.Petstore.Pet\$Extensions.kt") {
+            result.inspectLines($$"org.example.Petstore.Pet$Extensions.kt") {
                 it.forAtLeastOne { it shouldContain "tag" }
                 it.forAtLeastOne { it shouldContain "id" }
             }
-            result.inspectLines("org.example.Petstore.Error\$Extensions.kt") {
+            result.inspectLines($$"org.example.Petstore.Error$Extensions.kt") {
                 it.forAtLeastOne { it shouldContain "message" }
                 it.forAtLeastOne { it shouldContain "code" }
             }


### PR DESCRIPTION
I tried to run inspections on the whole project to migrate deprecated column access API in the implementation. 
Found that it's safe to replace ColumnAccessor overload when argument is either ColumnPath or actual ColumnAccessor. With FrameColumn or anything that contains actual data, migration path is not clear (see GroupByImpl for example)
Fixed some style issues / warning in the process.