### PR TITLE
Make AnyFrame.renderToString public

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3762,11 +3762,13 @@ public final class org/jetbrains/kotlinx/dataframe/api/PivotKt {
 
 public final class org/jetbrains/kotlinx/dataframe/api/PrintKt {
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)V
-	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZ)V
+	public static final synthetic fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZ)V
+	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataRow;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;)V
 	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZILjava/lang/Object;)V
+	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)V
 	public static final fun print-XIlnkTk (Ljava/lang/String;)V
 }
 
@@ -6276,6 +6278,11 @@ public final class org/jetbrains/kotlinx/dataframe/io/RendererDecimalFormat {
 public final class org/jetbrains/kotlinx/dataframe/io/RendererDecimalFormat$Companion {
 	public final fun fromPrecision-VVLz-gw (I)Ljava/lang/String;
 	public final fun of-VVLz-gw (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/io/StringKt {
+	public static final fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)Ljava/lang/String;
+	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/io/SupportedCodeGenerationFormat : org/jetbrains/kotlinx/dataframe/io/SupportedFormat {

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -27,7 +27,8 @@ public fun <T> DataFrame<T>.print(
     alignLeft: Boolean = false,
     columnTypes: Boolean = false,
     title: Boolean = false,
-): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title))
+    rowIndex: Boolean = true,
+): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex))
 
 // endregion
 

--- a/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/generated-sources/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -27,8 +27,7 @@ public fun <T> DataFrame<T>.print(
     alignLeft: Boolean = false,
     columnTypes: Boolean = false,
     title: Boolean = false,
-    rowIndex: Boolean = true,
-): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex))
+): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title))
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -21,7 +21,7 @@ public fun <T> DataRow<T>.print(): Unit = println(this)
 
 // region DataFrame
 
-@Deprecated(message=PRINT, level=DeprecationLevel.HIDDEN)
+@Deprecated(message = PRINT, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.print(
     rowsLimit: Int = 20,
     valueLimit: Int = 40,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.util.PRINT
 
 // region DataColumn
 
@@ -20,6 +21,7 @@ public fun <T> DataRow<T>.print(): Unit = println(this)
 
 // region DataFrame
 
+@Deprecated(message=PRINT, level=DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.print(
     rowsLimit: Int = 20,
     valueLimit: Int = 40,
@@ -27,7 +29,17 @@ public fun <T> DataFrame<T>.print(
     alignLeft: Boolean = false,
     columnTypes: Boolean = false,
     title: Boolean = false,
-): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title))
+): Unit = print(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, true)
+
+public fun <T> DataFrame<T>.print(
+    rowsLimit: Int = 20,
+    valueLimit: Int = 40,
+    borders: Boolean = false,
+    alignLeft: Boolean = false,
+    columnTypes: Boolean = false,
+    title: Boolean = false,
+    rowIndex: Boolean = true,
+): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex))
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.size
 import java.math.BigDecimal
 
-internal fun AnyFrame.renderToString(
+fun AnyFrame.renderToString(
     rowsLimit: Int = 20,
     valueLimit: Int = 40,
     borders: Boolean = false,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.size
 import java.math.BigDecimal
 
-fun AnyFrame.renderToString(
+public fun AnyFrame.renderToString(
     rowsLimit: Int = 20,
     valueLimit: Int = 40,
     borders: Boolean = false,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -44,6 +44,8 @@ internal const val PARSER_OPTIONS = "This constructor is only here for binary co
 
 internal const val PARSER_OPTIONS_COPY = "This function is only here for binary compatibility. $MESSAGE_1_0"
 
+internal const val PRINT = "This function is only here for binary compatibility. $MESSAGE_1_0"
+
 internal const val IS_COMPARABLE =
     "This function is replaced by `valuesAreComparable()` to better reflect its purpose. $MESSAGE_1_0"
 internal const val IS_COMPARABLE_REPLACE = "valuesAreComparable()"


### PR DESCRIPTION
Fixes request in #1129 

Two updates regarding the current DataFrame print flow -  
Setting AnyFrame.renderToString to public, allowing ability to call it externally.  
Updating DataFrame.print to include the rowIndex parameter, as it was the only parameter missing, being passed in to renderToString.