### PR TITLE
Remove annotations dependency from compiler-plugin-core

### DIFF
--- a/dataframe-compiler-plugin-core/build.gradle.kts
+++ b/dataframe-compiler-plugin-core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
         exclude(group = "com.squareup", module = "kotlinpoet-jvm")
         exclude(group = "ch.randelshofer", module = "fastdoubleparser")
         exclude(group = "io.github.oshai", module = "kotlin-logging-jvm")
+        exclude(group = "org.jetbrains", module = "annotations")
     }
 }
 
@@ -49,6 +50,7 @@ tasks.withType<ShadowJar> {
         exclude(dependency("com.squareup:kotlinpoet-jvm:.*"))
         exclude(dependency("ch.randelshofer:fastdoubleparser:.*"))
         exclude(dependency("io.github.oshai:kotlinlogging:.*"))
+        exclude(dependency("org.jetbrains:annotations:.*"))
     }
     exclude("org/jetbrains/kotlinx/dataframe/jupyter/**")
     exclude("org/jetbrains/kotlinx/dataframe/io/**")


### PR DESCRIPTION
We mistakenly bundle it, it causes problems here:
https://youtrack.jetbrains.com/issue/KTIJ-35307/Update-JetBrains-annotations-library-for-Kotlin-Plugin#focus=Comments-27-12562630.0-0