### PR TITLE
Add annotations to support types extending DataRow in the compiler plugin

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataRow.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/DataRow.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe
 
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.api.next
 import org.jetbrains.kotlinx.dataframe.api.prev
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
@@ -18,6 +19,7 @@ import kotlin.reflect.KProperty
  *
  * @param T Schema marker. See [DataFrame] for details
  */
+@HasSchema(schemaArg = 0)
 public interface DataRow<out T> {
 
     public fun index(): Int

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
@@ -2,6 +2,26 @@ package org.jetbrains.kotlinx.dataframe.annotations
 
 import kotlin.reflect.KClass
 
+/**
+ * Matches the type parameter of the annotated class to DataRow/DataFrame type parameter T.
+ *
+ * Annotate public API classes that implement DataRow/DataFrame interface to enable "extract schema/create column from values" operation:
+ * ```kotlin
+ * df.add {
+ *   "col" from { it }
+ * }
+ * ```
+ * Result before:
+ * `col: DataColumn<AddDataRow<MySchema>>`
+ *
+ * Result after:
+ *
+ * ```
+ * col:
+ *   col1: Int
+ *   col2: String
+ * ```
+ */
 @Target(AnnotationTarget.CLASS)
 public annotation class HasSchema(val schemaArg: Int)
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Selector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.api.add
@@ -99,6 +100,7 @@ public fun <T> DataFrame<T>.addAll(dataFrames: Iterable<AnyFrame>): DataFrame<T>
  * Receiver that is used by the [AddExpression] (for instance in the [add] and [update] operations)
  * to access new (added or updated) column value in preceding row.
  */
+@HasSchema(schemaArg = 0)
 public interface AddDataRow<out T> : DataRow<T> {
 
     /**


### PR DESCRIPTION
After recent DataRow => AddDataRow change, this test now works different from before:
```
df.add {
  "col" from { it }
}
```

PR will provide metadata for compiler plugin to fix this