### PR TITLE
Load dataframe-jupyter from core in notebooks

### DIFF
--- a/core/src/main/resources/META-INF/kotlin-jupyter-libraries/libraries.json
+++ b/core/src/main/resources/META-INF/kotlin-jupyter-libraries/libraries.json
@@ -1,0 +1,9 @@
+{
+  "descriptors": [
+    {
+      "init": [
+        "@Suppress(\"INVISIBLE_MEMBER\", \"INVISIBLE_REFERENCE\") USE { dependencies(\"org.jetbrains.kotlinx:dataframe-jupyter:${org.jetbrains.kotlinx.dataframe.BuildConfig.VERSION}\") }"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1140

Adds libraries.json which loads dataframe-jupyter from dataframe-core in notebooks. Requires https://github.com/Kotlin/kotlin-jupyter/pull/488.

TODO: Wait for the above PR to be merged and published. Adding this new argument will break existing kernels due to the `"descriptors"` argument being unknown.