### PR TITLE
Prepare utility to assert compile time column order

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -26,5 +26,9 @@ public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
 
 // endregion
 
-public inline fun <reified T> DataFrame<T>.compileTimeSchema(): DataFrameSchema =
-    compileTimeSchemaImpl(schema(), T::class)
+/**
+ * [ordered] - if true, columns are ordered the same as in runtime schema for easier diff between the two.
+ * if false, columns are ordered as they are represented in the compiler plugin
+ */
+public inline fun <reified T> DataFrame<T>.compileTimeSchema(ordered: Boolean = true): DataFrameSchema =
+    compileTimeSchemaImpl(if (ordered) schema() else null, T::class)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/schema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/schema.kt
@@ -8,8 +8,9 @@ import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import kotlin.reflect.KClass
 
 @PublishedApi
-internal fun compileTimeSchemaImpl(runtimeSchema: DataFrameSchema, klass: KClass<*>): DataFrameSchema {
+internal fun compileTimeSchemaImpl(runtimeSchema: DataFrameSchema?, klass: KClass<*>): DataFrameSchema {
     val compileSchema = getSchema(klass)
+    if (runtimeSchema == null) return compileSchema
     val root = ColumnPath(emptyList())
     val order = buildMap {
         putColumnsOrder(runtimeSchema, path = root)
@@ -41,8 +42,6 @@ internal fun DataFrameSchema.sortedBy(order: Map<ColumnPath, Int>, path: ColumnP
             is ColumnSchema.Group -> ColumnSchema.Group(column.schema.sortedBy(order, path + name), column.contentType)
 
             is ColumnSchema.Value -> column
-
-            else -> TODO("unexpected ColumnSchema class ${column::class}")
         }
     }.sortedBy { (name, _) ->
         order[path + name]


### PR DESCRIPTION
Without this flag actual column order in the schema is unavailable, so i cannot check if my implementation of sorting in compiler toDataFrame counterpart does anything useful