### PR TITLE
Update Gradle to 9.0

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6581,8 +6581,6 @@ public final class org/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords : j
 	public static final field EXTERNAL Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
 	public static final field FINAL Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
 	public static final field FUN Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
-	public static final field HEADER Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
-	public static final field IMPL Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
 	public static final field IN Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
 	public static final field INFIX Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
 	public static final field INLINE Lorg/jetbrains/kotlinx/dataframe/keywords/ModifierKeywords;
@@ -6636,8 +6634,6 @@ public final class org/jetbrains/kotlinx/dataframe/keywords/SoftKeywords : java/
 	public static final field FINAL Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
 	public static final field FINALLY Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
 	public static final field GET Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
-	public static final field HEADER Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
-	public static final field IMPL Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
 	public static final field IMPORT Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
 	public static final field INFIX Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;
 	public static final field INIT Lorg/jetbrains/kotlinx/dataframe/keywords/SoftKeywords;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,7 +5,6 @@ import nl.jolanrensen.kodex.gradle.creatingRunKodexTask
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import xyz.ronella.gradle.plugin.simple.git.task.GitTask
 
 plugins {
     with(libs.plugins) {
@@ -16,7 +15,6 @@ plugins {
 //        alias(kover)
         alias(ktlint)
         alias(kodex)
-        alias(simpleGit)
         alias(buildconfig)
         alias(binary.compatibility.validator)
 
@@ -152,12 +150,6 @@ val clearSamplesOutputs by tasks.registering {
     }
 }
 
-val addSamplesToGit by tasks.registering(GitTask::class, fun GitTask.() {
-    directory = file(".")
-    command = "add"
-    args = listOf("-A", "../docs/StardustDocs/resources/snippets")
-})
-
 val copySamplesOutputs = tasks.register<JavaExec>("copySamplesOutputs") {
     group = "documentation"
     mainClass = "org.jetbrains.kotlinx.dataframe.explainer.SampleAggregatorKt"
@@ -165,10 +157,6 @@ val copySamplesOutputs = tasks.register<JavaExec>("copySamplesOutputs") {
     dependsOn(clearSamplesOutputs)
     dependsOn(samplesTest)
     classpath = sourceSets.test.get().runtimeClasspath
-
-    doLast {
-        addSamplesToGit.get().executeCommand()
-    }
 }
 
 tasks.withType<KorroTask> {

--- a/examples/kotlin-dataframe-plugin-example/build.gradle.kts
+++ b/examples/kotlin-dataframe-plugin-example/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
-    kotlin("jvm") version "2.2.20-dev-3524"
-    kotlin("plugin.dataframe") version "2.2.20-dev-3524"
+    kotlin("jvm") version "2.2.20-Beta2"
+    kotlin("plugin.dataframe") version "2.2.20-Beta2"
 }
 
 group = "org.example"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-ksp = "2.2.0-2.0.2"
+ksp = "2.2.20-Beta2-2.0.2"
 kotlinJupyter = "0.15.0-587"
 
 ktlint = "12.3.0"
 
-# make sure to sync both manually with :generator module
-kotlin = "2.2.0" # needs jupyter compatibility with Kotlin 2.1 to update
+kotlin = "2.2.20-Beta2"
+# make sure to sync manually with :generator module
 kotlinpoet = "2.2.0"
 
 dokka = "2.0.0"
@@ -13,7 +13,7 @@ libsPublisher = "2.2.0-dev-61"
 
 # "Bootstrap" version of the dataframe, used in the build itself to generate @DataSchema APIs,
 # dogfood Gradle / KSP plugins in tests and idea-examples modules
-dataframe = "1.0.0-dev-6538"
+dataframe = "1.0.0-dev-8314"
 korro = "0.1.6"
 
 binaryCompatibilityValidator = "0.17.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SourceSetsExpectationsTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/SourceSetsExpectationsTest.kt
@@ -1,9 +1,7 @@
 package org.jetbrains.dataframe.gradle
 
-import io.kotest.assertions.asClue
 import io.kotest.inspectors.forAny
 import io.kotest.matchers.shouldBe
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.junit.Test
@@ -27,20 +25,6 @@ class SourceSetsExpectationsTest {
         project.plugins.apply("org.jetbrains.kotlin.multiplatform")
         project.extensions.getByType(KotlinMultiplatformExtension::class.java).let {
             it.sourceSets.findByName("jvmMain") shouldBe null
-        }
-    }
-
-    @Test
-    fun `there is main in android project`() {
-        val project = makeProject()
-        project.plugins.apply("com.android.application")
-        project.plugins.apply("org.jetbrains.kotlin.android")
-        project.extensions.getByType(KotlinAndroidProjectExtension::class.java).let { extension ->
-            val main = extension.sourceSets.getByName("main")
-            main.kotlin.sourceDirectories.toList().asClue { files ->
-                files.forAny { it.shouldEndWith("src", "main", "java") }
-                files.forAny { it.shouldEndWith("src", "main", "kotlin") }
-            }
         }
     }
 }

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/taskProperties/TaskDataSchemaPropertyTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/taskProperties/TaskDataSchemaPropertyTest.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.dataframe.gradle.taskProperties
 
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.shouldBe
 import org.gradle.api.ProjectConfigurationException
@@ -8,7 +7,6 @@ import org.jetbrains.dataframe.gradle.GenerateDataSchemaTask
 import org.jetbrains.dataframe.gradle.SchemaGeneratorExtension
 import org.jetbrains.dataframe.gradle.SchemaGeneratorPlugin
 import org.jetbrains.dataframe.gradle.makeProject
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.junit.Test
 
@@ -19,33 +17,6 @@ class TaskDataSchemaPropertyTest {
         project.plugins.apply(SchemaGeneratorPlugin::class.java)
         project.plugins.apply("org.jetbrains.kotlin.jvm")
         project.extensions.getByType(KotlinJvmProjectExtension::class.java).apply {
-            sourceSets.create("main1")
-        }
-        project.extensions.getByType(SchemaGeneratorExtension::class.java).apply {
-            sourceSet = "main1"
-            schema {
-                data = "123"
-                name = "org.example.my.321"
-            }
-        }
-        shouldNotThrow<ProjectConfigurationException> {
-            project.evaluate()
-        }
-        (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask)
-            .dataSchema.get()
-            .shouldBe(project.file("build/generated/dataframe/main1/kotlin/org/example/my/321.Generated.kt"))
-    }
-
-    @Test
-    fun `extension sourceSet present in android project`() {
-        val project = makeProject()
-        project.plugins.apply(SchemaGeneratorPlugin::class.java)
-        project.plugins.apply("com.android.application")
-        project.plugins.apply("org.jetbrains.kotlin.android")
-        (project.extensions.getByName("android") as BaseAppModuleExtension).let {
-            it.compileSdk = 30
-        }
-        project.extensions.getByType(KotlinAndroidProjectExtension::class.java).apply {
             sourceSets.create("main1")
         }
         project.extensions.getByType(SchemaGeneratorExtension::class.java).apply {

--- a/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/taskProperties/TaskPackageNamePropertyTest.kt
+++ b/plugins/dataframe-gradle-plugin/src/test/kotlin/org/jetbrains/dataframe/gradle/taskProperties/TaskPackageNamePropertyTest.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.dataframe.gradle.taskProperties
 
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.gradle.api.ProjectConfigurationException
@@ -101,27 +100,6 @@ class TaskPackageNamePropertyTest {
         val project = makeProject()
         project.plugins.apply(SchemaGeneratorPlugin::class.java)
         project.plugins.apply("org.jetbrains.kotlin.jvm")
-        File(project.projectDir, "/src/main/kotlin/org/test/").also { it.mkdirs() }
-        project.extensions.getByType(SchemaGeneratorExtension::class.java).apply {
-            schema {
-                data = "123"
-                name = "321"
-            }
-        }
-        project.evaluate()
-        (project.tasks.getByName("generateDataFrame321") as GenerateDataSchemaTask)
-            .packageName.get() shouldBe "org.test.dataframe"
-    }
-
-    @Test
-    fun `task infers packageName from directory structure on android`() {
-        val project = makeProject()
-        project.plugins.apply(SchemaGeneratorPlugin::class.java)
-        project.plugins.apply("com.android.application")
-        project.plugins.apply("org.jetbrains.kotlin.android")
-        (project.extensions.getByName("android") as BaseAppModuleExtension).let {
-            it.compileSdk = 30
-        }
         File(project.projectDir, "/src/main/kotlin/org/test/").also { it.mkdirs() }
         project.extensions.getByType(SchemaGeneratorExtension::class.java).apply {
             schema {

--- a/plugins/kotlin-dataframe/README.md
+++ b/plugins/kotlin-dataframe/README.md
@@ -1,10 +1,4 @@
 ## :plugins:kotlin-dataframe
 
-This module, published as "compiler-plugin-all", holds the Kotlin 2.x Compiler plugin of DataFrame.
-
-A [work-in-progress](https://github.com/Kotlin/dataframe/issues/704)
-plugin for your Kotlin project that can generate on-the-fly column accessors for the compiler and IDE even without
-having to provide data schemas!
-
-Details of how to use this compiler plugin for your own project will follow, but there is a
-[demo project](https://github.com/koperagen/df-plugin-demo) you can try already.
+Development of this module was moved to the Kotlin repository:
+https://github.com/JetBrains/kotlin/tree/master/plugins/kotlin-dataframe

--- a/plugins/kotlin-dataframe/build.gradle.kts
+++ b/plugins/kotlin-dataframe/build.gradle.kts
@@ -4,8 +4,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 plugins {
     id("java")
     kotlin("jvm")
-    kotlin("libs.publisher")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
     kotlin("plugin.serialization")
 }
 
@@ -110,16 +108,6 @@ fun Test.setLibraryProperty(propName: String, jarName: String) {
         ?.absolutePath
         ?: return
     systemProperty(propName, path)
-}
-
-kotlinPublications {
-    fairDokkaJars = false
-    publication {
-        publicationName = "api"
-        artifactId = "compiler-plugin-all"
-        description = "Data processing in Kotlin"
-        packageName = artifactId
-    }
 }
 
 // Disabling all tests before removing the compiler plugin here


### PR DESCRIPTION
Our old Gradle plugin requires Kotlin 2.2.0 in Gradle runtime to work, because ParseKt refers to the new kotlin.time.Instant class and for 8.14.2 + 1.0.0-dev-8342 generate schema task fails ClassNotFound exception. (this problem itself bothers me a little, but ok)

Removing SimpleGit because it's for now incompatible with 9.0