### PR TITLE
include JsonFacadeForDebugger in compilation

### DIFF
--- a/dataframe-json/build.gradle.kts
+++ b/dataframe-json/build.gradle.kts
@@ -53,6 +53,12 @@ tasks.test {
     useJUnitPlatform()
 }
 
+sourceSets {
+    main {
+        java.srcDirs("src/main/kotlin")
+    }
+}
+
 val instrumentedJars: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false


### PR DESCRIPTION
it wasn't in the jar because java didn't see the file in Kotlin source set; i changed java to point in the same directory because separate source sets for different languages is an outdated and bad practice :) 
<img width="2040" height="732" alt="image" src="https://github.com/user-attachments/assets/70d94190-a729-4899-ad3e-6f19734af279" />
