### PR TITLE
Improve rendering of ColumnGroup

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/KotlinNotebookPluginUtils.kt
@@ -236,13 +236,13 @@ public object KotlinNotebookPluginUtils {
 
             is FormattedFrame<*> -> dataframeLike.df
 
-            is AnyCol -> dataFrameOf(dataframeLike)
+            is AnyFrame -> dataframeLike
 
             is AnyRow -> dataframeLike.toDataFrame()
 
             is GroupBy<*, *> -> dataframeLike.toDataFrame()
 
-            is AnyFrame -> dataframeLike
+            is AnyCol -> dataFrameOf(dataframeLike)
 
             is DisableRowsLimitWrapper -> dataframeLike.value
 


### PR DESCRIPTION
Fixes #1245

Swapping `is AnyCol` with `is AnyFrame` allows to avoid applying `dataFrameOf()` to a `ColumnGroup` object when `convertToDataFrame()` in `KotlinNotebookPluginUtils` is called. 

In that case, a separate `ColumnGroup` object is rendered without the group,
![Rendering of a column group](https://github.com/user-attachments/assets/5700652e-d7b8-42a1-aa28-34d3eee24cfc)
which might look a bit unusual, but the reason to implement it is to ensure more intuitive access to the columns (because we can only access columns `a` and `b` and not `letters` from the code; with the existing approach we would see the group `letters`, but would not be able to access it).

Cast `asDataFrame` will leave it without the group being rendered:
![Rendering of a column group with cast to dataframe](https://github.com/user-attachments/assets/dac3d9ee-7410-4e1a-a237-b4031ce36c2d)

At the same time, if we convert this `ColumnGroup` object to a dataframe (with the function `public fun AnyBaseCol.toDataFrame(): AnyFrame = dataFrameOf(listOf(this))`, which is already present in the library), the group is rendered in the dataframe:
![Rendering of a dataframe with a column group](https://github.com/user-attachments/assets/7acc55c6-960c-453a-874b-d8282d8edb24)

This seems to be a correct result because in all cases rendering of the columns conforms to the way we access columns from the code (so the structure of data is reflected correctly), and column groups inside a dataframe are actually shown as groups, which prevents the user from being misled.

![Rendering of two dataframes combined](https://github.com/user-attachments/assets/b9c3f286-750e-40b8-b215-4542f3da3c26)