### PR TITLE
`.toDataFrame` fixes

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5904,8 +5904,8 @@ public final class org/jetbrains/kotlinx/dataframe/impl/api/SchemaKt {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/ToDataFrameKt {
-	public static final fun convertToDataFrame (Ljava/lang/Iterable;Lkotlin/reflect/KClass;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;I)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
-	public static final fun createDataFrameImpl (Ljava/lang/Iterable;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun convertToDataFrame (Ljava/lang/Iterable;Lkotlin/reflect/KType;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;I)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun createDataFrameImpl (Ljava/lang/Iterable;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun getCanBeUnfolded (Lkotlin/reflect/KClass;)Z
 	public static final fun getHasProperties (Lkotlin/reflect/KClass;)Z
 	public static final fun isValueType (Lkotlin/reflect/KClass;)Z
@@ -5916,7 +5916,7 @@ public final class org/jetbrains/kotlinx/dataframe/impl/api/ToSequenceKt {
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/UnfoldKt {
-	public static final fun unfoldImpl (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public static final fun unfoldImpl (Lorg/jetbrains/kotlinx/dataframe/DataColumn;Lkotlin/reflect/KType;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/impl/api/UpdateKt {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
-import org.jetbrains.kotlinx.dataframe.impl.api.canBeUnfolded
 import org.jetbrains.kotlinx.dataframe.impl.api.createDataFrameImpl
 import org.jetbrains.kotlinx.dataframe.impl.asList
 import org.jetbrains.kotlinx.dataframe.impl.columnName
@@ -21,6 +20,7 @@ import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.typeOf
 
 // region read DataFrame from objects
 
@@ -28,21 +28,13 @@ import kotlin.reflect.KProperty
 @Interpretable("toDataFrameDefault")
 public inline fun <reified T> Iterable<T>.toDataFrame(): DataFrame<T> =
     toDataFrame {
-        // check if type is value: primitives, primitive arrays, datetime types etc.,
-        // or has no properties
-        if (!T::class.canBeUnfolded) {
-            // create a single `value` column
-            ValueProperty<T>::value.name from { it }
-        } else {
-            // otherwise creates columns based on properties
-            properties()
-        }
+        properties()
     }
 
 @Refine
 @Interpretable("toDataFrameDsl")
 public inline fun <reified T> Iterable<T>.toDataFrame(noinline body: CreateDataFrameDsl<T>.() -> Unit): DataFrame<T> =
-    createDataFrameImpl(T::class, body)
+    createDataFrameImpl(typeOf<T>(), body)
 
 @Refine
 @Interpretable("toDataFrame")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
@@ -13,9 +13,10 @@ import org.jetbrains.kotlinx.dataframe.impl.api.unfoldImpl
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
 import kotlin.reflect.KCallable
 import kotlin.reflect.KProperty
+import kotlin.reflect.typeOf
 
 public inline fun <reified T> DataColumn<T>.unfold(vararg roots: KCallable<*>, maxDepth: Int = 0): AnyCol =
-    unfoldImpl { properties(roots = roots, maxDepth) }
+    unfoldImpl(typeOf<T>()) { properties(roots = roots, maxDepth) }
 
 @Refine
 @Interpretable("DataFrameUnfold")
@@ -23,7 +24,7 @@ public fun <T> DataFrame<T>.unfold(
     vararg roots: KCallable<*>,
     maxDepth: Int = 0,
     columns: ColumnsSelector<T, *>,
-): DataFrame<T> = replace(columns).with { it.unfoldImpl { properties(roots = roots, maxDepth) } }
+): DataFrame<T> = replace(columns).with { it.unfoldImpl(it.type()) { properties(roots = roots, maxDepth) } }
 
 public fun <T> DataFrame<T>.unfold(vararg columns: String): DataFrame<T> = unfold { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -34,6 +34,7 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
@@ -201,6 +202,16 @@ internal fun <T> Iterable<T>.createDataFrameImpl(
     body: CreateDataFrameDslImpl<T>.() -> Unit,
 ): DataFrame<T> {
     val builder = CreateDataFrameDslImpl(this, type)
+    builder.body()
+    return builder.columns.toDataFrameFromPairs()
+}
+
+@Deprecated("backward compatibility for Kandy", level = DeprecationLevel.ERROR)
+internal fun <T> Iterable<T>.createDataFrameImpl(
+    clazz: KClass<*>,
+    body: CreateDataFrameDslImpl<T>.() -> Unit,
+): DataFrame<T> {
+    val builder = CreateDataFrameDslImpl(this, clazz.starProjectedType)
     builder.body()
     return builder.columns.toDataFrameFromPairs()
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -28,6 +28,7 @@ import java.time.temporal.TemporalAmount
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.memberFunctions
@@ -98,13 +99,11 @@ internal val KClass<*>.isValueType: Boolean
  */
 @PublishedApi
 internal val KClass<*>.hasProperties: Boolean
-    get() = this.memberProperties.any { it.visibility == KVisibility.PUBLIC } ||
-        // check pojo-like classes
-        this.memberFunctions.any { it.visibility == KVisibility.PUBLIC && it.isGetterLike() }
+    get() = properties().isNotEmpty()
 
 internal class CreateDataFrameDslImpl<T>(
     override val source: Iterable<T>,
-    private val clazz: KClass<*>,
+    private val type: KType,
     private val prefix: ColumnPath = emptyPath(),
     private val configuration: TraverseConfiguration = TraverseConfiguration(),
 ) : CreateDataFrameDsl<T>(),
@@ -119,7 +118,7 @@ internal class CreateDataFrameDslImpl<T>(
     }
 
     override operator fun String.invoke(builder: CreateDataFrameDsl<T>.() -> Unit) {
-        val child = CreateDataFrameDslImpl(source, clazz, prefix + this)
+        val child = CreateDataFrameDslImpl(source, type, prefix + this)
         builder(child)
         columns.addAll(child.columns)
     }
@@ -182,7 +181,7 @@ internal class CreateDataFrameDslImpl<T>(
         }
         val df = convertToDataFrame(
             data = source,
-            clazz = clazz,
+            type = type,
             roots = roots.toList(),
             excludes = dsl.excludeProperties,
             preserveClasses = dsl.preserveClasses,
@@ -197,10 +196,10 @@ internal class CreateDataFrameDslImpl<T>(
 
 @PublishedApi
 internal fun <T> Iterable<T>.createDataFrameImpl(
-    clazz: KClass<*>,
+    type: KType,
     body: CreateDataFrameDslImpl<T>.() -> Unit,
 ): DataFrame<T> {
-    val builder = CreateDataFrameDslImpl(this, clazz)
+    val builder = CreateDataFrameDslImpl(this, type)
     builder.body()
     return builder.columns.toDataFrameFromPairs()
 }
@@ -208,22 +207,23 @@ internal fun <T> Iterable<T>.createDataFrameImpl(
 @PublishedApi
 internal fun convertToDataFrame(
     data: Iterable<*>,
-    clazz: KClass<*>,
+    type: KType,
     roots: List<KCallable<*>>,
     excludes: Set<KCallable<*>>,
     preserveClasses: Set<KClass<*>>,
     preserveProperties: Set<KCallable<*>>,
     maxDepth: Int,
 ): AnyFrame {
+    val clazz = type.classifierOrAny()
+    // this check relies on later recursive calls having roots = emptyList()
+    if (roots.isEmpty() && !clazz.canBeUnfolded) {
+        val column = DataColumn.createByType("value", data.toList(), type)
+        return dataFrameOf(column)
+    }
+
     val properties: List<KCallable<*>> = roots
         .ifEmpty {
-            clazz.memberProperties
-                .filter { it.visibility == KVisibility.PUBLIC }
-        }
-        // fall back to getter functions for pojo-like classes if no member properties were found
-        .ifEmpty {
-            clazz.memberFunctions
-                .filter { it.visibility == KVisibility.PUBLIC && it.isGetterLike() }
+            clazz.properties()
         }
         // sort properties by order in constructor
         .sortWithConstructor(clazz)
@@ -302,10 +302,11 @@ internal fun convertToDataFrame(
         val keepSubtree =
             maxDepth <= 0 && !fieldKind.shouldBeConvertedToFrameColumn && !fieldKind.shouldBeConvertedToColumnGroup
         val shouldCreateValueCol = keepSubtree ||
-            kClass == Any::class ||
             kClass in preserveClasses ||
             property in preserveProperties ||
-            kClass.isValueType
+            !kClass.canBeUnfolded &&
+            !fieldKind.shouldBeConvertedToFrameColumn &&
+            !fieldKind.shouldBeConvertedToColumnGroup
 
         val shouldCreateFrameCol = kClass == DataFrame::class && !nullable
         val shouldCreateColumnGroup = kClass == DataRow::class
@@ -368,7 +369,7 @@ internal fun convertToDataFrame(
                                         require(it is Iterable<*>)
                                         convertToDataFrame(
                                             data = it,
-                                            clazz = elementClass,
+                                            type = elementType,
                                             roots = emptyList(),
                                             excludes = excludes,
                                             preserveClasses = preserveClasses,
@@ -386,7 +387,7 @@ internal fun convertToDataFrame(
             else -> {
                 val df = convertToDataFrame(
                     data = values,
-                    clazz = kClass,
+                    type = returnType,
                     roots = emptyList(),
                     excludes = excludes,
                     preserveClasses = preserveClasses,
@@ -402,4 +403,16 @@ internal fun convertToDataFrame(
     } else {
         dataFrameOf(columns)
     }
+}
+
+private fun KType.classifierOrAny(): KClass<*> = classifier as? KClass<*> ?: Any::class
+
+private fun KClass<*>.properties(): List<KCallable<*>> {
+    // fall back to getter functions for pojo-like classes if no member properties were found
+    return memberProperties
+        .filter { it.visibility == KVisibility.PUBLIC }
+        .ifEmpty {
+            memberFunctions
+                .filter { it.visibility == KVisibility.PUBLIC && it.isGetterLike() }
+        }
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/unfold.kt
@@ -7,9 +7,10 @@ import org.jetbrains.kotlinx.dataframe.api.asColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.asDataColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.typeClass
+import kotlin.reflect.KType
 
 @PublishedApi
-internal fun <T> DataColumn<T>.unfoldImpl(body: CreateDataFrameDsl<T>.() -> Unit): AnyCol =
+internal fun <T> DataColumn<T>.unfoldImpl(type: KType, body: CreateDataFrameDsl<T>.() -> Unit): AnyCol =
     when (kind()) {
         ColumnKind.Group, ColumnKind.Frame -> this
 
@@ -17,7 +18,7 @@ internal fun <T> DataColumn<T>.unfoldImpl(body: CreateDataFrameDsl<T>.() -> Unit
             !typeClass.canBeUnfolded -> this
 
             else -> values()
-                .createDataFrameImpl(typeClass) { (this as CreateDataFrameDsl<T>).body() }
+                .createDataFrameImpl(type) { (this as CreateDataFrameDsl<T>).body() }
                 .asColumnGroup(name())
                 .asDataColumn()
         }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -157,7 +157,9 @@ class CreateDataFrameTests {
 
         val df2 = data.toDataFrame {
             preserve(B::row)
-            properties { preserve(DataFrame::class) }
+            properties {
+                preserve(DataFrame::class)
+            }
         }
         df2.frame.kind shouldBe ColumnKind.Value
         df2.frame.type shouldBe typeOf<DataFrame<A>>()
@@ -184,6 +186,24 @@ class CreateDataFrameTests {
         }
 
         res.schema() shouldBe data.toDataFrame(maxDepth = 0).schema()
+    }
+
+    class NestedExcludeClasses(val s: String, val list1: List<String>)
+
+    class ExcludeClasses(val i: Int, val list: List<Int>, val nested: NestedExcludeClasses)
+
+    @Test
+    fun `exclude classes`() {
+        val list = listOf(
+            ExcludeClasses(1, listOf(1, 2, 3), NestedExcludeClasses("str", listOf("foo", "bar"))),
+        )
+        val df = list.toDataFrame {
+            properties(maxDepth = 2) {
+                exclude(List::class)
+            }
+        }
+
+        df shouldBe list.toDataFrame(maxDepth = 2).remove { "list" and "nested"["list1"] }
     }
 
     enum class DummyEnum { A }


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1465
Btw i think strict `ktlint_standard_function-expression-body` rule is unnecessary, functions with return and with expression body can be a preference and coexist. At least for me this rule ALWAYS fails and forces me to rewrite
