### PR TITLE
Tiny quantile-fix

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
@@ -30,8 +30,10 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KProperty
 
 /* TODO KDocs
- * numbers -> Double or null
+ * primitive numbers -> Double or null
  * comparable -> itself or null
+ *
+ * Careful! non-primitive numbers will thus follow comparable rules
  *
  * TODO cases where the lambda dictates the return type require explicit type arguments for
  *  non-number, comparable overloads: https://youtrack.jetbrains.com/issue/KT-76683

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -30,8 +30,10 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KProperty
 
 /* TODO KDocs
- * numbers -> Double or null
+ * primitive numbers -> Double or null
  * comparable -> itself or null
+ *
+ * Careful! non-primitive numbers will thus follow comparable rules
  *
  * TODO cases where the lambda dictates the return type require explicit type arguments for
  *  non-number, comparable overloads: https://youtrack.jetbrains.com/issue/KT-76683

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/median.kt
@@ -7,8 +7,6 @@ import org.jetbrains.kotlinx.dataframe.impl.isIntraComparable
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.impl.renderType
-import java.math.BigDecimal
-import java.math.BigInteger
 import kotlin.math.round
 import kotlin.reflect.KType
 import kotlin.reflect.full.withNullability
@@ -38,11 +36,6 @@ internal fun <T : Comparable<T>> Sequence<T>.medianOrNull(type: KType, skipNaN: 
                 "Unable to compute the median for ${
                     renderType(type)
                 }. Only primitive numbers or self-comparables are supported.",
-            )
-
-        type == typeOf<BigDecimal>() || type == typeOf<BigInteger>() ->
-            throw IllegalArgumentException(
-                "Cannot calculate the median for big numbers in DataFrame. Only primitive numbers are supported.",
             )
 
         // TODO kdocs: note about loss of precision for Long
@@ -106,11 +99,6 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfMedian(type: KType, s
                 "Unable to compute the median for ${
                     renderType(type)
                 }. Only primitive numbers or self-comparables are supported.",
-            )
-
-        nonNullType == typeOf<BigDecimal>() || nonNullType == typeOf<BigInteger>() ->
-            throw IllegalArgumentException(
-                "Cannot calculate the median for big numbers in DataFrame. Only primitive numbers are supported.",
             )
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/percentile.kt
@@ -6,8 +6,6 @@ import org.jetbrains.kotlinx.dataframe.impl.isIntraComparable
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.impl.renderType
-import java.math.BigDecimal
-import java.math.BigInteger
 import kotlin.math.round
 import kotlin.reflect.KType
 import kotlin.reflect.full.withNullability
@@ -31,11 +29,6 @@ internal fun <T : Comparable<T>> Sequence<T>.percentileOrNull(percentile: Double
                 "Unable to compute the percentile for ${
                     renderType(type)
                 }. Only primitive numbers or self-comparables are supported.",
-            )
-
-        type == typeOf<BigDecimal>() || type == typeOf<BigInteger>() ->
-            throw IllegalArgumentException(
-                "Cannot calculate the percentile for big numbers in DataFrame. Only primitive numbers are supported.",
             )
 
         // TODO kdocs: note about loss of precision for Long
@@ -98,11 +91,6 @@ internal fun <T : Comparable<T & Any>?> Sequence<T>.indexOfPercentile(
                 "Unable to compute the percentile for ${
                     renderType(type)
                 }. Only primitive numbers or self-comparables are supported.",
-            )
-
-        nonNullType == typeOf<BigDecimal>() || nonNullType == typeOf<BigInteger>() ->
-            throw IllegalArgumentException(
-                "Cannot calculate the percentile for big numbers in DataFrame. Only primitive numbers are supported.",
             )
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/math/quantile.kt
@@ -6,8 +6,6 @@ import org.jetbrains.kotlinx.dataframe.impl.isIntraComparable
 import org.jetbrains.kotlinx.dataframe.impl.isPrimitiveNumber
 import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import org.jetbrains.kotlinx.dataframe.impl.renderType
-import java.math.BigDecimal
-import java.math.BigInteger
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.round
@@ -51,11 +49,6 @@ internal fun <T : Comparable<T>> Sequence<Any>.quantileOrNull(
                 "Unable to compute the $name for ${
                     renderType(type)
                 }. Only primitive numbers or self-comparables are supported.",
-            )
-
-        type == typeOf<BigDecimal>() || type == typeOf<BigInteger>() ->
-            throw IllegalArgumentException(
-                "Cannot calculate the $name for big numbers in DataFrame. Only primitive numbers are supported.",
             )
     }
 

--- a/docs/StardustDocs/topics/median.md
+++ b/docs/StardustDocs/topics/median.md
@@ -20,6 +20,8 @@ The operation is also available for self-comparable columns
 (so columns of type `T : Comparable<T>`, like `DateTime`, `String`, etc.)
 In this case, the return type remains `T?`.
 When the number of values is even, the median is the low of the two middle values.
+NOTE: This logic also applies to other self-comparable `Number` types, like `BigDecimal`.
+They will not be interpolated.
 
 All operations on `Double`/`Float` have the `skipNaN` option, which is
 set to `false` by default. This means that if a `NaN` is present in the input, it will be propagated to the result.

--- a/docs/StardustDocs/topics/percentile.md
+++ b/docs/StardustDocs/topics/percentile.md
@@ -25,6 +25,8 @@ The operation is also available for self-comparable columns
 In this case, the return type remains `T?`.
 The index of the result of the operation on these types is rounded using
 [Quantile Estimation Method](#quantile-estimation-methods) R3.
+NOTE: This logic also applies to other self-comparable `Number` types, like `BigDecimal`.
+They will not be interpolated.
 
 All operations on `Double`/`Float` have the `skipNaN` option, which is
 set to `false` by default. This means that if a `NaN` is present in the input, it will be propagated to the result.


### PR DESCRIPTION
removed big number error from quantile functions.
Expanded docs to clarify non-primitive numbers follow comparables.

This caused runtime exceptions when calling `dfWithBigNumber.median()`/`.percentile()` as all self-comparable columns were included, like `BigDecimal`, but they would trigger the exception.

This fix is needed for the compiler plugin as well