### PR TITLE
`GroupBy` statistics compiler plugin prep

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
@@ -235,7 +235,7 @@ public fun <T, C : Comparable<*>?> Grouped<T>.maxFor(
 ): DataFrame<T> = maxFor(skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByMax0")
+@Interpretable("GroupByMax2")
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.max(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,
@@ -598,13 +598,9 @@ public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.maxByOrNull
 public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.maxByOrNull(column: KProperty<C>): DataRow<T>? =
     maxByOrNull(column, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMax1")
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> Grouped<T>.max(): DataFrame<T> = max(skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMax0")
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Comparable<*>?> Grouped<T>.maxFor(columns: ColumnsForAggregateSelector<T, C>): DataFrame<T> =
     maxFor(skipNaN = skipNaNDefault, columns = columns)
@@ -623,8 +619,6 @@ public fun <T, C : Comparable<*>?> Grouped<T>.maxFor(vararg columns: ColumnRefer
 public fun <T, C : Comparable<*>?> Grouped<T>.maxFor(vararg columns: KProperty<C>): DataFrame<T> =
     maxFor(columns = columns, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMax0")
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.max(
     name: String? = null,
@@ -649,15 +643,12 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.max(
     name: String? = null,
 ): DataFrame<T> = max(columns = columns, name = name, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMaxOf")
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, reified C : Comparable<C & Any>?> Grouped<T>.maxOf(
     name: String? = null,
     crossinline expression: RowExpression<T, C>,
 ): DataFrame<T> = maxOf(name, skipNaN = skipNaNDefault, expression = expression)
 
-@Interpretable("GroupByReduceExpression")
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, G, reified R : Comparable<R & Any>?> GroupBy<T, G>.maxBy(
     crossinline rowExpression: RowExpression<G, R>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
@@ -150,7 +150,7 @@ public fun <T, C : Number?> Grouped<T>.meanFor(
 ): DataFrame<T> = meanFor(skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByMean0")
+@Interpretable("GroupByMean2")
 public fun <T, C : Number?> Grouped<T>.mean(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,
@@ -353,13 +353,9 @@ public fun <T, C : Number?> DataFrame<T>.mean(vararg columns: KProperty<C>): Dou
 public inline fun <T, reified D : Number?> DataFrame<T>.meanOf(crossinline expression: RowExpression<T, D>): Double =
     meanOf(skipNaN = skipNaNDefault, expression = expression)
 
-@Refine
-@Interpretable("GroupByMean1")
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> Grouped<T>.mean(): DataFrame<T> = mean(skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMean0")
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Number?> Grouped<T>.meanFor(columns: ColumnsForAggregateSelector<T, C>): DataFrame<T> =
     meanFor(skipNaN = skipNaNDefault, columns = columns)
@@ -378,8 +374,6 @@ public fun <T, C : Number?> Grouped<T>.meanFor(vararg columns: ColumnReference<C
 public fun <T, C : Number?> Grouped<T>.meanFor(vararg columns: KProperty<C>): DataFrame<T> =
     meanFor(columns = columns, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMean0")
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Number?> Grouped<T>.mean(name: String? = null, columns: ColumnsSelector<T, C>): DataFrame<T> =
     mean(name, skipNaN = skipNaNDefault, columns = columns)
@@ -398,8 +392,6 @@ public fun <T, C : Number?> Grouped<T>.mean(vararg columns: ColumnReference<C>, 
 public fun <T, C : Number?> Grouped<T>.mean(vararg columns: KProperty<C>, name: String? = null): DataFrame<T> =
     mean(columns = columns, name = name, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMeanOf")
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, reified R : Number?> Grouped<T>.meanOf(
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
@@ -353,7 +353,7 @@ public fun <T, C : Comparable<*>?> Grouped<T>.medianFor(
 ): DataFrame<T> = medianFor(skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByMedian0")
+@Interpretable("GroupByMedian2")
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.median(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
@@ -235,7 +235,7 @@ public fun <T, C : Comparable<*>?> Grouped<T>.minFor(
 ): DataFrame<T> = minFor(skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByMin0")
+@Interpretable("GroupByMin2")
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.min(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,
@@ -598,13 +598,9 @@ public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.minByOrNull
 public inline fun <T, reified C : Comparable<C & Any>?> DataFrame<T>.minByOrNull(column: KProperty<C>): DataRow<T>? =
     minByOrNull(column, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMin1")
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> Grouped<T>.min(): DataFrame<T> = min(skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMin0")
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Comparable<*>?> Grouped<T>.minFor(columns: ColumnsForAggregateSelector<T, C>): DataFrame<T> =
     minFor(skipNaN = skipNaNDefault, columns = columns)
@@ -623,8 +619,6 @@ public fun <T, C : Comparable<*>?> Grouped<T>.minFor(vararg columns: ColumnRefer
 public fun <T, C : Comparable<*>?> Grouped<T>.minFor(vararg columns: KProperty<C>): DataFrame<T> =
     minFor(columns = columns, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMin0")
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.min(
     name: String? = null,
@@ -649,15 +643,12 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.min(
     name: String? = null,
 ): DataFrame<T> = min(columns = columns, name = name, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupByMinOf")
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, reified C : Comparable<C & Any>?> Grouped<T>.minOf(
     name: String? = null,
     crossinline expression: RowExpression<T, C>,
 ): DataFrame<T> = minOf(name, skipNaN = skipNaNDefault, expression = expression)
 
-@Interpretable("GroupByReduceExpression")
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, G, reified R : Comparable<R & Any>?> GroupBy<T, G>.minBy(
     crossinline rowExpression: RowExpression<G, R>,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -421,7 +421,7 @@ public fun <T, C : Comparable<*>?> Grouped<T>.percentileFor(
 ): DataFrame<T> = percentileFor(percentile, skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByPercentile0")
+@Interpretable("GroupByPercentile2")
 public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentile(
     percentile: Double,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
@@ -160,7 +160,7 @@ public fun <T, C : Number?> Grouped<T>.stdFor(
 ): DataFrame<T> = stdFor(skipNaN, ddof) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupByStd0")
+@Interpretable("GroupByStd2")
 public fun <T, C : Number?> Grouped<T>.std(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -263,7 +263,7 @@ public fun <T, C : Number?> Grouped<T>.sumFor(
 ): DataFrame<T> = sumFor(skipNaN) { columns.toColumnSet() }
 
 @Refine
-@Interpretable("GroupBySum0")
+@Interpretable("GroupBySum2")
 public fun <T, C : Number?> Grouped<T>.sum(
     name: String? = null,
     skipNaN: Boolean = skipNaNDefault,
@@ -500,13 +500,9 @@ public inline fun <T, reified C : Number?> DataFrame<T>.sum(vararg columns: KPro
 public inline fun <T, reified C : Number?> DataFrame<T>.sumOf(crossinline expression: RowExpression<T, C>): C & Any =
     sumOf(skipNaN = skipNaNDefault, expression = expression)
 
-@Refine
-@Interpretable("GroupBySum1")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> Grouped<T>.sum(): DataFrame<T> = sum(skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupBySum0")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Number?> Grouped<T>.sumFor(columns: ColumnsForAggregateSelector<T, C>): DataFrame<T> =
     sumFor(skipNaN = skipNaNDefault, columns = columns)
@@ -525,8 +521,6 @@ public fun <T, C : Number?> Grouped<T>.sumFor(vararg columns: ColumnReference<C>
 public fun <T, C : Number?> Grouped<T>.sumFor(vararg columns: KProperty<C>): DataFrame<T> =
     sumFor(columns = columns, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupBySum0")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T, C : Number?> Grouped<T>.sum(name: String? = null, columns: ColumnsSelector<T, C>): DataFrame<T> =
     sum(name, skipNaN = skipNaNDefault, columns = columns)
@@ -545,8 +539,6 @@ public fun <T, C : Number?> Grouped<T>.sum(vararg columns: ColumnReference<C>, n
 public fun <T, C : Number?> Grouped<T>.sum(vararg columns: KProperty<C>, name: String? = null): DataFrame<T> =
     sum(columns = columns, name = name, skipNaN = skipNaNDefault)
 
-@Refine
-@Interpretable("GroupBySumOf")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public inline fun <T, reified R : Number?> Grouped<T>.sumOf(
     resultName: String? = null,


### PR DESCRIPTION
changed `x {}` statistics interpreter name to not reuse `xFor {}`'s anymore. 

Deleted CP annotations from HIDDEN deprecated functions

needed for https://github.com/Kotlin/dataframe/issues/1090