### PR TITLE
Add config for https://context7.com/kotlin/dataframe

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "excludeFolders": [
+    "docs/StardustDocs/resources/snippets/*.html",
+    "**/*.fix.txt"
+  ]
+}


### PR DESCRIPTION
A lot of snippets parsed by context7 are from HTML files and some from *.fir.txt - both are misleading and overall useless. Let's exclude these files as a starting point

https://github.com/upstash/context7/blob/master/docs/adding-projects.md