### PR TITLE
Document increasing the heap size for Kotlin Notebook

### DIFF
--- a/docs/StardustDocs/topics/setup/SetupKotlinNotebook.md
+++ b/docs/StardustDocs/topics/setup/SetupKotlinNotebook.md
@@ -117,3 +117,10 @@ showcasing how Kotlin DataFrame can help with a variety of data tasks.
 
 * Discover powerful [](Kotlin-DataFrame-Features-in-Kotlin-Notebook.md)that
 make exploring and understanding your data easier and more effective.
+
+## Memory Errors?
+
+* If you are experiencing `OutOfMemoryError`s and heap space errors, you can adjust Notebook's
+memory settings independently of IntelliJ IDEA's memory settings.
+
+* In IntelliJ IDEA, go to Settings... Tools... Kotlin Notebook and increase the `Max heap size`


### PR DESCRIPTION
Added a small section on adjusting memory settings for Kotlin Notebook. (personally I found the answer on Kotlin Slack #datascience channel)

This might be important enough to be mentioned on the project README, as it is rather difficult to find/discover currently. I spent multiple hours dealing with memory errors thinking the solution was increasing the IDEA memory size, which had no effect. Thanks :)