### PR TITLE
Remove redundant type parameter from transpose

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
@@ -3,7 +3,6 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.impl.api.convertTo
 import org.jetbrains.kotlinx.dataframe.impl.columnName
 import org.jetbrains.kotlinx.dataframe.impl.owner
@@ -13,7 +12,7 @@ import kotlin.reflect.typeOf
 
 // region DataRow
 
-public fun <T> DataRow<T>.transpose(): DataFrame<NameValuePair<*>> {
+public fun AnyRow.transpose(): DataFrame<NameValuePair<*>> {
     val valueColumn = DataColumn.createByInference(NameValuePair<*>::value.columnName, values)
     val nameColumn = owner.columnNames().toValueColumn(NameValuePair<*>::name.name)
     return dataFrameOf(nameColumn, valueColumn).cast()


### PR DESCRIPTION
It's not used at all and all usages still compile
Makes it clearer:
<img width="1792" height="396" alt="image" src="https://github.com/user-attachments/assets/ff41ff0c-a40e-4835-8e86-1f23256308f3" />

vs

<img width="1758" height="346" alt="image" src="https://github.com/user-attachments/assets/b9bd6db0-e173-45ab-975f-bc7d0653126a" />

