### PR TITLE
Fixes pivot shortcuts to use `PivotDsl`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/pivot.kt
@@ -486,8 +486,9 @@ internal interface DataFramePivotMatchesCommonDocs
 
 /**
  * @include [DataFramePivotMatchesCommonDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
  *
+ * @include [PivotDslDocs]
  * ### Example
  * ```kotlin
  * // Compute whether matching rows exist for all unique values of "city"
@@ -498,7 +499,7 @@ internal interface DataFramePivotMatchesCommonDocs
  *
  * @param [inward] If `true` (default), the generated pivoted columns are nested inside the original column;
  *               if `false`, they are placed at the top level.
- * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used as [pivot] keys for the operation.
+ * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used as [pivot] keys for the operation.
  * @return A new [DataFrame] representing a [Boolean] presence matrix — with grouping key columns as rows,
  *         pivot key values as columns, and `true`/`false` cells indicating existing combinations.
  */
@@ -577,7 +578,9 @@ internal interface DataFramePivotCountsCommonDocs
 
 /**
  * @include [DataFramePivotCountsCommonDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
+ *
+ * @include [PivotDslDocs]
  *
  * ### Example
  * ```kotlin
@@ -588,7 +591,7 @@ internal interface DataFramePivotCountsCommonDocs
  * ```
  *
  * @include [PivotDocs.InwardKDocs]
- * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used as [pivot] keys for the operation.
+ * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used as [pivot] keys for the operation.
  * @return A new [DataFrame] representing a counting matrix — with grouping key columns as rows,
  *         pivot key values as columns, and the number of rows with the corresponding combinations in the cells.
  */
@@ -655,7 +658,7 @@ private interface CommonPivotForGroupByDocs
  * @include [CommonPivotForGroupByDocs]
  * @include [SelectingColumns.Dsl.WithExample] {@include [SetPivotOperationArg] {@set [SelectingColumns.RECEIVER] <code>`gb`</code>}}
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are pivoted.
+ * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are pivoted.
  * @return A new [PivotGroupBy] that preserves the original [groupBy] key columns
  * and pivots the provided columns.
  */
@@ -713,7 +716,9 @@ internal interface GroupByPivotMatchesCommonDocs
 
 /**
  * @include [GroupByPivotMatchesCommonDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
+ *
+ * @include [PivotDslDocs]
  *
  * ### Example
  * ```kotlin
@@ -723,7 +728,7 @@ internal interface GroupByPivotMatchesCommonDocs
  * ```
  *
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used as [pivot] keys for the operation.
+ * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used as [pivot] keys for the operation.
  * @return A new [DataFrame] representing a Boolean presence matrix — with grouping key columns as rows,
  *         pivot key values as columns, and `true`/`false` cells indicating existing combinations.
  */
@@ -787,7 +792,9 @@ internal interface GroupByPivotCountsCommonDocs
 
 /**
  * @include [GroupByPivotCountsCommonDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
+ *
+ * @include [PivotDslDocs]
  *
  * ### Example
  * ```kotlin
@@ -797,7 +804,7 @@ internal interface GroupByPivotCountsCommonDocs
  * ```
  *
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used as [pivot] keys for the operation.
+ * @param [columns] The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used as [pivot] keys for the operation.
  * @return A new [DataFrame] representing a counting matrix — with grouping key columns as rows,
  *         pivot key values as columns, and the number of rows with the corresponding combinations in the cells.
  */
@@ -936,8 +943,7 @@ public fun <T> AggregateGroupedDsl<T>.pivot(
  * ```
  *
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param columns The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used
- * as keys for pivoting and in which order.
+ * @param [columns] The [Column Names][String] that defines which columns are used as [pivot] keys for the operation.
  * @return A [PivotGroupBy] for further [aggregations][PivotGroupByDocs.Aggregation].
  */
 public fun <T> AggregateGroupedDsl<T>.pivot(vararg columns: String, inward: Boolean = true): PivotGroupBy<T> =
@@ -983,7 +989,9 @@ internal interface AggregateGroupedDslPivotMatchesDocs
 
 /**
  * @include [AggregateGroupedDslPivotMatchesDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
+ *
+ * @include [PivotDslDocs]
  * ### Example
  * ```kotlin
  * df.groupBy { name.firstName }.aggregate {
@@ -994,7 +1002,7 @@ internal interface AggregateGroupedDslPivotMatchesDocs
  * ```
  *
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param columns The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used
+ * @param columns The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used
  * as keys for pivoting and in which order.
  * @return A new [DataFrame] representing a Boolean presence matrix — with grouping key columns as rows,
  * pivot key values as columns, and `true`/`false` cells indicating existing combinations.
@@ -1067,9 +1075,10 @@ internal interface AggregateGroupedDslPivotCountsDocs
 
 /**
  * @include [AggregateGroupedDslPivotCountsDocs]
- * @include [SelectingColumns.Dsl]
+ * Select or express pivot columns using the [PivotDsl].
+ *
+ * @include [PivotDslDocs]
  * ### Example
- * ```kotlin
  * ```kotlin
  * df.groupBy { name.firstName }.aggregate {
  *     // Compute number of for all unique values of "city"
@@ -1079,7 +1088,7 @@ internal interface AggregateGroupedDslPivotCountsDocs
  * ```
  *
  * @include [PivotDocs.InwardKDocsForGrouped]
- * @param columns The [Pivot Columns Selector][PivotColumnsSelector]that defines which columns are used
+ * @param columns The [Pivot Columns Selector][PivotColumnsSelector] that defines which columns are used
  * as keys for pivoting and in which order.
  * @return A new [DataFrame] representing a counting matrix — with grouping key columns as rows,
  * pivot key values as columns, and the number of rows with the corresponding combinations in the cells.


### PR DESCRIPTION
Fixes #1548 by making all pivot shortcuts use `PivotDsl`. I believe this will not cause issues as `PivotDsl : ColumnsSelectionDsl`, and all shortcuts simply call `pivot {}.operation()`.