### PR TITLE
Suppress readExcel StatusLogger from log4j in 2025.2.4 notebooks

### DIFF
--- a/dataframe-jupyter/build.gradle.kts
+++ b/dataframe-jupyter/build.gradle.kts
@@ -23,10 +23,6 @@ repositories {
 dependencies {
     api(projects.dataframe)
 
-    // logger, need it for apache poi
-    implementation(libs.log4j.core)
-    implementation(libs.log4j.api)
-
     testImplementation(libs.junit)
     testImplementation(libs.serialization.json)
 


### PR DESCRIPTION
This message doesn't appear in 2025.3 anymore, but for 2025.2.+ fix is needed. Let's agree if we want it