### PR TITLE
Auto Opt-in experimental UUID in notebooks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -194,6 +194,8 @@ allprojects {
             // enables support for kotlin.time.Instant as kotlinx.datetime.Instant was deprecated; Issue #1350
             // Can be removed once kotlin.time.Instant is marked "stable".
             optIn.add("kotlin.time.ExperimentalTime")
+            // can be removed once kotlin.uuid.ExperimentalUuidApi is marked "stable".
+            optIn.add("kotlin.uuid.ExperimentalUuidApi")
         }
     }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/codeGen/ReplCodeGeneratorImpl.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
 
@@ -120,23 +121,33 @@ internal class ReplCodeGeneratorImpl : ReplCodeGenerator {
         result.newMarkers.forEach {
             generatedMarkers[it.name] = it
         }
-        return if (schema.hasExperimentalInstant()) {
+
+        val optIns = buildString {
+            if (schema.hasExperimentalInstant()) appendLine("@file:OptIn(kotlin.time.ExperimentalTime::class)")
+            if (schema.hasExperimentalUuid()) appendLine("@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)")
+        }
+
+        return if (optIns.isNotEmpty()) {
             result.code.copy(
-                declarations = "@file:OptIn(kotlin.time.ExperimentalTime::class)\n" + result.code.declarations,
+                declarations = optIns + "\n" + result.code.declarations,
             )
         } else {
             result.code
         }
     }
 
-    private fun DataFrameSchema.hasExperimentalInstant(): Boolean =
+    private fun DataFrameSchema.hasColumnOfType(type: KType): Boolean =
         columns.values.any { column ->
             when (column) {
-                is ColumnSchema.Frame -> column.schema.hasExperimentalInstant()
-                is ColumnSchema.Group -> column.schema.hasExperimentalInstant()
-                is ColumnSchema.Value -> column.type.isSubtypeOf(typeOf<Instant?>())
+                is ColumnSchema.Frame -> column.schema.hasColumnOfType(type)
+                is ColumnSchema.Group -> column.schema.hasColumnOfType(type)
+                is ColumnSchema.Value -> column.type.isSubtypeOf(type)
             }
         }
+
+    private fun DataFrameSchema.hasExperimentalInstant(): Boolean = hasColumnOfType(typeOf<Instant?>())
+
+    private fun DataFrameSchema.hasExperimentalUuid(): Boolean = hasColumnOfType(typeOf<Uuid?>())
 
     override fun process(markerClass: KClass<*>): Code {
         val newMarkers = mutableListOf<Marker>()

--- a/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
+++ b/dataframe-jupyter/src/test/kotlin/org/jetbrains/kotlinx/dataframe/jupyter/JupyterCodegenTests.kt
@@ -60,6 +60,32 @@ class JupyterCodegenTests : JupyterReplTestCase() {
     }
 
     @Test
+    fun `opt in experimental Uuid`() {
+        @Language("kts")
+        val res1 = execRaw(
+            """
+            @file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+            
+            val uuid: kotlin.uuid.Uuid = kotlin.uuid.Uuid.NIL
+            val df = dataFrameOf("a" to columnOf(uuid))
+            df
+            """.trimIndent(),
+        )
+
+        @Language("kts")
+        val res2 = execRaw(
+            """
+            @file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+            
+            df.a
+            """.trimIndent(),
+        )
+
+        res2.shouldBeInstanceOf<DataColumn<*>>()
+        res2.type() shouldBe typeOf<kotlin.uuid.Uuid>()
+    }
+
+    @Test
     fun `Don't inherit from data class`() {
         @Language("kts")
         val res1 = execRendered(


### PR DESCRIPTION
Follow up for https://github.com/Kotlin/dataframe/pull/1601 which fixes its test and adds the same logic for kotlin.uuid.ExperimentalUuidApi