### PR TITLE
Enable llms.txt generation in docs

### DIFF
--- a/docs/StardustDocs/cfg/buildprofiles.xml
+++ b/docs/StardustDocs/cfg/buildprofiles.xml
@@ -18,6 +18,7 @@
         <browser-edits-url>https://github.com/Kotlin/dataframe/edit/master/docs/StardustDocs/</browser-edits-url>
         <include-in-head>include-head.html</include-in-head>
     </variables>
+    <llms-txt single-file="true"/>
     <sitemap change-frequency="monthly"/>
     <build-profile instance="d">
         <variables>


### PR DESCRIPTION
Related to https://github.com/Kotlin/dataframe/issues/1258
More info about this file: https://www.jetbrains.com/help/writerside/generate-llms-txt.html
I couldn't test it locally, but in GH Actions use writerside builder 2025.04.8412﻿
 that includes this feature: https://www.jetbrains.com/help/writerside/8312.html
 
 Let's see the content, decide if we need it. Although single artifact for LLM is a thing, LLM providers seem to use our *.md topics from GitHub instead of documentation website. 