### PR TITLE
Add GH Action to produce direct links to download example subprojects

### DIFF
--- a/.github/workflows/archive-examples.yml
+++ b/.github/workflows/archive-examples.yml
@@ -1,0 +1,81 @@
+  name: Archive Example Projects
+
+  on:
+    push:
+      branches:
+        - master
+      paths:
+        - 'examples/android-example/**'
+        - 'examples/kotlin-dataframe-plugin-example/**'
+    workflow_dispatch:
+
+  jobs:
+    build-archives:
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Create android-example archive
+          run: |
+            cd examples/android-example
+            zip -r ../../android-example.zip . -x "*.git*" "build/*" ".gradle/*" "*/build/*"
+
+        - name: Create kotlin-dataframe-plugin-example archive
+          run: |
+            cd examples/kotlin-dataframe-plugin-example
+            zip -r ../../kotlin-dataframe-plugin-example.zip . -x "*.git*" "build/*" ".gradle/*" "*/build/*"
+
+        - name: Checkout example-projects-archives branch
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            if git ls-remote --exit-code --heads origin example-projects-archives; then
+              git fetch origin example-projects-archives
+              git checkout example-projects-archives
+            else
+              git checkout --orphan example-projects-archives
+              git rm -rf .
+            fi
+
+        - name: Update archives
+          run: |
+            git rm -f *.zip 2>/dev/null || true
+            
+            mv android-example.zip .
+            mv kotlin-dataframe-plugin-example.zip .
+            
+            cat > README.md << 'EOF'
+            # Kotlin DataFrame - Example Projects Archives
+            
+            Automatically generated archives of example projects.
+            
+            ## Available archives:
+            
+            ### Android Example
+            Example of using Kotlin DataFrame in an Android application.
+            
+            **Download:** [android-example.zip](https://github.com/Kotlin/dataframe/raw/example-projects-archives/android-example.zip)
+            
+            ### Kotlin DataFrame Plugin Example
+            Example of using the compiler plugin for Kotlin DataFrame.
+            
+            **Download:** [kotlin-dataframe-plugin-example.zip](https://github.com/Kotlin/dataframe/raw/example-projects-archives/kotlin-dataframe-plugin-example.zip)
+            
+            ---
+            
+            Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            
+            Source commit: ${{ github.sha }}
+            EOF
+            
+            git add .
+            git commit -m "Update example archives from ${{ github.sha }}" || echo "No changes to commit"
+
+        - name: Push to example-projects-archives branch
+          run: |
+            git push -f origin example-projects-archives
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There's a problem that even include build subprojects are a part of dataframe repo, so one need to download and build it entirely to run them.
New GH Action will build zip archives from subproject directories and push them to separate orphan branch. We will be able to share links directly to download. 
It'll make these subprojects more easily available and will enable sharing of more complex projects while keeping everything under one project for nice development experience