### PR TITLE
Fix links to Compiler-Plugin.md

### DIFF
--- a/docs/StardustDocs/topics/FAQ.md
+++ b/docs/StardustDocs/topics/FAQ.md
@@ -112,7 +112,7 @@ They are generated automatically when working with Kotlin DataFrame in:
 - [Kotlin Notebook](SetupKotlinNotebook.md), where extension properties are generated 
 after each cell execution.
 - A Kotlin project in [IntelliJ IDEA](https://www.jetbrains.com/idea/) with the
-  [](Compiler-Plugin.md) enabled, where the properties are generated at compile time.
+  [compiler plugin](Compiler-Plugin.md) enabled, where the properties are generated at compile time.
 
 ## I used the KProperties API in older versions, what should I use now that it's deprecated?
 

--- a/docs/StardustDocs/topics/schemas/Migration-From-Plugins.md
+++ b/docs/StardustDocs/topics/schemas/Migration-From-Plugins.md
@@ -5,7 +5,7 @@ However, they are now being phased out. This section provides an overview of the
 
 ## Gradle Plugin
 
-> Do not confuse this with the [](Compiler-Plugin.md), which is a Kotlin compiler plugin
+> Do not confuse this with the [compiler plugin](Compiler-Plugin.md), which is a Kotlin compiler plugin
 > and has a different plugin ID.  
 > {style="note"}
 
@@ -16,7 +16,7 @@ However, they are now being phased out. This section provides an overview of the
       the [`generate..()` methods](DataSchemaGenerationMethods.md).
 
 2. **Generation of [extension properties](extensionPropertiesApi.md)** from data schemas  
-   This is now handled by the [](Compiler-Plugin.md), which:
+   This is now handled by the [compiler plugin](Compiler-Plugin.md), which:
     - Generates extension properties for declared data schemas.
     - Automatically updates the schema and regenerates properties after structural DataFrame operations.
 


### PR DESCRIPTION
Empty links to compiler-plugin.md are now rendered as Setup And Overview. Doesn't make sense in the context, so here's the fix.