### PR TITLE
Optimize Iterable<Map>.toDataFrame conversion

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -65,7 +65,25 @@ public fun <T> Iterable<DataRow<T>>.toDataFrame(): DataFrame<T> {
 }
 
 @JvmName("toDataFrameMapStringAnyNullable")
-public fun Iterable<Map<String, *>>.toDataFrame(): DataFrame<*> = map { it.toDataRow() }.toDataFrame()
+public fun Iterable<Map<String, Any?>>.toDataFrame(): AnyFrame {
+    val list = asList()
+    if (list.isEmpty()) return DataFrame.empty()
+
+    val allKeys = linkedSetOf<String>()
+    for (row in this) {
+        allKeys.addAll(row.keys)
+    }
+
+    val columns = allKeys.map { key ->
+        val values = ArrayList<Any?>(list.size)
+        for (row in this) {
+            values.add(row[key])
+        }
+        DataColumn.createByInference(key, values)
+    }
+
+    return columns.toDataFrame()
+}
 
 @JvmName("toDataFrameAnyColumn")
 public fun Iterable<AnyBaseCol>.toDataFrame(): AnyFrame = dataFrameOf(this)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -452,6 +452,8 @@ class CreateDataFrameTests {
         df["b"][0] shouldBe true
         df["c"][1] shouldBe 2
         df["d"][1] shouldBe false
+        df.columns().all { it.type().isMarkedNullable } shouldBe true
+        df["a"].type() shouldBe typeOf<Int?>()
     }
 
     class NoPublicPropsClass(private val a: Int, private val b: String)


### PR DESCRIPTION
Now it hits a lot of heavy reflection calls like `type.isSubtypeOf<AnyRow?>()`, `AnyFrame` on each `Map -> DataRow`. 
Collecting values first, inferring type for all gives a visible improvement

17 s -> 1.5 s

Code i used for testing:

```kt
val rowCount: Int = 1_000_000
val columnCount: Int = 10
val columns = (0 until columnCount).map { "col$it" }
val maps: List<Map<String, Any?>> = (0 until rowCount).map { rowIdx ->
    columns.associate { col ->
        col to when (columns.indexOf(col) % 4) {
            0 -> rowIdx
            1 -> "value_$rowIdx"
            2 -> rowIdx * 1.5
            3 -> rowIdx % 2 == 0
            else -> null
        }
    }
}

maps.toDataFrame()
```

fixes https://github.com/Kotlin/dataframe/issues/90