### PR TITLE
Migrate most of the examples in 40 puzzles from delegate style dataframeOf(Columns) to dataFrameOf(Pair<String, Column>)

### DIFF
--- a/examples/notebooks/dev/puzzles/40 puzzles.ipynb
+++ b/examples/notebooks/dev/puzzles/40 puzzles.ipynb
@@ -22,8 +22,20 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:19:59.395182Z",
-     "start_time": "2025-09-09T10:19:54.390222Z"
+     "end_time": "2025-12-18T11:19:41.542631050Z",
+     "start_time": "2025-12-18T11:19:40.843063224Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_3_jupyter",
+      "Line_4_jupyter",
+      "Line_5_jupyter",
+      "Line_6_jupyter",
+      "Line_7_jupyter",
+      "Line_8_jupyter",
+      "Line_9_jupyter",
+      "Line_10_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -41,10 +53,10 @@
     "\n",
     "Consider the following columns:\n",
     "```[kotlin]\n",
-    "val animal by columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
-    "val age by columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7, 3)\n",
-    "val visits by columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
-    "val priority by columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
+    "columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
+    "columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7, 3)\n",
+    "columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
+    "columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
     "```\n",
     "**2.** Create a DataFrame df from this columns."
    ]
@@ -52,25 +64,32 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:02.727979Z",
-     "start_time": "2025-09-09T10:19:59.649721Z"
+     "end_time": "2025-12-18T11:19:42.256463391Z",
+     "start_time": "2025-12-18T11:19:41.547295069Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_11_jupyter",
+      "Line_12_jupyter",
+      "Line_13_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val animal by columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
-    "val age by columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7.0, 3.0)\n",
-    "val visits by columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
-    "val priority by columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
-    "\n",
-    "val df = dataFrameOf(animal, age, visits, priority)\n",
+    "val df = dataFrameOf(\n",
+    "    \"animal\" to columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\"),\n",
+    "    \"age\" to columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7.0, 3.0),\n",
+    "    \"visits\" to columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1),\n",
+    "    \"priority\" to columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\"),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_1()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_1\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_1()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_1\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -249,7 +268,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741824&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539264&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -534,10 +553,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741824, rootId: -1073741824, totalRows: 10 } ) });\n",
+       "], id: 486539264, rootId: 486539264, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741824) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539264) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -552,7 +571,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -710,10 +729,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741823\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539265\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741823\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539265\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -734,8 +753,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:03.156449Z",
-     "start_time": "2025-09-09T10:20:03.035219Z"
+     "end_time": "2025-12-18T11:19:42.668067585Z",
+     "start_time": "2025-12-18T11:19:42.493753232Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_15_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -760,8 +784,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:04.574614Z",
-     "start_time": "2025-09-09T10:20:04.227657Z"
+     "end_time": "2025-12-18T11:19:43.024905933Z",
+     "start_time": "2025-12-18T11:19:42.687874922Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_16_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -770,7 +799,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_3()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_3\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_3()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_3\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -949,7 +978,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741820&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539268&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 4, columnsCount = 14&lt;&sol;p&gt;\n",
        "\n",
@@ -1244,10 +1273,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;median: Comparable&lt;*&gt;&bsol;&quot;&gt;median&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;no&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;p75: Comparable&lt;*&gt;&bsol;&quot;&gt;p75&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;yes&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;max: Comparable&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;snake&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;yes&quot;] }, \n",
-       "], id: -1073741820, rootId: -1073741820, totalRows: 4 } ) });\n",
+       "], id: 486539268, rootId: 486539268, totalRows: 4 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741820) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539268) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -1262,7 +1291,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -1420,10 +1449,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741819\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">name</th><th class=\"bottomBorder\" style=\"text-align:left\">type</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th><th class=\"bottomBorder\" style=\"text-align:left\">unique</th><th class=\"bottomBorder\" style=\"text-align:left\">nulls</th><th class=\"bottomBorder\" style=\"text-align:left\">top</th><th class=\"bottomBorder\" style=\"text-align:left\">freq</th><th class=\"bottomBorder\" style=\"text-align:left\">mean</th><th class=\"bottomBorder\" style=\"text-align:left\">std</th><th class=\"bottomBorder\" style=\"text-align:left\">min</th><th class=\"bottomBorder\" style=\"text-align:left\">p25</th><th class=\"bottomBorder\" style=\"text-align:left\">median</th><th class=\"bottomBorder\" style=\"text-align:left\">p75</th><th class=\"bottomBorder\" style=\"text-align:left\">max</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">animal</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">snake</td></tr><tr><td  style=\"vertical-align:top\">age</td><td  style=\"vertical-align:top\">Double</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">8</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">visits</td><td  style=\"vertical-align:top\">Int</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">1.900000</td><td  style=\"vertical-align:top\">0.875595</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">priority</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">yes</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539269\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">name</th><th class=\"bottomBorder\" style=\"text-align:left\">type</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th><th class=\"bottomBorder\" style=\"text-align:left\">unique</th><th class=\"bottomBorder\" style=\"text-align:left\">nulls</th><th class=\"bottomBorder\" style=\"text-align:left\">top</th><th class=\"bottomBorder\" style=\"text-align:left\">freq</th><th class=\"bottomBorder\" style=\"text-align:left\">mean</th><th class=\"bottomBorder\" style=\"text-align:left\">std</th><th class=\"bottomBorder\" style=\"text-align:left\">min</th><th class=\"bottomBorder\" style=\"text-align:left\">p25</th><th class=\"bottomBorder\" style=\"text-align:left\">median</th><th class=\"bottomBorder\" style=\"text-align:left\">p75</th><th class=\"bottomBorder\" style=\"text-align:left\">max</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">animal</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">snake</td></tr><tr><td  style=\"vertical-align:top\">age</td><td  style=\"vertical-align:top\">Double</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">8</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">visits</td><td  style=\"vertical-align:top\">Int</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">1.900000</td><td  style=\"vertical-align:top\">0.875595</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">priority</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">yes</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741819\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539269\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -1444,8 +1473,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:06.002260Z",
-     "start_time": "2025-09-09T10:20:05.722387Z"
+     "end_time": "2025-12-18T11:19:43.282299347Z",
+     "start_time": "2025-12-18T11:19:43.094411261Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_18_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -1464,7 +1498,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_4()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_4\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_5()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_5\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -1643,7 +1677,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741818&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539272&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -1928,25 +1962,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741818, rootId: -1073741818, totalRows: 3 } ) });\n",
+       "], id: 486539272, rootId: 486539272, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741818) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539272) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_4() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_4\");\n",
-       "                    resize_iframe_out_4(elem);\n",
-       "                    setInterval(resize_iframe_out_4, 5000, elem);\n",
+       "                function o_resize_iframe_out_5() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_5\");\n",
+       "                    resize_iframe_out_5(elem);\n",
+       "                    setInterval(resize_iframe_out_5, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_4(el) {\n",
+       "                function resize_iframe_out_5(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -2104,10 +2138,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741817\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539273\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741817\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539273\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -2128,17 +2162,22 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:07.907697Z",
-     "start_time": "2025-09-09T10:20:07.711736Z"
+     "end_time": "2025-12-18T11:19:43.547372659Z",
+     "start_time": "2025-12-18T11:19:43.339126731Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_20_jupyter"
+     ]
     }
    },
    "cell_type": "code",
-   "source": "df[animal, age]",
+   "source": "df.select { animal and age }",
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_7()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_7\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_7()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_7\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -2317,7 +2356,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741812&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539276&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -2600,10 +2639,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;,&quot;dog&quot;,&quot;cat&quot;,&quot;snake&quot;,&quot;cat&quot;,&quot;dog&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741812, rootId: -1073741812, totalRows: 10 } ) });\n",
+       "], id: 486539276, rootId: 486539276, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741812) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539276) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -2618,7 +2657,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -2776,10 +2815,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741811\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539277\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741811\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539277\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -2800,17 +2839,22 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:08.944974Z",
-     "start_time": "2025-09-09T10:20:08.818476Z"
+     "end_time": "2025-12-18T11:19:43.840786386Z",
+     "start_time": "2025-12-18T11:19:43.614032321Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_22_jupyter"
+     ]
     }
    },
    "cell_type": "code",
-   "source": "df[3, 4, 8][animal, age]",
+   "source": "df[3, 4, 8].select { animal and age }",
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_8()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_8\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_9()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_9\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -2989,7 +3033,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741810&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539280&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -3272,25 +3316,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;dog&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741810, rootId: -1073741810, totalRows: 3 } ) });\n",
+       "], id: 486539280, rootId: 486539280, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741810) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539280) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_8() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_8\");\n",
-       "                    resize_iframe_out_8(elem);\n",
-       "                    setInterval(resize_iframe_out_8, 5000, elem);\n",
+       "                function o_resize_iframe_out_9() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_9\");\n",
+       "                    resize_iframe_out_9(elem);\n",
+       "                    setInterval(resize_iframe_out_9, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_8(el) {\n",
+       "                function resize_iframe_out_9(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -3448,10 +3492,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741809\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539281\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741809\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539281\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -3472,8 +3516,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:10.601401Z",
-     "start_time": "2025-09-09T10:20:10.368239Z"
+     "end_time": "2025-12-18T11:19:44.130666181Z",
+     "start_time": "2025-12-18T11:19:43.890826650Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_24_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -3482,7 +3531,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_11()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_11\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_11()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_11\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -3661,7 +3710,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741804&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539284&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -3946,10 +3995,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741804, rootId: -1073741804, totalRows: 3 } ) });\n",
+       "], id: 486539284, rootId: 486539284, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741804) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539284) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -3964,7 +4013,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -4122,10 +4171,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741803\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539285\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741803\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539285\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -4146,8 +4195,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:11.365451Z",
-     "start_time": "2025-09-09T10:20:11.155586Z"
+     "end_time": "2025-12-18T11:19:44.432826220Z",
+     "start_time": "2025-12-18T11:19:44.195451619Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_26_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -4156,7 +4210,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_12()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_12\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_13()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_13\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -4335,7 +4389,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741802&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539288&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 2, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -4620,25 +4674,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;] }, \n",
-       "], id: -1073741802, rootId: -1073741802, totalRows: 2 } ) });\n",
+       "], id: 486539288, rootId: 486539288, totalRows: 2 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741802) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539288) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_12() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_12\");\n",
-       "                    resize_iframe_out_12(elem);\n",
-       "                    setInterval(resize_iframe_out_12, 5000, elem);\n",
+       "                function o_resize_iframe_out_13() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_13\");\n",
+       "                    resize_iframe_out_13(elem);\n",
+       "                    setInterval(resize_iframe_out_13, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_12(el) {\n",
+       "                function resize_iframe_out_13(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -4796,10 +4850,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741801\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539289\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741801\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539289\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -4820,8 +4874,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:13.067840Z",
-     "start_time": "2025-09-09T10:20:12.870865Z"
+     "end_time": "2025-12-18T11:19:44.731860002Z",
+     "start_time": "2025-12-18T11:19:44.516203139Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_28_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -4830,7 +4889,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_15()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_15\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_15()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_15\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -5009,7 +5068,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741796&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539292&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 2, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -5294,10 +5353,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741796, rootId: -1073741796, totalRows: 2 } ) });\n",
+       "], id: 486539292, rootId: 486539292, totalRows: 2 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741796) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539292) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -5312,7 +5371,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -5470,10 +5529,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741795\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539293\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741795\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539293\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -5494,8 +5553,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:13.690452Z",
-     "start_time": "2025-09-09T10:20:13.483329Z"
+     "end_time": "2025-12-18T11:19:45.067952922Z",
+     "start_time": "2025-12-18T11:19:44.828539799Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_30_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -5504,7 +5568,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_16()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_16\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_17()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_17\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -5683,7 +5747,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741794&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539296&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 4, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -5968,25 +6032,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741794, rootId: -1073741794, totalRows: 4 } ) });\n",
+       "], id: 486539296, rootId: 486539296, totalRows: 4 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741794) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539296) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_16() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_16\");\n",
-       "                    resize_iframe_out_16(elem);\n",
-       "                    setInterval(resize_iframe_out_16, 5000, elem);\n",
+       "                function o_resize_iframe_out_17() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_17\");\n",
+       "                    resize_iframe_out_17(elem);\n",
+       "                    setInterval(resize_iframe_out_17, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_16(el) {\n",
+       "                function resize_iframe_out_17(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -6144,10 +6208,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741793\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539297\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741793\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539297\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -6168,8 +6232,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:15.695961Z",
-     "start_time": "2025-09-09T10:20:15.204861Z"
+     "end_time": "2025-12-18T11:19:45.321374555Z",
+     "start_time": "2025-12-18T11:19:45.119529698Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_32_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6178,7 +6247,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_19()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_19\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_19()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_19\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -6357,7 +6426,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741788&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539300&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -6642,10 +6711,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741788, rootId: -1073741788, totalRows: 10 } ) });\n",
+       "], id: 486539300, rootId: 486539300, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741788) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539300) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -6660,7 +6729,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -6818,10 +6887,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741787\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">1.500000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539301\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">1.500000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741787\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539301\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -6842,8 +6911,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:16.646710Z",
-     "start_time": "2025-09-09T10:20:16.476888Z"
+     "end_time": "2025-12-18T11:19:45.509286538Z",
+     "start_time": "2025-12-18T11:19:45.377472164Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_34_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6870,8 +6944,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:17.836313Z",
-     "start_time": "2025-09-09T10:20:17.587717Z"
+     "end_time": "2025-12-18T11:19:45.733964446Z",
+     "start_time": "2025-12-18T11:19:45.522355616Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_35_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6880,7 +6959,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_21()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_21\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_21()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_21\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -7059,7 +7138,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741784&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539304&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -7342,10 +7421,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741784, rootId: -1073741784, totalRows: 3 } ) });\n",
+       "], id: 486539304, rootId: 486539304, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741784) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539304) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -7360,7 +7439,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -7518,10 +7597,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741783\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539305\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741783\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539305\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -7542,8 +7621,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:18.597759Z",
-     "start_time": "2025-09-09T10:20:18.454593Z"
+     "end_time": "2025-12-18T11:19:45.965591312Z",
+     "start_time": "2025-12-18T11:19:45.805912316Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_37_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -7555,7 +7639,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_22()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_22\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_23()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_23\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -7734,7 +7818,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741782&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539308&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -8019,25 +8103,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741782, rootId: -1073741782, totalRows: 10 } ) });\n",
+       "], id: 486539308, rootId: 486539308, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741782) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539308) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_22() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_22\");\n",
-       "                    resize_iframe_out_22(elem);\n",
-       "                    setInterval(resize_iframe_out_22, 5000, elem);\n",
+       "                function o_resize_iframe_out_23() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_23\");\n",
+       "                    resize_iframe_out_23(elem);\n",
+       "                    setInterval(resize_iframe_out_23, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_22(el) {\n",
+       "                function resize_iframe_out_23(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -8195,10 +8279,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741781\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539309\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741781\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539309\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -8219,8 +8303,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:19.769933Z",
-     "start_time": "2025-09-09T10:20:19.591996Z"
+     "end_time": "2025-12-18T11:19:46.367888372Z",
+     "start_time": "2025-12-18T11:19:46.058158419Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_39_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -8229,7 +8318,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_25()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_25\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_25()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_25\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -8408,7 +8497,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741776&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539312&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -8691,10 +8780,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;count: Int&bsol;&quot;&gt;count&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741776, rootId: -1073741776, totalRows: 3 } ) });\n",
+       "], id: 486539312, rootId: 486539312, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741776) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539312) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -8709,7 +8798,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -8867,10 +8956,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741775\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539313\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741775\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539313\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -8891,8 +8980,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:20.558950Z",
-     "start_time": "2025-09-09T10:20:20.305732Z"
+     "end_time": "2025-12-18T11:19:46.660623189Z",
+     "start_time": "2025-12-18T11:19:46.449941128Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_41_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -8901,7 +8995,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_26()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_26\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_27()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_27\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -9080,7 +9174,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741774&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539316&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -9365,25 +9459,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741774, rootId: -1073741774, totalRows: 10 } ) });\n",
+       "], id: 486539316, rootId: 486539316, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741774) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539316) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_26() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_26\");\n",
-       "                    resize_iframe_out_26(elem);\n",
-       "                    setInterval(resize_iframe_out_26, 5000, elem);\n",
+       "                function o_resize_iframe_out_27() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_27\");\n",
+       "                    resize_iframe_out_27(elem);\n",
+       "                    setInterval(resize_iframe_out_27, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_26(el) {\n",
+       "                function resize_iframe_out_27(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -9541,10 +9635,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741773\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539317\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741773\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539317\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -9565,8 +9659,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:22.589698Z",
-     "start_time": "2025-09-09T10:20:22.375775Z"
+     "end_time": "2025-12-18T11:19:46.937073806Z",
+     "start_time": "2025-12-18T11:19:46.722579483Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_43_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -9575,7 +9674,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_29()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_29\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_29()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_29\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -9754,7 +9853,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741768&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539320&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -10039,10 +10138,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: Boolean&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;true&quot;,&quot;true&quot;,&quot;false&quot;,&quot;true&quot;,&quot;false&quot;,&quot;false&quot;,&quot;false&quot;,&quot;true&quot;,&quot;false&quot;,&quot;false&quot;] }, \n",
-       "], id: -1073741768, rootId: -1073741768, totalRows: 10 } ) });\n",
+       "], id: 486539320, rootId: 486539320, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741768) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539320) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -10057,7 +10156,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -10215,10 +10314,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741767\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539321\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741767\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539321\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -10239,8 +10338,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:23.215530Z",
-     "start_time": "2025-09-09T10:20:23.057774Z"
+     "end_time": "2025-12-18T11:19:47.183097405Z",
+     "start_time": "2025-12-18T11:19:46.992589282Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_45_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -10249,7 +10353,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_30()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_30\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_31()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_31\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -10428,7 +10532,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741766&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539324&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -10713,25 +10817,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741766, rootId: -1073741766, totalRows: 10 } ) });\n",
+       "], id: 486539324, rootId: 486539324, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741766) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539324) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_30() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_30\");\n",
-       "                    resize_iframe_out_30(elem);\n",
-       "                    setInterval(resize_iframe_out_30, 5000, elem);\n",
+       "                function o_resize_iframe_out_31() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_31\");\n",
+       "                    resize_iframe_out_31(elem);\n",
+       "                    setInterval(resize_iframe_out_31, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_30(el) {\n",
+       "                function resize_iframe_out_31(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -10889,10 +10993,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741765\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539325\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741765\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539325\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -10917,8 +11021,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:24.572846Z",
-     "start_time": "2025-09-09T10:20:24.294243Z"
+     "end_time": "2025-12-18T11:19:47.538227593Z",
+     "start_time": "2025-12-18T11:19:47.243994037Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_47_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -10927,7 +11036,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_33()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_33\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_33()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_33\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -11106,7 +11215,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741760&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539328&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -11392,10 +11501,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;3: Double?&bsol;&quot;&gt;3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;2: Double?&bsol;&quot;&gt;2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: DataRow&lt;*&gt;&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 2.5&bsol;n3: 2.5&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;3: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 4.5&bsol;n2: 0.5&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;2: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 3.0&bsol;n3: NaN&bsol;n2: 6.0&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;3: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;2: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741760, rootId: -1073741760, totalRows: 3 } ) });\n",
+       "], id: 486539328, rootId: 486539328, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741760) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539328) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -11410,7 +11519,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -11568,10 +11677,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741759\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">animal</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">visits</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">1</th><th class=\"bottomBorder\" style=\"text-align:left\">3</th><th class=\"bottomBorder\" style=\"text-align:left\">2</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">cat</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">null</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">snake</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">dog</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">6.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539329\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">animal</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">visits</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">1</th><th class=\"bottomBorder\" style=\"text-align:left\">3</th><th class=\"bottomBorder\" style=\"text-align:left\">2</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">cat</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">null</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">snake</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">dog</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">6.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741759\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539329\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -11602,7 +11711,7 @@
    "source": [
     "**20.** You have a DataFrame df with a column 'A' of integers. For example:\n",
     "```kotlin\n",
-    "val df = dataFrameOf(\"A\")(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7)\n",
+    "val df = dataFrameOf(\"A\" to columnOf(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7))\n",
     "```\n",
     "How do you filter out rows which contain the same integer as the row immediately above?\n",
     "\n",
@@ -11615,20 +11724,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:25.370850Z",
-     "start_time": "2025-09-09T10:20:25.033558Z"
+     "end_time": "2025-12-18T11:19:47.812973387Z",
+     "start_time": "2025-12-18T11:19:47.592009662Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_49_jupyter",
+      "Line_50_jupyter",
+      "Line_51_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val df = dataFrameOf(\"A\")(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7)\n",
+    "val df = dataFrameOf(\"A\" to columnOf(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7))\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_34()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_34\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_35()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_35\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -11807,7 +11923,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741758&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539332&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 11, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -12089,25 +12205,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741758, rootId: -1073741758, totalRows: 11 } ) });\n",
+       "], id: 486539332, rootId: 486539332, totalRows: 11 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741758) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539332) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_34() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_34\");\n",
-       "                    resize_iframe_out_34(elem);\n",
-       "                    setInterval(resize_iframe_out_34, 5000, elem);\n",
+       "                function o_resize_iframe_out_35() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_35\");\n",
+       "                    resize_iframe_out_35(elem);\n",
+       "                    setInterval(resize_iframe_out_35, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_34(el) {\n",
+       "                function resize_iframe_out_35(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -12265,10 +12381,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741757\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539333\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741757\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539333\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -12284,8 +12400,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:26.967333Z",
-     "start_time": "2025-09-09T10:20:26.811413Z"
+     "end_time": "2025-12-18T11:19:48.106029432Z",
+     "start_time": "2025-12-18T11:19:47.883015099Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_53_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -12294,7 +12415,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_37()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_37\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_37()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_37\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -12473,7 +12594,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741752&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539336&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -12755,10 +12876,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741752, rootId: -1073741752, totalRows: 7 } ) });\n",
+       "], id: 486539336, rootId: 486539336, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741752) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539336) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -12773,7 +12894,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -12931,10 +13052,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741751\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539337\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741751\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539337\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -12950,8 +13071,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:27.631518Z",
-     "start_time": "2025-09-09T10:20:27.484179Z"
+     "end_time": "2025-12-18T11:19:48.354220694Z",
+     "start_time": "2025-12-18T11:19:48.153924502Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_55_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -12960,7 +13086,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_38()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_38\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_39()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_39\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -13139,7 +13265,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741750&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539340&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -13421,25 +13547,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741750, rootId: -1073741750, totalRows: 7 } ) });\n",
+       "], id: 486539340, rootId: 486539340, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741750) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539340) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_38() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_38\");\n",
-       "                    resize_iframe_out_38(elem);\n",
-       "                    setInterval(resize_iframe_out_38, 5000, elem);\n",
+       "                function o_resize_iframe_out_39() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_39\");\n",
+       "                    resize_iframe_out_39(elem);\n",
+       "                    setInterval(resize_iframe_out_39, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_38(el) {\n",
+       "                function resize_iframe_out_39(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -13597,10 +13723,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741749\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539341\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741749\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539341\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -13621,8 +13747,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:29.315966Z",
-     "start_time": "2025-09-09T10:20:29.209502Z"
+     "end_time": "2025-12-18T11:19:48.524516883Z",
+     "start_time": "2025-12-18T11:19:48.428439626Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_57_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -13631,7 +13762,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_41()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_41\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_41()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_41\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -13810,7 +13941,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741744&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539344&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -14092,10 +14223,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741744, rootId: -1073741744, totalRows: 7 } ) });\n",
+       "], id: 486539344, rootId: 486539344, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741744) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539344) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -14110,7 +14241,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -14268,10 +14399,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741743\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539345\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741743\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539345\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -14299,8 +14430,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:30.397907Z",
-     "start_time": "2025-09-09T10:20:29.980818Z"
+     "end_time": "2025-12-18T11:19:48.976011050Z",
+     "start_time": "2025-12-18T11:19:48.636984362Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_58_jupyter",
+      "Line_59_jupyter",
+      "Line_60_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -14312,7 +14450,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_42()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_42\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_42()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_42\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -14491,7 +14629,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741742&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539346&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -14772,13 +14910,13 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.476393&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.277764&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.533610&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.992791&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.995942&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.402171&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.439975&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.779849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.634597&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.642784&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.464037&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.331262&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.230575&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.642034&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.082391&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741742, rootId: -1073741742, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.389647&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.788586&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.858807&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.883197&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.931211&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.552994&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.127921&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.673938&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.765814&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.402562&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.853043&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.833489&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.781276&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.929804&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.438368&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539346, rootId: 486539346, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741742) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539346) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -14793,7 +14931,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -14951,14 +15089,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741741\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.476393</td><td  style=\"vertical-align:top\">0.402171</td><td  style=\"vertical-align:top\">0.464037</td></tr><tr><td  style=\"vertical-align:top\">0.277764</td><td  style=\"vertical-align:top\">0.439975</td><td  style=\"vertical-align:top\">0.331262</td></tr><tr><td  style=\"vertical-align:top\">0.533610</td><td  style=\"vertical-align:top\">0.779849</td><td  style=\"vertical-align:top\">0.230575</td></tr><tr><td  style=\"vertical-align:top\">0.992791</td><td  style=\"vertical-align:top\">0.634597</td><td  style=\"vertical-align:top\">0.642034</td></tr><tr><td  style=\"vertical-align:top\">0.995942</td><td  style=\"vertical-align:top\">0.642784</td><td  style=\"vertical-align:top\">0.082391</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539347\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.389647</td><td  style=\"vertical-align:top\">0.552994</td><td  style=\"vertical-align:top\">0.853043</td></tr><tr><td  style=\"vertical-align:top\">0.788586</td><td  style=\"vertical-align:top\">0.127921</td><td  style=\"vertical-align:top\">0.833489</td></tr><tr><td  style=\"vertical-align:top\">0.858807</td><td  style=\"vertical-align:top\">0.673938</td><td  style=\"vertical-align:top\">0.781276</td></tr><tr><td  style=\"vertical-align:top\">0.883197</td><td  style=\"vertical-align:top\">0.765814</td><td  style=\"vertical-align:top\">0.929804</td></tr><tr><td  style=\"vertical-align:top\">0.931211</td><td  style=\"vertical-align:top\">0.402562</td><td  style=\"vertical-align:top\">0.438368</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741741\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539347\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.4763925813135824,\"b\":0.4021705312133531,\"c\":0.464036708774875},{\"a\":0.2777636584540719,\"b\":0.43997477270591434,\"c\":0.33126197700986315},{\"a\":0.5336096049935759,\"b\":0.7798491298160639,\"c\":0.23057468751492816},{\"a\":0.9927906804875166,\"b\":0.6345967324643486,\"c\":0.6420341351149527},{\"a\":0.9959418117402272,\"b\":0.6427843294584921,\"c\":0.08239111462902493}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.38964725344768747,\"b\":0.552993764027322,\"c\":0.8530430376111371},{\"a\":0.7885858820136266,\"b\":0.12792147763728656,\"c\":0.8334889732578966},{\"a\":0.8588073780857777,\"b\":0.673938093076138,\"c\":0.7812759099616297},{\"a\":0.8831974604892261,\"b\":0.765814199023807,\"c\":0.9298044650001936},{\"a\":0.931211129866274,\"b\":0.40256161724758266,\"c\":0.4383683880175443}]}"
      },
      "execution_count": 25,
      "metadata": {},
@@ -14970,8 +15108,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:31.541472Z",
-     "start_time": "2025-09-09T10:20:31.390436Z"
+     "end_time": "2025-12-18T11:19:49.490759745Z",
+     "start_time": "2025-12-18T11:19:49.100396054Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_63_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -14983,7 +15126,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_45()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_45\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_45()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_45\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -15162,7 +15305,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741736&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539352&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -15443,13 +15586,13 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.028859&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.071903&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.018932&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.236317&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.422236&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.045363&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.090308&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.265171&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.121877&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.069079&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.016503&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.018405&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.284103&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.114440&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.491315&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741736, rootId: -1073741736, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.208914&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.205254&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.087467&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.023592&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.340497&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.045568&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.455411&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.097402&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.093791&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.188152&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.254482&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.250157&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.009935&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.070199&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.152345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539352, rootId: 486539352, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741736) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539352) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -15464,7 +15607,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -15622,14 +15765,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741735\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.028859</td><td  style=\"vertical-align:top\">-0.045363</td><td  style=\"vertical-align:top\">0.016503</td></tr><tr><td  style=\"vertical-align:top\">-0.071903</td><td  style=\"vertical-align:top\">0.090308</td><td  style=\"vertical-align:top\">-0.018405</td></tr><tr><td  style=\"vertical-align:top\">0.018932</td><td  style=\"vertical-align:top\">0.265171</td><td  style=\"vertical-align:top\">-0.284103</td></tr><tr><td  style=\"vertical-align:top\">0.236317</td><td  style=\"vertical-align:top\">-0.121877</td><td  style=\"vertical-align:top\">-0.114440</td></tr><tr><td  style=\"vertical-align:top\">0.422236</td><td  style=\"vertical-align:top\">0.069079</td><td  style=\"vertical-align:top\">-0.491315</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539353\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-0.208914</td><td  style=\"vertical-align:top\">-0.045568</td><td  style=\"vertical-align:top\">0.254482</td></tr><tr><td  style=\"vertical-align:top\">0.205254</td><td  style=\"vertical-align:top\">-0.455411</td><td  style=\"vertical-align:top\">0.250157</td></tr><tr><td  style=\"vertical-align:top\">0.087467</td><td  style=\"vertical-align:top\">-0.097402</td><td  style=\"vertical-align:top\">0.009935</td></tr><tr><td  style=\"vertical-align:top\">0.023592</td><td  style=\"vertical-align:top\">-0.093791</td><td  style=\"vertical-align:top\">0.070199</td></tr><tr><td  style=\"vertical-align:top\">0.340497</td><td  style=\"vertical-align:top\">-0.188152</td><td  style=\"vertical-align:top\">-0.152345</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741735\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539353\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.028859307546312274,\"b\":-0.045362742553917035,\"c\":0.016503435007604872},{\"a\":-0.07190314426921124,\"b\":0.09030796998263119,\"c\":-0.018404825713420003},{\"a\":0.01893179755205321,\"b\":0.2651713223745412,\"c\":-0.28410311992659454},{\"a\":0.2363168311319106,\"b\":-0.12187711689125746,\"c\":-0.11443971424065336},{\"a\":0.4222360597976458,\"b\":0.06907857751591062,\"c\":-0.4913146373135565}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":-0.2089140982476947,\"b\":-0.04556758766806013,\"c\":0.25448168591575493},{\"a\":0.20525377104402331,\"b\":-0.4554106333323167,\"c\":0.25015686228829337},{\"a\":0.08746691771126269,\"b\":-0.09740236729837703,\"c\":0.009935449587114675},{\"a\":0.02359208565148385,\"b\":-0.09379117581393526,\"c\":0.0701990901624514},{\"a\":0.3404974181558069,\"b\":-0.1881520944628844,\"c\":-0.15234532369292275}]}"
      },
      "execution_count": 26,
      "metadata": {},
@@ -15654,8 +15797,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:32.627938Z",
-     "start_time": "2025-09-09T10:20:32.029446Z"
+     "end_time": "2025-12-18T11:19:49.906927775Z",
+     "start_time": "2025-12-18T11:19:49.567367152Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_65_jupyter",
+      "Line_66_jupyter",
+      "Line_67_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -15668,7 +15818,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_46()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_46\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_47()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_47\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -15847,7 +15997,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741734&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539356&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -16128,35 +16278,35 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.200907&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.756915&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.771118&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.261827&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.752958&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.887191&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.064409&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.988253&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.729440&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.320814&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.254947&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.734192&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.521926&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.209404&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.720208&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;d: Double&bsol;&quot;&gt;d&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.388157&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.110249&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.731664&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.602179&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.767147&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;e: Double&bsol;&quot;&gt;e&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.908765&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.590999&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.022142&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.847507&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.597244&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;f: Double&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.329694&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.704905&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.635532&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.730487&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.057618&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;g: Double&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.952278&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.912019&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.766838&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.126333&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.191310&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.285820&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.652098&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.853087&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.545107&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.203321&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.013636&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.036866&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.906844&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.795482&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.903760&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.095965&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.420558&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.446849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.378680&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.523245&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741734, rootId: -1073741734, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.841911&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.498208&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.788916&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.553347&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.874932&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.282187&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.847661&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.162458&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.482594&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.162043&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.504844&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.227987&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.183311&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.405461&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.477525&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;d: Double&bsol;&quot;&gt;d&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.316049&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.518230&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.926585&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.369849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.884059&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;e: Double&bsol;&quot;&gt;e&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.490350&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.126070&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.429727&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.431532&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.292586&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;f: Double&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.593206&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.616324&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.740767&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.177826&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.854866&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;g: Double&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.550719&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.147116&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.930618&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.465287&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.456486&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.814340&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.262463&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.971054&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.262496&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.589303&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.089081&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.323552&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.802308&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.201674&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.140426&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.113149&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.737167&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.230486&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.430214&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.911116&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539356, rootId: 486539356, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741734) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539356) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_46() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_46\");\n",
-       "                    resize_iframe_out_46(elem);\n",
-       "                    setInterval(resize_iframe_out_46, 5000, elem);\n",
+       "                function o_resize_iframe_out_47() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_47\");\n",
+       "                    resize_iframe_out_47(elem);\n",
+       "                    setInterval(resize_iframe_out_47, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_46(el) {\n",
+       "                function resize_iframe_out_47(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -16314,14 +16464,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741733\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.200907</td><td  style=\"vertical-align:top\">0.887191</td><td  style=\"vertical-align:top\">0.254947</td><td  style=\"vertical-align:top\">0.388157</td><td  style=\"vertical-align:top\">0.908765</td><td  style=\"vertical-align:top\">0.329694</td><td  style=\"vertical-align:top\">0.952278</td><td  style=\"vertical-align:top\">0.285820</td><td  style=\"vertical-align:top\">0.013636</td><td  style=\"vertical-align:top\">0.095965</td></tr><tr><td  style=\"vertical-align:top\">0.756915</td><td  style=\"vertical-align:top\">0.064409</td><td  style=\"vertical-align:top\">0.734192</td><td  style=\"vertical-align:top\">0.110249</td><td  style=\"vertical-align:top\">0.590999</td><td  style=\"vertical-align:top\">0.704905</td><td  style=\"vertical-align:top\">0.912019</td><td  style=\"vertical-align:top\">0.652098</td><td  style=\"vertical-align:top\">0.036866</td><td  style=\"vertical-align:top\">0.420558</td></tr><tr><td  style=\"vertical-align:top\">0.771118</td><td  style=\"vertical-align:top\">0.988253</td><td  style=\"vertical-align:top\">0.521926</td><td  style=\"vertical-align:top\">0.731664</td><td  style=\"vertical-align:top\">0.022142</td><td  style=\"vertical-align:top\">0.635532</td><td  style=\"vertical-align:top\">0.766838</td><td  style=\"vertical-align:top\">0.853087</td><td  style=\"vertical-align:top\">0.906844</td><td  style=\"vertical-align:top\">0.446849</td></tr><tr><td  style=\"vertical-align:top\">0.261827</td><td  style=\"vertical-align:top\">0.729440</td><td  style=\"vertical-align:top\">0.209404</td><td  style=\"vertical-align:top\">0.602179</td><td  style=\"vertical-align:top\">0.847507</td><td  style=\"vertical-align:top\">0.730487</td><td  style=\"vertical-align:top\">0.126333</td><td  style=\"vertical-align:top\">0.545107</td><td  style=\"vertical-align:top\">0.795482</td><td  style=\"vertical-align:top\">0.378680</td></tr><tr><td  style=\"vertical-align:top\">0.752958</td><td  style=\"vertical-align:top\">0.320814</td><td  style=\"vertical-align:top\">0.720208</td><td  style=\"vertical-align:top\">0.767147</td><td  style=\"vertical-align:top\">0.597244</td><td  style=\"vertical-align:top\">0.057618</td><td  style=\"vertical-align:top\">0.191310</td><td  style=\"vertical-align:top\">0.203321</td><td  style=\"vertical-align:top\">0.903760</td><td  style=\"vertical-align:top\">0.523245</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539357\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.841911</td><td  style=\"vertical-align:top\">0.282187</td><td  style=\"vertical-align:top\">0.504844</td><td  style=\"vertical-align:top\">0.316049</td><td  style=\"vertical-align:top\">0.490350</td><td  style=\"vertical-align:top\">0.593206</td><td  style=\"vertical-align:top\">0.550719</td><td  style=\"vertical-align:top\">0.814340</td><td  style=\"vertical-align:top\">0.089081</td><td  style=\"vertical-align:top\">0.113149</td></tr><tr><td  style=\"vertical-align:top\">0.498208</td><td  style=\"vertical-align:top\">0.847661</td><td  style=\"vertical-align:top\">0.227987</td><td  style=\"vertical-align:top\">0.518230</td><td  style=\"vertical-align:top\">0.126070</td><td  style=\"vertical-align:top\">0.616324</td><td  style=\"vertical-align:top\">0.147116</td><td  style=\"vertical-align:top\">0.262463</td><td  style=\"vertical-align:top\">0.323552</td><td  style=\"vertical-align:top\">0.737167</td></tr><tr><td  style=\"vertical-align:top\">0.788916</td><td  style=\"vertical-align:top\">0.162458</td><td  style=\"vertical-align:top\">0.183311</td><td  style=\"vertical-align:top\">0.926585</td><td  style=\"vertical-align:top\">0.429727</td><td  style=\"vertical-align:top\">0.740767</td><td  style=\"vertical-align:top\">0.930618</td><td  style=\"vertical-align:top\">0.971054</td><td  style=\"vertical-align:top\">0.802308</td><td  style=\"vertical-align:top\">0.230486</td></tr><tr><td  style=\"vertical-align:top\">0.553347</td><td  style=\"vertical-align:top\">0.482594</td><td  style=\"vertical-align:top\">0.405461</td><td  style=\"vertical-align:top\">0.369849</td><td  style=\"vertical-align:top\">0.431532</td><td  style=\"vertical-align:top\">0.177826</td><td  style=\"vertical-align:top\">0.465287</td><td  style=\"vertical-align:top\">0.262496</td><td  style=\"vertical-align:top\">0.201674</td><td  style=\"vertical-align:top\">0.430214</td></tr><tr><td  style=\"vertical-align:top\">0.874932</td><td  style=\"vertical-align:top\">0.162043</td><td  style=\"vertical-align:top\">0.477525</td><td  style=\"vertical-align:top\">0.884059</td><td  style=\"vertical-align:top\">0.292586</td><td  style=\"vertical-align:top\">0.854866</td><td  style=\"vertical-align:top\">0.456486</td><td  style=\"vertical-align:top\">0.589303</td><td  style=\"vertical-align:top\">0.140426</td><td  style=\"vertical-align:top\">0.911116</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741733\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539357\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":10,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.20090685064331937,\"b\":0.8871912255133791,\"c\":0.2549468111321541,\"d\":0.38815694631380127,\"e\":0.9087653789721286,\"f\":0.3296938927440395,\"g\":0.9522777703806122,\"h\":0.2858200144042208,\"i\":0.013636055573945094,\"j\":0.09596530470652986},{\"a\":0.7569150749029241,\"b\":0.06440905190823076,\"c\":0.7341915384170767,\"d\":0.11024863730405987,\"e\":0.590999032572314,\"f\":0.7049045211724224,\"g\":0.9120191694445311,\"h\":0.6520979901678069,\"i\":0.036866394726266294,\"j\":0.42055787198537553},{\"a\":0.7711179884037822,\"b\":0.9882529014691451,\"c\":0.5219260940599081,\"d\":0.7316640236098008,\"e\":0.02214156003644352,\"f\":0.6355322467903455,\"g\":0.7668379494838335,\"h\":0.8530872406235399,\"i\":0.9068442102269314,\"j\":0.44684852264187824},{\"a\":0.26182665083165513,\"b\":0.7294403477511925,\"c\":0.2094035232312974,\"d\":0.6021794872113193,\"e\":0.8475066241565566,\"f\":0.7304873105946014,\"g\":0.12633259066356395,\"h\":0.5451066654099072,\"i\":0.7954819015909015,\"j\":0.378679721185631},{\"a\":0.7529584519095024,\"b\":0.3208139103643325,\"c\":0.7202083013432629,\"d\":0.767147363074108,\"e\":0.5972443068782157,\"f\":0.05761833328160326,\"g\":0.19130970715775053,\"h\":0.20332141649523094,\"i\":0.9037601846779532,\"j\":0.5232454636011823}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":10,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.8419114160124052,\"b\":0.282186920782716,\"c\":0.5048443177170018,\"d\":0.31604901017535125,\"e\":0.4903503697680932,\"f\":0.5932062822034694,\"g\":0.5507189032521874,\"h\":0.8143400642944842,\"i\":0.0890806635407565,\"j\":0.11314865188165824},{\"a\":0.49820844533063235,\"b\":0.8476612083057321,\"c\":0.22798742360150803,\"d\":0.5182296202669303,\"e\":0.12607036482076805,\"f\":0.6163241622452882,\"g\":0.1471161686192296,\"h\":0.26246326600812764,\"i\":0.32355220762629744,\"j\":0.7371668074893234},{\"a\":0.788915937670967,\"b\":0.16245843051774012,\"c\":0.18331082327972492,\"d\":0.9265848824100162,\"e\":0.4297273634305062,\"f\":0.7407665914938036,\"g\":0.9306177608421328,\"h\":0.9710544319125589,\"i\":0.802308385674185,\"j\":0.23048565019517087},{\"a\":0.553347476141766,\"b\":0.48259411048976075,\"c\":0.40546089768988547,\"d\":0.3698490765337128,\"e\":0.43153183270372275,\"f\":0.17782580998707898,\"g\":0.465287247289943,\"h\":0.2624963066894521,\"i\":0.20167375143620148,\"j\":0.43021369129837617},{\"a\":0.8749319981380302,\"b\":0.16204312466903636,\"c\":0.4775248119116894,\"d\":0.8840586021809772,\"e\":0.2925857979551013,\"f\":0.8548662347706445,\"g\":0.4564858905910003,\"h\":0.5893027524048042,\"i\":0.1404261330157901,\"j\":0.911116058678073}]}"
      },
      "execution_count": 27,
      "metadata": {},
@@ -16333,8 +16483,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:34.365240Z",
-     "start_time": "2025-09-09T10:20:34.058803Z"
+     "end_time": "2025-12-18T11:19:50.235988942Z",
+     "start_time": "2025-12-18T11:19:49.987687771Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_69_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16343,7 +16498,7 @@
     {
      "data": {
       "text/plain": [
-       "j"
+       "i"
       ]
      },
      "execution_count": 28,
@@ -16361,8 +16516,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:35.327978Z",
-     "start_time": "2025-09-09T10:20:34.825964Z"
+     "end_time": "2025-12-18T11:19:50.387907271Z",
+     "start_time": "2025-12-18T11:19:50.238960093Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_70_jupyter",
+      "Line_71_jupyter",
+      "Line_72_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16374,7 +16536,7 @@
     {
      "data": {
       "text/plain": [
-       "18"
+       "19"
       ]
      },
      "execution_count": 29,
@@ -16398,8 +16560,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:36.465361Z",
-     "start_time": "2025-09-09T10:20:35.654021Z"
+     "end_time": "2025-12-18T11:19:50.641509850Z",
+     "start_time": "2025-12-18T11:19:50.391210050Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_73_jupyter",
+      "Line_74_jupyter",
+      "Line_75_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16420,7 +16589,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_49()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_49\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_49()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_49\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -16599,7 +16768,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741728&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539360&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -16890,10 +17059,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.51&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.67&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.76&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.24&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.48&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.01&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.68&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741728, rootId: -1073741728, totalRows: 5 } ) });\n",
+       "], id: 486539360, rootId: 486539360, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741728) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539360) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -16908,7 +17077,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -17066,10 +17235,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741727\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.250000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.430000</td><td  style=\"vertical-align:top\">0.710000</td><td  style=\"vertical-align:top\">0.510000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.670000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">0.160000</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.310000</td><td  style=\"vertical-align:top\">0.400000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.240000</td><td  style=\"vertical-align:top\">0.010000</td></tr><tr><td  style=\"vertical-align:top\">0.490000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.620000</td><td  style=\"vertical-align:top\">0.730000</td><td  style=\"vertical-align:top\">0.260000</td><td  style=\"vertical-align:top\">0.850000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.410000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.050000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.610000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.480000</td><td  style=\"vertical-align:top\">0.680000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539361\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.250000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.430000</td><td  style=\"vertical-align:top\">0.710000</td><td  style=\"vertical-align:top\">0.510000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.670000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">0.160000</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.310000</td><td  style=\"vertical-align:top\">0.400000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.240000</td><td  style=\"vertical-align:top\">0.010000</td></tr><tr><td  style=\"vertical-align:top\">0.490000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.620000</td><td  style=\"vertical-align:top\">0.730000</td><td  style=\"vertical-align:top\">0.260000</td><td  style=\"vertical-align:top\">0.850000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.410000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.050000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.610000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.480000</td><td  style=\"vertical-align:top\">0.680000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741727\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539361\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -17085,8 +17254,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:37.444264Z",
-     "start_time": "2025-09-09T10:20:36.980547Z"
+     "end_time": "2025-12-18T11:19:51.054313756Z",
+     "start_time": "2025-12-18T11:19:50.738227798Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_77_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -17101,7 +17275,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_50()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_50\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_51()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_51\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -17280,7 +17454,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741726&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539364&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;res&quot;, type = String, size = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -17562,25 +17736,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;res: String&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;e&quot;,&quot;c&quot;,&quot;d&quot;,&quot;h&quot;,&quot;d&quot;] }, \n",
-       "], id: -1073741726, rootId: -1073741726, totalRows: 5 } ) });\n",
+       "], id: 486539364, rootId: 486539364, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741726) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539364) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_50() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_50\");\n",
-       "                    resize_iframe_out_50(elem);\n",
-       "                    setInterval(resize_iframe_out_50, 5000, elem);\n",
+       "                function o_resize_iframe_out_51() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_51\");\n",
+       "                    resize_iframe_out_51(elem);\n",
+       "                    setInterval(resize_iframe_out_51, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_50(el) {\n",
+       "                function resize_iframe_out_51(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -17738,10 +17912,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741725\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">e</td></tr><tr><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">h</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539365\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">e</td></tr><tr><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">h</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741725\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539365\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -17760,10 +17934,10 @@
    "source": [
     "**25.** A DataFrame has a column of groups 'grps' and a column of integer values 'vals':\n",
     "```kotlin\n",
-    "val grps by column(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\")\n",
-    "val vals by column(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87)\n",
-    "\n",
-    "val df = dataFrameOf(grps, vals)\n",
+    "val df = dataFrameOf(\n",
+    "    \"grps\" to columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\"),\n",
+    "    \"vals\" to columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87),\n",
+    ")\n",
     "```\n",
     "\n",
     "For each group, find the sum of the three greatest values. You should end up with the answer as follows:\n",
@@ -17778,23 +17952,30 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:39.631818Z",
-     "start_time": "2025-09-09T10:20:38.996891Z"
+     "end_time": "2025-12-18T11:19:51.467157852Z",
+     "start_time": "2025-12-18T11:19:51.142193506Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_79_jupyter",
+      "Line_80_jupyter",
+      "Line_81_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val grps by columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\")\n",
-    "val vals by columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87)\n",
-    "\n",
-    "val df = dataFrameOf(grps, vals)\n",
+    "val df = dataFrameOf(\n",
+    "    \"grps\" to columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\"),\n",
+    "    \"vals\" to columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_52()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_52\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_53()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_53\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -17973,7 +18154,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741722&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539368&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -18256,25 +18437,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;c&quot;,&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;c&quot;,&quot;c&quot;,&quot;c&quot;,&quot;b&quot;,&quot;b&quot;,&quot;c&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;12&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;45&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;54&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;235&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;57&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741722, rootId: -1073741722, totalRows: 15 } ) });\n",
+       "], id: 486539368, rootId: 486539368, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741722) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539368) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_52() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_52\");\n",
-       "                    resize_iframe_out_52(elem);\n",
-       "                    setInterval(resize_iframe_out_52, 5000, elem);\n",
+       "                function o_resize_iframe_out_53() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_53\");\n",
+       "                    resize_iframe_out_53(elem);\n",
+       "                    setInterval(resize_iframe_out_53, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_52(el) {\n",
+       "                function resize_iframe_out_53(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -18432,10 +18613,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741721\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">vals</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">12</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">345</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">45</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">54</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">235</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">21</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">57</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">87</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539369\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">vals</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">12</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">345</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">45</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">54</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">235</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">21</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">57</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">87</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741721\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539369\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -18451,8 +18632,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:40.958555Z",
-     "start_time": "2025-09-09T10:20:40.712890Z"
+     "end_time": "2025-12-18T11:19:51.874156449Z",
+     "start_time": "2025-12-18T11:19:51.536795229Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_83_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -18465,7 +18651,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_55()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_55\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_55()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_55\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -18644,7 +18830,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741716&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539372&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -18927,10 +19113,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;b&quot;,&quot;c&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;res: Int&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;409&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;156&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741716, rootId: -1073741716, totalRows: 3 } ) });\n",
+       "], id: 486539372, rootId: 486539372, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741716) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539372) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -18945,7 +19131,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -19103,10 +19289,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741715\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">409</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">156</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">345</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539373\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">409</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">156</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">345</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741715\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539373\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -19147,8 +19333,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:42.098844Z",
-     "start_time": "2025-09-09T10:20:41.524488Z"
+     "end_time": "2025-12-18T11:19:52.289287480Z",
+     "start_time": "2025-12-18T11:19:51.941954661Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_85_jupyter",
+      "Line_86_jupyter",
+      "Line_87_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -19164,7 +19357,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_56()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_56\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_57()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_57\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -19343,7 +19536,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741714&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539376&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;... showing only top 20 of 100 rows&lt;&sol;p&gt;&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 100, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -19626,25 +19819,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;34&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;70&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;53&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;80&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;45&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;27&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;70&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;11&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;51&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;46&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;56&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;58&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;48&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;73&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;B: Int&bsol;&quot;&gt;B&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;41&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;33&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;41&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;88&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;68&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;60&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;29&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;49&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741714, rootId: -1073741714, totalRows: 100 } ) });\n",
+       "], id: 486539376, rootId: 486539376, totalRows: 100 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741714) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539376) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_56() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_56\");\n",
-       "                    resize_iframe_out_56(elem);\n",
-       "                    setInterval(resize_iframe_out_56, 5000, elem);\n",
+       "                function o_resize_iframe_out_57() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_57\");\n",
+       "                    resize_iframe_out_57(elem);\n",
+       "                    setInterval(resize_iframe_out_57, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_56(el) {\n",
+       "                function resize_iframe_out_57(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -19802,10 +19995,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741713\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">34</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">33</td></tr><tr><td  style=\"vertical-align:top\">22</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">88</td></tr><tr><td  style=\"vertical-align:top\">53</td><td  style=\"vertical-align:top\">68</td></tr><tr><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">59</td></tr><tr><td  style=\"vertical-align:top\">45</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">27</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">8</td></tr><tr><td  style=\"vertical-align:top\">11</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">51</td><td  style=\"vertical-align:top\">60</td></tr><tr><td  style=\"vertical-align:top\">46</td><td  style=\"vertical-align:top\">43</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">17</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">42</td></tr><tr><td  style=\"vertical-align:top\">56</td><td  style=\"vertical-align:top\">29</td></tr><tr><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">49</td></tr><tr><td  style=\"vertical-align:top\">48</td><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">73</td><td  style=\"vertical-align:top\">52</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539377\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">34</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">33</td></tr><tr><td  style=\"vertical-align:top\">22</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">88</td></tr><tr><td  style=\"vertical-align:top\">53</td><td  style=\"vertical-align:top\">68</td></tr><tr><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">59</td></tr><tr><td  style=\"vertical-align:top\">45</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">27</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">8</td></tr><tr><td  style=\"vertical-align:top\">11</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">51</td><td  style=\"vertical-align:top\">60</td></tr><tr><td  style=\"vertical-align:top\">46</td><td  style=\"vertical-align:top\">43</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">17</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">42</td></tr><tr><td  style=\"vertical-align:top\">56</td><td  style=\"vertical-align:top\">29</td></tr><tr><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">49</td></tr><tr><td  style=\"vertical-align:top\">48</td><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">73</td><td  style=\"vertical-align:top\">52</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741713\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539377\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -19821,8 +20014,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:43.816621Z",
-     "start_time": "2025-09-09T10:20:43.416356Z"
+     "end_time": "2025-12-18T11:19:52.799510118Z",
+     "start_time": "2025-12-18T11:19:52.372865385Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_89_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -19835,7 +20033,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_59()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_59\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_59()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_59\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -20014,7 +20212,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741708&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539380&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -20297,10 +20495,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: String&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;(0, 10]&quot;,&quot;(10, 20]&quot;,&quot;(20, 30]&quot;,&quot;(30, 40]&quot;,&quot;(40, 50]&quot;,&quot;(50, 60]&quot;,&quot;(60, 70]&quot;,&quot;(70, 80]&quot;,&quot;(80, 90]&quot;,&quot;(90, 100]&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;B: Int&bsol;&quot;&gt;B&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;353&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;873&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;321&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;322&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;432&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;754&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;405&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;561&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;657&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;527&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741708, rootId: -1073741708, totalRows: 10 } ) });\n",
+       "], id: 486539380, rootId: 486539380, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741708) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539380) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -20315,7 +20513,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -20473,10 +20671,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741707\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">(0, 10]</td><td  style=\"vertical-align:top\">353</td></tr><tr><td  style=\"vertical-align:top\">(10, 20]</td><td  style=\"vertical-align:top\">873</td></tr><tr><td  style=\"vertical-align:top\">(20, 30]</td><td  style=\"vertical-align:top\">321</td></tr><tr><td  style=\"vertical-align:top\">(30, 40]</td><td  style=\"vertical-align:top\">322</td></tr><tr><td  style=\"vertical-align:top\">(40, 50]</td><td  style=\"vertical-align:top\">432</td></tr><tr><td  style=\"vertical-align:top\">(50, 60]</td><td  style=\"vertical-align:top\">754</td></tr><tr><td  style=\"vertical-align:top\">(60, 70]</td><td  style=\"vertical-align:top\">405</td></tr><tr><td  style=\"vertical-align:top\">(70, 80]</td><td  style=\"vertical-align:top\">561</td></tr><tr><td  style=\"vertical-align:top\">(80, 90]</td><td  style=\"vertical-align:top\">657</td></tr><tr><td  style=\"vertical-align:top\">(90, 100]</td><td  style=\"vertical-align:top\">527</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539381\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">(0, 10]</td><td  style=\"vertical-align:top\">353</td></tr><tr><td  style=\"vertical-align:top\">(10, 20]</td><td  style=\"vertical-align:top\">873</td></tr><tr><td  style=\"vertical-align:top\">(20, 30]</td><td  style=\"vertical-align:top\">321</td></tr><tr><td  style=\"vertical-align:top\">(30, 40]</td><td  style=\"vertical-align:top\">322</td></tr><tr><td  style=\"vertical-align:top\">(40, 50]</td><td  style=\"vertical-align:top\">432</td></tr><tr><td  style=\"vertical-align:top\">(50, 60]</td><td  style=\"vertical-align:top\">754</td></tr><tr><td  style=\"vertical-align:top\">(60, 70]</td><td  style=\"vertical-align:top\">405</td></tr><tr><td  style=\"vertical-align:top\">(70, 80]</td><td  style=\"vertical-align:top\">561</td></tr><tr><td  style=\"vertical-align:top\">(80, 90]</td><td  style=\"vertical-align:top\">657</td></tr><tr><td  style=\"vertical-align:top\">(90, 100]</td><td  style=\"vertical-align:top\">527</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741707\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539381\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -20506,7 +20704,7 @@
    "source": [
     "**27.** Consider a DataFrame `df` where there is an integer column 'X':\n",
     "```kotlin\n",
-    "val df = dataFrameOf(\"X\")(7, 2, 0, 3, 4, 2, 5, 0, 3 , 4)\n",
+    "val df = dataFrameOf(\"X\" to columnOf(7, 2, 0, 3, 4, 2, 5, 0, 3, 4))\n",
     "```\n",
     "For each value, count the difference back to the previous zero (or the start of the column, whichever is closer). These values should therefore be\n",
     "\n",
@@ -20520,20 +20718,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:44.400104Z",
-     "start_time": "2025-09-09T10:20:44.117352Z"
+     "end_time": "2025-12-18T11:19:53.262677781Z",
+     "start_time": "2025-12-18T11:19:52.881011560Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_91_jupyter",
+      "Line_92_jupyter",
+      "Line_93_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val df = dataFrameOf(\"X\")(7, 2, 0, 3, 4, 2, 5, 0, 3, 4)\n",
+    "val df = dataFrameOf(\"X\" to columnOf(7, 2, 0, 3, 4, 2, 5, 0, 3, 4))\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_60()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_60\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_61()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_61\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -20712,7 +20917,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741706&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539384&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -20994,25 +21199,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;X: Int&bsol;&quot;&gt;X&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741706, rootId: -1073741706, totalRows: 10 } ) });\n",
+       "], id: 486539384, rootId: 486539384, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741706) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539384) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_60() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_60\");\n",
-       "                    resize_iframe_out_60(elem);\n",
-       "                    setInterval(resize_iframe_out_60, 5000, elem);\n",
+       "                function o_resize_iframe_out_61() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_61\");\n",
+       "                    resize_iframe_out_61(elem);\n",
+       "                    setInterval(resize_iframe_out_61, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_60(el) {\n",
+       "                function resize_iframe_out_61(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -21170,10 +21375,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741705\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">X</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539385\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">X</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741705\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539385\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -21189,8 +21394,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:46.239893Z",
-     "start_time": "2025-09-09T10:20:46.023751Z"
+     "end_time": "2025-12-18T11:19:53.552737696Z",
+     "start_time": "2025-12-18T11:19:53.347104241Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_95_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -21203,7 +21413,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_62()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_62\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_63()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_63\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -21382,7 +21592,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741702&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539388&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;Y&quot;, type = Int, size = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -21664,25 +21874,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;Y: Int&bsol;&quot;&gt;Y&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741702, rootId: -1073741702, totalRows: 10 } ) });\n",
+       "], id: 486539388, rootId: 486539388, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741702) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539388) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_62() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_62\");\n",
-       "                    resize_iframe_out_62(elem);\n",
-       "                    setInterval(resize_iframe_out_62, 5000, elem);\n",
+       "                function o_resize_iframe_out_63() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_63\");\n",
+       "                    resize_iframe_out_63(elem);\n",
+       "                    setInterval(resize_iframe_out_63, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_62(el) {\n",
+       "                function resize_iframe_out_63(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -21840,10 +22050,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741701\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">Y</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539389\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">Y</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741701\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539389\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -21873,8 +22083,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:47.723910Z",
-     "start_time": "2025-09-09T10:20:46.986249Z"
+     "end_time": "2025-12-18T11:19:54.071017006Z",
+     "start_time": "2025-12-18T11:19:53.641692715Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_97_jupyter",
+      "Line_98_jupyter",
+      "Line_99_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -21889,7 +22106,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_64()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_64\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_65()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_65\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -22068,7 +22285,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741698&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539392&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 8, columnsCount = 8&lt;&sol;p&gt;\n",
        "\n",
@@ -22357,25 +22574,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;f: Int&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;85&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;97&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;35&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;39&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;55&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;97&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;g: Int&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;74&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;63&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;80&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;65&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;h: Int&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;25&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;81&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;39&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;31&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;38&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741698, rootId: -1073741698, totalRows: 8 } ) });\n",
+       "], id: 486539392, rootId: 486539392, totalRows: 8 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741698) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539392) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_64() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_64\");\n",
-       "                    resize_iframe_out_64(elem);\n",
-       "                    setInterval(resize_iframe_out_64, 5000, elem);\n",
+       "                function o_resize_iframe_out_65() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_65\");\n",
+       "                    resize_iframe_out_65(elem);\n",
+       "                    setInterval(resize_iframe_out_65, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_64(el) {\n",
+       "                function resize_iframe_out_65(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -22533,10 +22750,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741697\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">88</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">85</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">25</td></tr><tr><td  style=\"vertical-align:top\">49</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">52</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">81</td></tr><tr><td  style=\"vertical-align:top\">92</td><td  style=\"vertical-align:top\">41</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">57</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">39</td></tr><tr><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">72</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">50</td><td  style=\"vertical-align:top\">35</td><td  style=\"vertical-align:top\">14</td><td  style=\"vertical-align:top\">31</td></tr><tr><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">33</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">38</td></tr><tr><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">64</td><td  style=\"vertical-align:top\">91</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">76</td><td  style=\"vertical-align:top\">75</td><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">32</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539393\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">88</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">85</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">25</td></tr><tr><td  style=\"vertical-align:top\">49</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">52</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">81</td></tr><tr><td  style=\"vertical-align:top\">92</td><td  style=\"vertical-align:top\">41</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">57</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">39</td></tr><tr><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">72</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">50</td><td  style=\"vertical-align:top\">35</td><td  style=\"vertical-align:top\">14</td><td  style=\"vertical-align:top\">31</td></tr><tr><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">33</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">38</td></tr><tr><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">64</td><td  style=\"vertical-align:top\">91</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">76</td><td  style=\"vertical-align:top\">75</td><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">32</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741697\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539393\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -22552,8 +22769,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:49.199193Z",
-     "start_time": "2025-09-09T10:20:48.654185Z"
+     "end_time": "2025-12-18T11:19:54.475257403Z",
+     "start_time": "2025-12-18T11:19:54.139804923Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_101_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -22566,7 +22788,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_67()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_67\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_67()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_67\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -22745,7 +22967,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741692&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539396&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -23028,10 +23250,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;index: Int&bsol;&quot;&gt;index&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;name: String&bsol;&quot;&gt;name&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;d&quot;,&quot;c&quot;,&quot;f&quot;] }, \n",
-       "], id: -1073741692, rootId: -1073741692, totalRows: 3 } ) });\n",
+       "], id: 486539396, rootId: 486539396, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741692) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539396) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -23046,7 +23268,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -23204,10 +23426,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741691\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">index</th><th class=\"bottomBorder\" style=\"text-align:left\">name</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">f</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539397\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">index</th><th class=\"bottomBorder\" style=\"text-align:left\">name</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">f</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741691\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539397\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -23261,8 +23483,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:50.881413Z",
-     "start_time": "2025-09-09T10:20:49.682553Z"
+     "end_time": "2025-12-18T11:19:55.074975184Z",
+     "start_time": "2025-12-18T11:19:54.581439706Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_103_jupyter",
+      "Line_104_jupyter",
+      "Line_105_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -23280,7 +23509,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_68()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_68\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_69()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_69\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -23459,7 +23688,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741690&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539400&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -23742,25 +23971,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;A&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;] }, \n",
-       "], id: -1073741690, rootId: -1073741690, totalRows: 15 } ) });\n",
+       "], id: 486539400, rootId: 486539400, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741690) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539400) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_68() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_68\");\n",
-       "                    resize_iframe_out_68(elem);\n",
-       "                    setInterval(resize_iframe_out_68, 5000, elem);\n",
+       "                function o_resize_iframe_out_69() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_69\");\n",
+       "                    resize_iframe_out_69(elem);\n",
+       "                    setInterval(resize_iframe_out_69, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_68(el) {\n",
+       "                function resize_iframe_out_69(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -23918,10 +24147,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741689\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539401\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741689\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539401\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -23937,8 +24166,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:52.921344Z",
-     "start_time": "2025-09-09T10:20:51.977826Z"
+     "end_time": "2025-12-18T11:19:55.629440336Z",
+     "start_time": "2025-12-18T11:19:55.172126724Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_107_jupyter",
+      "Line_108_jupyter",
+      "Line_109_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -23955,7 +24191,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_70()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_70\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_71()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_71\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -24134,7 +24370,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741686&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539404&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -24418,25 +24654,25 @@
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;A&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;patched_values: Any&bsol;&quot;&gt;patched_values&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741686, rootId: -1073741686, totalRows: 15 } ) });\n",
+       "], id: 486539404, rootId: 486539404, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741686) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539404) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_70() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_70\");\n",
-       "                    resize_iframe_out_70(elem);\n",
-       "                    setInterval(resize_iframe_out_70, 5000, elem);\n",
+       "                function o_resize_iframe_out_71() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_71\");\n",
+       "                    resize_iframe_out_71(elem);\n",
+       "                    setInterval(resize_iframe_out_71, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_70(el) {\n",
+       "                function resize_iframe_out_71(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -24594,10 +24830,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741685\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">patched_values</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">28.000000</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">9.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">19.000000</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">23.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539405\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">patched_values</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">28.000000</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">9.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">19.000000</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">23.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741685\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539405\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -24616,10 +24852,10 @@
    "source": [
     "**30.** Implement a rolling mean over groups with window size 3, which ignores NaN value. For example, consider the following DataFrame:\n",
     "```kotlin\n",
-    "val group by columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\")\n",
-    "val value by columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0)\n",
-    "\n",
-    "val df = dataFrameOf(group, value)\n",
+    "val df = dataFrameOf(\n",
+    "    \"groups\" to columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\"),\n",
+    "    \"value\" to columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0),\n",
+    ")\n",
     "df\n",
     "\n",
     "group   value\n",
@@ -24658,23 +24894,30 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:55.956419Z",
-     "start_time": "2025-09-09T10:20:54.685746Z"
+     "end_time": "2025-12-18T11:19:56.047538523Z",
+     "start_time": "2025-12-18T11:19:55.719618410Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_111_jupyter",
+      "Line_112_jupyter",
+      "Line_113_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val groups by columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\")\n",
-    "val value by columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0)\n",
-    "\n",
-    "val df = dataFrameOf(groups, value)\n",
+    "val df = dataFrameOf(\n",
+    "    \"groups\" to columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\"),\n",
+    "    \"value\" to columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_73()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_73\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_73()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_73\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -24853,7 +25096,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741680&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539408&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -25136,10 +25379,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;groups: String&bsol;&quot;&gt;groups&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;value: Double&bsol;&quot;&gt;value&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741680, rootId: -1073741680, totalRows: 12 } ) });\n",
+       "], id: 486539408, rootId: 486539408, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741680) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539408) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -25154,7 +25397,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -25312,10 +25555,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741679\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539409\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741679\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539409\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -25331,8 +25574,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:57.287951Z",
-     "start_time": "2025-09-09T10:20:56.616951Z"
+     "end_time": "2025-12-18T11:19:56.601931010Z",
+     "start_time": "2025-12-18T11:19:56.148703247Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_115_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -25348,7 +25596,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_74()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_74\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_75()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_75\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -25527,7 +25775,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741678&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539412&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -25811,25 +26059,25 @@
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;groups: String&bsol;&quot;&gt;groups&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;value: Double&bsol;&quot;&gt;value&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;res: Double&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.500000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.666667&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.666667&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.500000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741678, rootId: -1073741678, totalRows: 12 } ) });\n",
+       "], id: 486539412, rootId: 486539412, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741678) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539412) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_74() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_74\");\n",
-       "                    resize_iframe_out_74(elem);\n",
-       "                    setInterval(resize_iframe_out_74, 5000, elem);\n",
+       "                function o_resize_iframe_out_75() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_75\");\n",
+       "                    resize_iframe_out_75(elem);\n",
+       "                    setInterval(resize_iframe_out_75, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_74(el) {\n",
+       "                function resize_iframe_out_75(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -25987,10 +26235,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741677\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">3.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td><td  style=\"vertical-align:top\">4.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539413\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">3.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td><td  style=\"vertical-align:top\">4.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741677\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539413\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -26019,8 +26267,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:58.558932Z",
-     "start_time": "2025-09-09T10:20:58.505722Z"
+     "end_time": "2025-12-18T11:19:56.754450953Z",
+     "start_time": "2025-12-18T11:19:56.683121372Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_117_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26031,8 +26284,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:00.685365Z",
-     "start_time": "2025-09-09T10:20:59.536462Z"
+     "end_time": "2025-12-18T11:19:57.126047058Z",
+     "start_time": "2025-12-18T11:19:56.791536294Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_118_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26078,8 +26336,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:02.442214Z",
-     "start_time": "2025-09-09T10:21:01.069826Z"
+     "end_time": "2025-12-18T11:19:57.565043672Z",
+     "start_time": "2025-12-18T11:19:57.140265113Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_119_jupyter",
+      "Line_120_jupyter",
+      "Line_121_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26089,16 +26354,17 @@
     "\n",
     "val days = (start..end).toList()\n",
     "\n",
-    "val dti = days.toColumn(\"dti\")\n",
-    "val s = List(dti.size()) { Random.nextDouble() }.toColumn(\"s\")\n",
-    "val df = dataFrameOf(dti, s)\n",
+    "val df = dataFrameOf(\n",
+    "    \"dti\" to days.toColumn(),\n",
+    "    \"s\" to List(days.size) { Random.nextDouble() }.toColumn()\n",
+    ")\n",
     "df.head()"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_77()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_77\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_77()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_77\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -26277,7 +26543,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741672&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539416&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -26559,11 +26825,11 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-01-01&quot;,&quot;2015-01-02&quot;,&quot;2015-01-03&quot;,&quot;2015-01-04&quot;,&quot;2015-01-05&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.357134&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.981796&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.327260&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.244478&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.880524&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741672, rootId: -1073741672, totalRows: 5 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.799701&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.542949&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.813556&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.898062&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.539191&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539416, rootId: 486539416, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741672) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539416) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -26578,7 +26844,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -26736,14 +27002,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741671\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-01</td><td  style=\"vertical-align:top\">0.357134</td></tr><tr><td  style=\"vertical-align:top\">2015-01-02</td><td  style=\"vertical-align:top\">0.981796</td></tr><tr><td  style=\"vertical-align:top\">2015-01-03</td><td  style=\"vertical-align:top\">0.327260</td></tr><tr><td  style=\"vertical-align:top\">2015-01-04</td><td  style=\"vertical-align:top\">0.244478</td></tr><tr><td  style=\"vertical-align:top\">2015-01-05</td><td  style=\"vertical-align:top\">0.880524</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539417\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-01</td><td  style=\"vertical-align:top\">0.799701</td></tr><tr><td  style=\"vertical-align:top\">2015-01-02</td><td  style=\"vertical-align:top\">0.542949</td></tr><tr><td  style=\"vertical-align:top\">2015-01-03</td><td  style=\"vertical-align:top\">0.813556</td></tr><tr><td  style=\"vertical-align:top\">2015-01-04</td><td  style=\"vertical-align:top\">0.898062</td></tr><tr><td  style=\"vertical-align:top\">2015-01-05</td><td  style=\"vertical-align:top\">0.539191</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741671\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539417\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"dti\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"dti\":\"2015-01-01\",\"s\":0.357134438243794},{\"dti\":\"2015-01-02\",\"s\":0.9817957414685655},{\"dti\":\"2015-01-03\",\"s\":0.3272601693624704},{\"dti\":\"2015-01-04\",\"s\":0.2444781450031347},{\"dti\":\"2015-01-05\",\"s\":0.8805243026418469}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"dti\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"dti\":\"2015-01-01\",\"s\":0.7997012481451563},{\"dti\":\"2015-01-02\",\"s\":0.542948925540349},{\"dti\":\"2015-01-03\",\"s\":0.8135564640710455},{\"dti\":\"2015-01-04\",\"s\":0.8980617499274379},{\"dti\":\"2015-01-05\",\"s\":0.5391906092303334}]}"
      },
      "execution_count": 46,
      "metadata": {},
@@ -26760,8 +27026,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:03.542501Z",
-     "start_time": "2025-09-09T10:21:03.319882Z"
+     "end_time": "2025-12-18T11:19:57.887949175Z",
+     "start_time": "2025-12-18T11:19:57.627409636Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_123_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26770,7 +27041,7 @@
     {
      "data": {
       "text/plain": [
-       "27.452590509515105"
+       "25.543176247723252"
       ]
      },
      "execution_count": 47,
@@ -26788,8 +27059,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:04.646806Z",
-     "start_time": "2025-09-09T10:21:04.342642Z"
+     "end_time": "2025-12-18T11:19:58.114859437Z",
+     "start_time": "2025-12-18T11:19:57.914142752Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_124_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26798,7 +27074,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_79()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_79\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_79()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_79\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -26977,7 +27253,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741668&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539420&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -27259,11 +27535,11 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;month: kotlinx.datetime.Month&bsol;&quot;&gt;month&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;JANUARY&quot;,&quot;FEBRUARY&quot;,&quot;MARCH&quot;,&quot;APRIL&quot;,&quot;MAY&quot;,&quot;JUNE&quot;,&quot;JULY&quot;,&quot;AUGUST&quot;,&quot;SEPTEMBER&quot;,&quot;OCTOBER&quot;,&quot;NOVEMBER&quot;,&quot;DECEMBER&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.473490&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.553154&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.436992&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.418088&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.507365&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.541990&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.528750&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.481131&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.487592&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.425681&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.561784&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.581119&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741668, rootId: -1073741668, totalRows: 12 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.537513&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.524215&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.459084&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.539626&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.425648&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.489793&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.460490&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.433911&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.475016&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.556229&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.396961&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.521459&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539420, rootId: 486539420, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741668) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539420) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -27278,7 +27554,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -27436,14 +27712,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741667\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">month</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">JANUARY</td><td  style=\"vertical-align:top\">0.473490</td></tr><tr><td  style=\"vertical-align:top\">FEBRUARY</td><td  style=\"vertical-align:top\">0.553154</td></tr><tr><td  style=\"vertical-align:top\">MARCH</td><td  style=\"vertical-align:top\">0.436992</td></tr><tr><td  style=\"vertical-align:top\">APRIL</td><td  style=\"vertical-align:top\">0.418088</td></tr><tr><td  style=\"vertical-align:top\">MAY</td><td  style=\"vertical-align:top\">0.507365</td></tr><tr><td  style=\"vertical-align:top\">JUNE</td><td  style=\"vertical-align:top\">0.541990</td></tr><tr><td  style=\"vertical-align:top\">JULY</td><td  style=\"vertical-align:top\">0.528750</td></tr><tr><td  style=\"vertical-align:top\">AUGUST</td><td  style=\"vertical-align:top\">0.481131</td></tr><tr><td  style=\"vertical-align:top\">SEPTEMBER</td><td  style=\"vertical-align:top\">0.487592</td></tr><tr><td  style=\"vertical-align:top\">OCTOBER</td><td  style=\"vertical-align:top\">0.425681</td></tr><tr><td  style=\"vertical-align:top\">NOVEMBER</td><td  style=\"vertical-align:top\">0.561784</td></tr><tr><td  style=\"vertical-align:top\">DECEMBER</td><td  style=\"vertical-align:top\">0.581119</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539421\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">month</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">JANUARY</td><td  style=\"vertical-align:top\">0.537513</td></tr><tr><td  style=\"vertical-align:top\">FEBRUARY</td><td  style=\"vertical-align:top\">0.524215</td></tr><tr><td  style=\"vertical-align:top\">MARCH</td><td  style=\"vertical-align:top\">0.459084</td></tr><tr><td  style=\"vertical-align:top\">APRIL</td><td  style=\"vertical-align:top\">0.539626</td></tr><tr><td  style=\"vertical-align:top\">MAY</td><td  style=\"vertical-align:top\">0.425648</td></tr><tr><td  style=\"vertical-align:top\">JUNE</td><td  style=\"vertical-align:top\">0.489793</td></tr><tr><td  style=\"vertical-align:top\">JULY</td><td  style=\"vertical-align:top\">0.460490</td></tr><tr><td  style=\"vertical-align:top\">AUGUST</td><td  style=\"vertical-align:top\">0.433911</td></tr><tr><td  style=\"vertical-align:top\">SEPTEMBER</td><td  style=\"vertical-align:top\">0.475016</td></tr><tr><td  style=\"vertical-align:top\">OCTOBER</td><td  style=\"vertical-align:top\">0.556229</td></tr><tr><td  style=\"vertical-align:top\">NOVEMBER</td><td  style=\"vertical-align:top\">0.396961</td></tr><tr><td  style=\"vertical-align:top\">DECEMBER</td><td  style=\"vertical-align:top\">0.521459</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741667\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539421\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.Month\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":12,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month\":\"JANUARY\",\"s\":0.47348998916661705},{\"month\":\"FEBRUARY\",\"s\":0.5531539670972504},{\"month\":\"MARCH\",\"s\":0.4369916816007971},{\"month\":\"APRIL\",\"s\":0.4180884808059291},{\"month\":\"MAY\",\"s\":0.507365153168778},{\"month\":\"JUNE\",\"s\":0.5419898168074897},{\"month\":\"JULY\",\"s\":0.5287496128488068},{\"month\":\"AUGUST\",\"s\":0.4811308176003324},{\"month\":\"SEPTEMBER\",\"s\":0.4875916585545935},{\"month\":\"OCTOBER\",\"s\":0.42568119079189526},{\"month\":\"NOVEMBER\",\"s\":0.5617840761646236},{\"month\":\"DECEMBER\",\"s\":0.5811189699208551}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.Month\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":12,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month\":\"JANUARY\",\"s\":0.5375128507100408},{\"month\":\"FEBRUARY\",\"s\":0.5242150349941221},{\"month\":\"MARCH\",\"s\":0.4590837094316621},{\"month\":\"APRIL\",\"s\":0.5396262610274204},{\"month\":\"MAY\",\"s\":0.42564847901454406},{\"month\":\"JUNE\",\"s\":0.48979324892116555},{\"month\":\"JULY\",\"s\":0.4604903807995807},{\"month\":\"AUGUST\",\"s\":0.4339111213149513},{\"month\":\"SEPTEMBER\",\"s\":0.4750157287398121},{\"month\":\"OCTOBER\",\"s\":0.5562291918749319},{\"month\":\"NOVEMBER\",\"s\":0.3969606206218127},{\"month\":\"DECEMBER\",\"s\":0.5214586359388804}]}"
      },
      "execution_count": 48,
      "metadata": {},
@@ -27460,8 +27736,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:05.593856Z",
-     "start_time": "2025-09-09T10:21:05.213184Z"
+     "end_time": "2025-12-18T11:19:58.536299106Z",
+     "start_time": "2025-12-18T11:19:58.230471525Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_126_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -27478,7 +27759,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_80()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_80\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_81()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_81\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -27657,7 +27938,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741666&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539424&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -27939,29 +28220,29 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;month4: Int&bsol;&quot;&gt;month4&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-04-20&quot;,&quot;2015-07-22&quot;,&quot;2015-09-15&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.996142&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.996376&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.998481&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-03-22&quot;,&quot;2015-05-14&quot;,&quot;2015-12-16&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.998280&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.991455&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.999891&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;month4: Int&bsol;&quot;&gt;month4&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;max: DataRow&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-04-20&bsol;ns: 0.996142449438107&bsol;nmonth4: 1&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-04-20&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-07-22&bsol;ns: 0.9963756973660238&bsol;nmonth4: 2&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-07-22&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-09-15&bsol;ns: 0.9984806388730291&bsol;nmonth4: 3&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-09-15&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741666, rootId: -1073741666, totalRows: 3 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;max: DataRow&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-03-22&bsol;ns: 0.9982800125376523&bsol;nmonth4: 1&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-03-22&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-05-14&bsol;ns: 0.9914549696180743&bsol;nmonth4: 2&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-05-14&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-12-16&bsol;ns: 0.9998914835120076&bsol;nmonth4: 3&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-12-16&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539424, rootId: 486539424, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741666) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539424) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_80() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_80\");\n",
-       "                    resize_iframe_out_80(elem);\n",
-       "                    setInterval(resize_iframe_out_80, 5000, elem);\n",
+       "                function o_resize_iframe_out_81() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_81\");\n",
+       "                    resize_iframe_out_81(elem);\n",
+       "                    setInterval(resize_iframe_out_81, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_80(el) {\n",
+       "                function resize_iframe_out_81(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -28119,14 +28400,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741665\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">month4</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">max</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th><th class=\"bottomBorder\" style=\"text-align:left\">month4</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">1</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-04-20</td><td  style=\"vertical-align:top\">0.996142</td><td  style=\"vertical-align:top\">1</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">2</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-07-22</td><td  style=\"vertical-align:top\">0.996376</td><td  style=\"vertical-align:top\">2</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">3</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-09-15</td><td  style=\"vertical-align:top\">0.998481</td><td  style=\"vertical-align:top\">3</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539425\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">month4</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">max</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th><th class=\"bottomBorder\" style=\"text-align:left\">month4</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">1</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-03-22</td><td  style=\"vertical-align:top\">0.998280</td><td  style=\"vertical-align:top\">1</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">2</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-05-14</td><td  style=\"vertical-align:top\">0.991455</td><td  style=\"vertical-align:top\">2</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">3</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-12-16</td><td  style=\"vertical-align:top\">0.999891</td><td  style=\"vertical-align:top\">3</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741665\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539425\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month4\",\"max\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ColumnGroup\"}],\"nrow\":3,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month4\":1,\"max\":{\"data\":{\"dti\":\"2015-04-20\",\"s\":0.996142449438107,\"month4\":1},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":2,\"max\":{\"data\":{\"dti\":\"2015-07-22\",\"s\":0.9963756973660238,\"month4\":2},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":3,\"max\":{\"data\":{\"dti\":\"2015-09-15\",\"s\":0.9984806388730291,\"month4\":3},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month4\",\"max\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ColumnGroup\"}],\"nrow\":3,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month4\":1,\"max\":{\"data\":{\"dti\":\"2015-03-22\",\"s\":0.9982800125376523,\"month4\":1},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":2,\"max\":{\"data\":{\"dti\":\"2015-05-14\",\"s\":0.9914549696180743,\"month4\":2},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":3,\"max\":{\"data\":{\"dti\":\"2015-12-16\",\"s\":0.9998914835120076,\"month4\":3},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}}]}"
      },
      "execution_count": 49,
      "metadata": {},
@@ -28143,8 +28424,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:06.740021Z",
-     "start_time": "2025-09-09T10:21:06.693834Z"
+     "end_time": "2025-12-18T11:19:58.720573737Z",
+     "start_time": "2025-12-18T11:19:58.641394272Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_128_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -28158,8 +28444,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:08.229904Z",
-     "start_time": "2025-09-09T10:21:07.618142Z"
+     "end_time": "2025-12-18T11:19:59.016056372Z",
+     "start_time": "2025-12-18T11:19:58.722834006Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_129_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -28176,7 +28467,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_83()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_83\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_83()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_83\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -28355,7 +28646,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741660&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539428&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;... showing only top 20 of 24 rows&lt;&sol;p&gt;&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;thirdThursday&quot;, type = kotlinx.datetime.LocalDate, size = 24&lt;&sol;p&gt;\n",
        "\n",
@@ -28637,10 +28928,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;thirdThursday: kotlinx.datetime.LocalDate&bsol;&quot;&gt;thirdThursday&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-01-15&quot;,&quot;2015-02-19&quot;,&quot;2015-03-19&quot;,&quot;2015-04-16&quot;,&quot;2015-05-14&quot;,&quot;2015-06-18&quot;,&quot;2015-07-16&quot;,&quot;2015-08-13&quot;,&quot;2015-09-17&quot;,&quot;2015-10-15&quot;,&quot;2015-11-19&quot;,&quot;2015-12-17&quot;,&quot;2016-01-14&quot;,&quot;2016-02-18&quot;,&quot;2016-03-17&quot;,&quot;2016-04-14&quot;,&quot;2016-05-19&quot;,&quot;2016-06-16&quot;,&quot;2016-07-14&quot;,&quot;2016-08-18&quot;] }, \n",
-       "], id: -1073741660, rootId: -1073741660, totalRows: 24 } ) });\n",
+       "], id: 486539428, rootId: 486539428, totalRows: 24 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741660) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539428) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -28655,7 +28946,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -28813,10 +29104,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741659\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">thirdThursday</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-15</td></tr><tr><td  style=\"vertical-align:top\">2015-02-19</td></tr><tr><td  style=\"vertical-align:top\">2015-03-19</td></tr><tr><td  style=\"vertical-align:top\">2015-04-16</td></tr><tr><td  style=\"vertical-align:top\">2015-05-14</td></tr><tr><td  style=\"vertical-align:top\">2015-06-18</td></tr><tr><td  style=\"vertical-align:top\">2015-07-16</td></tr><tr><td  style=\"vertical-align:top\">2015-08-13</td></tr><tr><td  style=\"vertical-align:top\">2015-09-17</td></tr><tr><td  style=\"vertical-align:top\">2015-10-15</td></tr><tr><td  style=\"vertical-align:top\">2015-11-19</td></tr><tr><td  style=\"vertical-align:top\">2015-12-17</td></tr><tr><td  style=\"vertical-align:top\">2016-01-14</td></tr><tr><td  style=\"vertical-align:top\">2016-02-18</td></tr><tr><td  style=\"vertical-align:top\">2016-03-17</td></tr><tr><td  style=\"vertical-align:top\">2016-04-14</td></tr><tr><td  style=\"vertical-align:top\">2016-05-19</td></tr><tr><td  style=\"vertical-align:top\">2016-06-16</td></tr><tr><td  style=\"vertical-align:top\">2016-07-14</td></tr><tr><td  style=\"vertical-align:top\">2016-08-18</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539429\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">thirdThursday</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-15</td></tr><tr><td  style=\"vertical-align:top\">2015-02-19</td></tr><tr><td  style=\"vertical-align:top\">2015-03-19</td></tr><tr><td  style=\"vertical-align:top\">2015-04-16</td></tr><tr><td  style=\"vertical-align:top\">2015-05-14</td></tr><tr><td  style=\"vertical-align:top\">2015-06-18</td></tr><tr><td  style=\"vertical-align:top\">2015-07-16</td></tr><tr><td  style=\"vertical-align:top\">2015-08-13</td></tr><tr><td  style=\"vertical-align:top\">2015-09-17</td></tr><tr><td  style=\"vertical-align:top\">2015-10-15</td></tr><tr><td  style=\"vertical-align:top\">2015-11-19</td></tr><tr><td  style=\"vertical-align:top\">2015-12-17</td></tr><tr><td  style=\"vertical-align:top\">2016-01-14</td></tr><tr><td  style=\"vertical-align:top\">2016-02-18</td></tr><tr><td  style=\"vertical-align:top\">2016-03-17</td></tr><tr><td  style=\"vertical-align:top\">2016-04-14</td></tr><tr><td  style=\"vertical-align:top\">2016-05-19</td></tr><tr><td  style=\"vertical-align:top\">2016-06-16</td></tr><tr><td  style=\"vertical-align:top\">2016-07-14</td></tr><tr><td  style=\"vertical-align:top\">2016-08-18</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741659\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539429\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -28841,12 +29132,12 @@
     "\n",
     "Take this monstrosity of a dataframe to use in the following puzzles:\n",
     "```kotlin\n",
-    "val fromTo = listOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\").toColumn(\"From_To\")\n",
-    "val flightNumber = listOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0).toColumn(\"FlightNumber\")\n",
-    "val recentDelays = listOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)).toColumn(\"RecentDelays\")\n",
-    "val airline = listOf(\"KLM(!)\", \"<Air France> (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\").toColumn(\"Airline\")\n",
-    "\n",
-    "val df = dataFrameOf(fromTo, flightNumber, recentDelays, airline)\n",
+    "var df = dataFrameOf(\n",
+    "    \"From_To\" to columnOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\"),\n",
+    "    \"FlightNumber\" to columnOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0),\n",
+    "    \"RecentDelays\" to columnOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)),\n",
+    "    \"Airline\" to columnOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\"),\n",
+    ")\n",
     "```\n",
     "\n",
     "It looks like this:\n",
@@ -28863,25 +29154,32 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:10.011614Z",
-     "start_time": "2025-09-09T10:21:08.536332Z"
+     "end_time": "2025-12-18T11:19:59.743092247Z",
+     "start_time": "2025-12-18T11:19:59.127837817Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_131_jupyter",
+      "Line_132_jupyter",
+      "Line_133_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val fromTo = listOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\").toColumn(\"From_To\")\n",
-    "val flightNumber = listOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0).toColumn(\"FlightNumber\")\n",
-    "val recentDelays = listOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)).toColumn(\"RecentDelays\")\n",
-    "val airline = listOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\").toColumn(\"Airline\")\n",
-    "\n",
-    "var df = dataFrameOf(fromTo, flightNumber, recentDelays, airline)\n",
+    "var df = dataFrameOf(\n",
+    "    \"From_To\" to columnOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\"),\n",
+    "    \"FlightNumber\" to columnOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0),\n",
+    "    \"RecentDelays\" to columnOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)),\n",
+    "    \"Airline\" to columnOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\"),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_84()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_84\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_85()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_85\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -29060,7 +29358,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741658&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539432&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -29345,25 +29643,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Double&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741658, rootId: -1073741658, totalRows: 5 } ) });\n",
+       "], id: 486539432, rootId: 486539432, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741658) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539432) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_84() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_84\");\n",
-       "                    resize_iframe_out_84(elem);\n",
-       "                    setInterval(resize_iframe_out_84, 5000, elem);\n",
+       "                function o_resize_iframe_out_85() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_85\");\n",
+       "                    resize_iframe_out_85(elem);\n",
+       "                    setInterval(resize_iframe_out_85, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_84(el) {\n",
+       "                function resize_iframe_out_85(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -29521,10 +29819,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741657\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045.000000</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065.000000</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085.000000</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539433\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045.000000</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065.000000</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085.000000</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741657\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539433\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -29549,8 +29847,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:11.999406Z",
-     "start_time": "2025-09-09T10:21:11.582393Z"
+     "end_time": "2025-12-18T11:20:00.173798942Z",
+     "start_time": "2025-12-18T11:19:59.836065273Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_135_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -29564,7 +29867,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_87()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_87\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_87()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_87\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -29743,7 +30046,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741652&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539436&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -30028,10 +30331,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741652, rootId: -1073741652, totalRows: 5 } ) });\n",
+       "], id: 486539436, rootId: 486539436, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741652) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539436) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -30046,7 +30349,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -30204,10 +30507,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741651\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539437\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741651\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539437\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -30233,8 +30536,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:13.245179Z",
-     "start_time": "2025-09-09T10:21:12.639383Z"
+     "end_time": "2025-12-18T11:20:00.606941273Z",
+     "start_time": "2025-12-18T11:20:00.245568490Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_137_jupyter",
+      "Line_138_jupyter",
+      "Line_139_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -30246,7 +30556,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_88()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_88\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_89()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_89\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -30425,7 +30735,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741650&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539440&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -30711,25 +31021,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741650, rootId: -1073741650, totalRows: 5 } ) });\n",
+       "], id: 486539440, rootId: 486539440, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741650) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539440) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_88() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_88\");\n",
-       "                    resize_iframe_out_88(elem);\n",
-       "                    setInterval(resize_iframe_out_88, 5000, elem);\n",
+       "                function o_resize_iframe_out_89() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_89\");\n",
+       "                    resize_iframe_out_89(elem);\n",
+       "                    setInterval(resize_iframe_out_89, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_88(el) {\n",
+       "                function resize_iframe_out_89(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -30887,10 +31197,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741649\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon</td><td  style=\"vertical-align:top\">paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid</td><td  style=\"vertical-align:top\">miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON</td><td  style=\"vertical-align:top\">StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539441\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon</td><td  style=\"vertical-align:top\">paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid</td><td  style=\"vertical-align:top\">miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON</td><td  style=\"vertical-align:top\">StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741649\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539441\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -30914,8 +31224,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:14.533957Z",
-     "start_time": "2025-09-09T10:21:14.142724Z"
+     "end_time": "2025-12-18T11:20:00.993293322Z",
+     "start_time": "2025-12-18T11:20:00.698864044Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_141_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -30927,7 +31242,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_91()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_91\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_91()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_91\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -31106,7 +31421,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741644&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539444&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -31392,10 +31707,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741644, rootId: -1073741644, totalRows: 5 } ) });\n",
+       "], id: 486539444, rootId: 486539444, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741644) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539444) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -31410,7 +31725,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -31568,10 +31883,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741643\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539445\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741643\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539445\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -31595,8 +31910,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:15.418855Z",
-     "start_time": "2025-09-09T10:21:15.048348Z"
+     "end_time": "2025-12-18T11:20:01.328403705Z",
+     "start_time": "2025-12-18T11:20:01.074557822Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_143_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -31610,7 +31930,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_92()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_92\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_93()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_93\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -31789,7 +32109,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741642&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539448&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -32075,25 +32395,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
-       "], id: -1073741642, rootId: -1073741642, totalRows: 5 } ) });\n",
+       "], id: 486539448, rootId: 486539448, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741642) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539448) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_92() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_92\");\n",
-       "                    resize_iframe_out_92(elem);\n",
-       "                    setInterval(resize_iframe_out_92, 5000, elem);\n",
+       "                function o_resize_iframe_out_93() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_93\");\n",
+       "                    resize_iframe_out_93(elem);\n",
+       "                    setInterval(resize_iframe_out_93, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_92(el) {\n",
+       "                function resize_iframe_out_93(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -32251,10 +32571,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741641\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539449\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741641\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539449\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -32281,20 +32601,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:17.414060Z",
-     "start_time": "2025-09-09T10:21:16.638036Z"
+     "end_time": "2025-12-18T11:20:01.740439057Z",
+     "start_time": "2025-12-18T11:20:01.448232137Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_145_jupyter",
+      "Line_146_jupyter",
+      "Line_147_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val prep_df = df2.split { RecentDelays }.into { \"delay_$it\" }\n",
-    "prep_df"
+    "val cleanDf = df2.split { RecentDelays }.into { \"delay_$it\" }\n",
+    "cleanDf"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_95()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_95\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_95()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_95\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -32473,7 +32800,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741636&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539452&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 7&lt;&sol;p&gt;\n",
        "\n",
@@ -32761,10 +33088,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;delay_2: Int?&bsol;&quot;&gt;delay_2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;delay_3: Int?&bsol;&quot;&gt;delay_3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
-       "], id: -1073741636, rootId: -1073741636, totalRows: 5 } ) });\n",
+       "], id: 486539452, rootId: 486539452, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741636) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539452) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -32779,7 +33106,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -32937,10 +33264,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741635\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_3</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539453\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_3</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741635\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539453\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -32956,19 +33283,679 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "The dataframe looks much better now!\n"
+   "source": "Data looks much better now! Now, add a finishing `.renameToCamelCase` to get Kotlin-style identifiers.\n"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:18.101398Z",
-     "start_time": "2025-09-09T10:21:18.097885Z"
+     "end_time": "2025-12-18T11:20:02.082661779Z",
+     "start_time": "2025-12-18T11:20:01.832916739Z"
     }
    },
    "cell_type": "code",
-   "source": "",
-   "outputs": [],
-   "execution_count": null
+   "source": "cleanDf.renameToCamelCase()",
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "            <iframe onload=\"o_resize_iframe_out_97()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_97\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
+       "        &lt;head&gt;\n",
+       "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
+       "                :root {\n",
+       "    --background: #fff;\n",
+       "    --background-odd: #f5f5f5;\n",
+       "    --background-hover: #d9edfd;\n",
+       "    --header-text-color: #474747;\n",
+       "    --text-color: #848484;\n",
+       "    --text-color-dark: #000;\n",
+       "    --text-color-medium: #737373;\n",
+       "    --text-color-pale: #b3b3b3;\n",
+       "    --inner-border-color: #aaa;\n",
+       "    --bold-border-color: #000;\n",
+       "    --link-color: #296eaa;\n",
+       "    --link-color-pale: #296eaa;\n",
+       "    --link-hover: #1a466c;\n",
+       "}\n",
+       "\n",
+       ":root[theme=&quot;dark&quot;], :root [data-jp-theme-light=&quot;false&quot;], .dataframe_dark{\n",
+       "    --background: #303030;\n",
+       "    --background-odd: #3c3c3c;\n",
+       "    --background-hover: #464646;\n",
+       "    --header-text-color: #dddddd;\n",
+       "    --text-color: #b3b3b3;\n",
+       "    --text-color-dark: #dddddd;\n",
+       "    --text-color-medium: #b2b2b2;\n",
+       "    --text-color-pale: #737373;\n",
+       "    --inner-border-color: #707070;\n",
+       "    --bold-border-color: #777777;\n",
+       "    --link-color: #008dc0;\n",
+       "    --link-color-pale: #97e1fb;\n",
+       "    --link-hover: #00688e;\n",
+       "}\n",
+       "\n",
+       "p.dataframe_description {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe {\n",
+       "    font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;\n",
+       "    font-size: 12px;\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--text-color-dark);\n",
+       "    border: none;\n",
+       "    border-collapse: collapse;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th, td {\n",
+       "    padding: 6px;\n",
+       "    border: 1px solid transparent;\n",
+       "    text-align: left;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th {\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--header-text-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td {\n",
+       "    vertical-align: top;\n",
+       "    white-space: nowrap;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.bottomBorder {\n",
+       "    border-bottom-color: var(--bold-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:nth-child(odd) {\n",
+       "    background: var(--background-odd);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:nth-child(even) {\n",
+       "    background: var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:hover {\n",
+       "    background: var(--background-hover);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a {\n",
+       "    cursor: pointer;\n",
+       "    color: var(--link-color);\n",
+       "    text-decoration: none;\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover &gt; td a {\n",
+       "    color: var(--link-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a:hover {\n",
+       "    color: var(--link-hover);\n",
+       "    text-decoration: underline;\n",
+       "}\n",
+       "\n",
+       "table.dataframe img {\n",
+       "    max-width: fit-content;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.complex {\n",
+       "    background-color: var(--background);\n",
+       "    border: 1px solid var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .leftBorder {\n",
+       "    border-left-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightBorder {\n",
+       "    border-right-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightAlign {\n",
+       "    text-align: right;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expanderSvg {\n",
+       "    width: 8px;\n",
+       "    height: 8px;\n",
+       "    margin-right: 3px;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expander {\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "}\n",
+       "\n",
+       "&sol;* formatting *&sol;\n",
+       "\n",
+       "table.dataframe .null {\n",
+       "    color: var(--text-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .structural {\n",
+       "    color: var(--text-color-medium);\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .dataFrameCaption {\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .numbers {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "\n",
+       ":root {\n",
+       "    --scroll-bg: #f5f5f5;\n",
+       "    --scroll-fg: #b3b3b3;\n",
+       "}\n",
+       ":root[theme=&quot;dark&quot;], :root [data-jp-theme-light=&quot;false&quot;]{\n",
+       "    --scroll-bg: #3c3c3c;\n",
+       "    --scroll-fg: #97e1fb;\n",
+       "}\n",
+       "body {\n",
+       "    scrollbar-color: var(--scroll-fg) var(--scroll-bg);\n",
+       "}\n",
+       "body::-webkit-scrollbar {\n",
+       "    width: 10px; &sol;* Mostly for vertical scrollbars *&sol;\n",
+       "    height: 10px; &sol;* Mostly for horizontal scrollbars *&sol;\n",
+       "}\n",
+       "body::-webkit-scrollbar-thumb {\n",
+       "    background-color: var(--scroll-fg);\n",
+       "}\n",
+       "body::-webkit-scrollbar-track {\n",
+       "    background-color: var(--scroll-bg);\n",
+       "}\n",
+       "            &lt;&sol;style&gt;\n",
+       "        &lt;&sol;head&gt;\n",
+       "        &lt;body&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539456&quot;&gt;&lt;&sol;table&gt;\n",
+       "\n",
+       "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 7&lt;&sol;p&gt;\n",
+       "\n",
+       "        &lt;&sol;body&gt;\n",
+       "        &lt;script&gt;\n",
+       "            (function () {\n",
+       "    window.DataFrame = window.DataFrame || new (function () {\n",
+       "        this.addTable = function (df) {\n",
+       "            let cols = df.cols;\n",
+       "            for (let i = 0; i &lt; cols.length; i++) {\n",
+       "                for (let c of cols[i].children) {\n",
+       "                    cols[c].parent = i;\n",
+       "                }\n",
+       "            }\n",
+       "            df.nrow = 0\n",
+       "            for (let i = 0; i &lt; df.cols.length; i++) {\n",
+       "                if (df.cols[i].values.length &gt; df.nrow) df.nrow = df.cols[i].values.length\n",
+       "            }\n",
+       "            if (df.id === df.rootId) {\n",
+       "                df.expandedFrames = new Set()\n",
+       "                df.childFrames = {}\n",
+       "                const table = this.getTableElement(df.id)\n",
+       "                table.df = df\n",
+       "                for (let i = 0; i &lt; df.cols.length; i++) {\n",
+       "                    let col = df.cols[i]\n",
+       "                    if (col.parent === undefined &amp;&amp; col.children.length &gt; 0) col.expanded = true\n",
+       "                }\n",
+       "            } else {\n",
+       "                const rootDf = this.getTableData(df.rootId)\n",
+       "                rootDf.childFrames[df.id] = df\n",
+       "            }\n",
+       "        }\n",
+       "\n",
+       "        this.computeRenderData = function (df) {\n",
+       "            let result = []\n",
+       "            let pos = 0\n",
+       "            for (let col = 0; col &lt; df.cols.length; col++) {\n",
+       "                if (df.cols[col].parent === undefined)\n",
+       "                    pos += this.computeRenderDataRec(df.cols, col, pos, 0, result, false, false)\n",
+       "            }\n",
+       "            for (let i = 0; i &lt; result.length; i++) {\n",
+       "                let row = result[i]\n",
+       "                for (let j = 0; j &lt; row.length; j++) {\n",
+       "                    let cell = row[j]\n",
+       "                    if (j === 0)\n",
+       "                        cell.leftBd = false\n",
+       "                    if (j &lt; row.length - 1) {\n",
+       "                        let nextData = row[j + 1]\n",
+       "                        if (nextData.leftBd) cell.rightBd = true\n",
+       "                        else if (cell.rightBd) nextData.leftBd = true\n",
+       "                    } else cell.rightBd = false\n",
+       "                }\n",
+       "            }\n",
+       "            return result\n",
+       "        }\n",
+       "\n",
+       "        this.computeRenderDataRec = function (cols, colId, pos, depth, result, leftBorder, rightBorder) {\n",
+       "            if (result.length === depth) {\n",
+       "                const array = [];\n",
+       "                if (pos &gt; 0) {\n",
+       "                    let j = 0\n",
+       "                    for (let i = 0; j &lt; pos; i++) {\n",
+       "                        let c = result[depth - 1][i]\n",
+       "                        j += c.span\n",
+       "                        let copy = Object.assign({empty: true}, c)\n",
+       "                        array.push(copy)\n",
+       "                    }\n",
+       "                }\n",
+       "                result.push(array)\n",
+       "            }\n",
+       "            const col = cols[colId];\n",
+       "            let size = 0;\n",
+       "            if (col.expanded) {\n",
+       "                let childPos = pos\n",
+       "                for (let i = 0; i &lt; col.children.length; i++) {\n",
+       "                    let child = col.children[i]\n",
+       "                    let childLeft = i === 0 &amp;&amp; (col.children.length &gt; 1 || leftBorder)\n",
+       "                    let childRight = i === col.children.length - 1 &amp;&amp; (col.children.length &gt; 1 || rightBorder)\n",
+       "                    let childSize = this.computeRenderDataRec(cols, child, childPos, depth + 1, result, childLeft, childRight)\n",
+       "                    childPos += childSize\n",
+       "                    size += childSize\n",
+       "                }\n",
+       "            } else {\n",
+       "                for (let i = depth + 1; i &lt; result.length; i++)\n",
+       "                    result[i].push({id: colId, span: 1, leftBd: leftBorder, rightBd: rightBorder, empty: true})\n",
+       "                size = 1\n",
+       "            }\n",
+       "            let left = leftBorder\n",
+       "            let right = rightBorder\n",
+       "            if (size &gt; 1) {\n",
+       "                left = true\n",
+       "                right = true\n",
+       "            }\n",
+       "            result[depth].push({id: colId, span: size, leftBd: left, rightBd: right})\n",
+       "            return size\n",
+       "        }\n",
+       "\n",
+       "        this.getTableElement = function (id) {\n",
+       "            return document.getElementById(&quot;df_&quot; + id)\n",
+       "        }\n",
+       "\n",
+       "        this.getTableData = function (id) {\n",
+       "            return this.getTableElement(id).df\n",
+       "        }\n",
+       "\n",
+       "        this.createExpander = function (isExpanded) {\n",
+       "            const svgNs = &quot;http:&sol;&sol;www.w3.org&sol;2000&sol;svg&quot;\n",
+       "            let svg = document.createElementNS(svgNs, &quot;svg&quot;)\n",
+       "            svg.classList.add(&quot;expanderSvg&quot;)\n",
+       "            let path = document.createElementNS(svgNs, &quot;path&quot;)\n",
+       "            if (isExpanded) {\n",
+       "                svg.setAttribute(&quot;viewBox&quot;, &quot;0 -2 8 8&quot;)\n",
+       "                path.setAttribute(&quot;d&quot;, &quot;M1 0 l-1 1 4 4 4 -4 -1 -1 -3 3Z&quot;)\n",
+       "            } else {\n",
+       "                svg.setAttribute(&quot;viewBox&quot;, &quot;-2 0 8 8&quot;)\n",
+       "                path.setAttribute(&quot;d&quot;, &quot;M1 0 l-1 1 3 3 -3 3 1 1 4 -4Z&quot;)\n",
+       "            }\n",
+       "            path.setAttribute(&quot;fill&quot;, &quot;currentColor&quot;)\n",
+       "            svg.appendChild(path)\n",
+       "            return svg\n",
+       "        }\n",
+       "\n",
+       "        this.renderTable = function (id) {\n",
+       "\n",
+       "            let table = this.getTableElement(id)\n",
+       "\n",
+       "            if (table === null) return\n",
+       "\n",
+       "            table.innerHTML = &quot;&quot;\n",
+       "\n",
+       "            let df = table.df\n",
+       "            let rootDf = df.rootId === df.id ? df : this.getTableData(df.rootId)\n",
+       "\n",
+       "            &sol;&sol; header\n",
+       "            let header = document.createElement(&quot;thead&quot;)\n",
+       "            table.appendChild(header)\n",
+       "\n",
+       "            let renderData = this.computeRenderData(df)\n",
+       "            for (let j = 0; j &lt; renderData.length; j++) {\n",
+       "                let rowData = renderData[j]\n",
+       "                let tr = document.createElement(&quot;tr&quot;);\n",
+       "                let isLastRow = j === renderData.length - 1\n",
+       "                header.appendChild(tr);\n",
+       "                for (let i = 0; i &lt; rowData.length; i++) {\n",
+       "                    let cell = rowData[i]\n",
+       "                    let th = document.createElement(&quot;th&quot;);\n",
+       "                    th.setAttribute(&quot;colspan&quot;, cell.span)\n",
+       "                    let colId = cell.id\n",
+       "                    let col = df.cols[colId];\n",
+       "                    if (!cell.empty) {\n",
+       "                        if (col.children.length === 0) {\n",
+       "                            th.innerHTML = col.name\n",
+       "                        } else {\n",
+       "                            let link = document.createElement(&quot;a&quot;)\n",
+       "                            link.className = &quot;expander&quot;\n",
+       "                            let that = this\n",
+       "                            link.onclick = function () {\n",
+       "                                col.expanded = !col.expanded\n",
+       "                                that.renderTable(id)\n",
+       "                            }\n",
+       "                            link.appendChild(this.createExpander(col.expanded))\n",
+       "                            link.innerHTML += col.name\n",
+       "                            th.appendChild(link)\n",
+       "                        }\n",
+       "                    }\n",
+       "                    let classes = (cell.leftBd ? &quot; leftBorder&quot; : &quot;&quot;) + (cell.rightBd ? &quot; rightBorder&quot; : &quot;&quot;)\n",
+       "                    if (col.rightAlign)\n",
+       "                        classes += &quot; rightAlign&quot;\n",
+       "                    if (isLastRow)\n",
+       "                        classes += &quot; bottomBorder&quot;\n",
+       "                    if (classes.length &gt; 0)\n",
+       "                        th.setAttribute(&quot;class&quot;, classes)\n",
+       "                    tr.appendChild(th)\n",
+       "                }\n",
+       "            }\n",
+       "\n",
+       "            &sol;&sol; body\n",
+       "            let body = document.createElement(&quot;tbody&quot;)\n",
+       "            table.appendChild(body)\n",
+       "\n",
+       "            let columns = renderData.pop()\n",
+       "            for (let row = 0; row &lt; df.nrow; row++) {\n",
+       "                let tr = document.createElement(&quot;tr&quot;);\n",
+       "                body.appendChild(tr)\n",
+       "                for (let i = 0; i &lt; columns.length; i++) {\n",
+       "                    let cell = columns[i]\n",
+       "                    let td = document.createElement(&quot;td&quot;);\n",
+       "                    let colId = cell.id\n",
+       "                    let col = df.cols[colId]\n",
+       "                    let classes = (cell.leftBd ? &quot; leftBorder&quot; : &quot;&quot;) + (cell.rightBd ? &quot; rightBorder&quot; : &quot;&quot;)\n",
+       "                    if (col.rightAlign)\n",
+       "                        classes += &quot; rightAlign&quot;\n",
+       "                    if (classes.length &gt; 0)\n",
+       "                        td.setAttribute(&quot;class&quot;, classes)\n",
+       "                    tr.appendChild(td)\n",
+       "                    let value = col.values[row]\n",
+       "                    if (value.frameId !== undefined) {\n",
+       "                        let frameId = value.frameId\n",
+       "                        let expanded = rootDf.expandedFrames.has(frameId)\n",
+       "                        let link = document.createElement(&quot;a&quot;)\n",
+       "                        link.className = &quot;expander&quot;\n",
+       "                        let that = this\n",
+       "                        link.onclick = function () {\n",
+       "                            if (rootDf.expandedFrames.has(frameId))\n",
+       "                                rootDf.expandedFrames.delete(frameId)\n",
+       "                            else rootDf.expandedFrames.add(frameId)\n",
+       "                            that.renderTable(id)\n",
+       "                        }\n",
+       "                        link.appendChild(this.createExpander(expanded))\n",
+       "                        link.innerHTML += value.value\n",
+       "                        if (expanded) {\n",
+       "                            td.appendChild(link)\n",
+       "                            td.appendChild(document.createElement(&quot;p&quot;))\n",
+       "                            const childTable = document.createElement(&quot;table&quot;)\n",
+       "                            childTable.className = &quot;dataframe&quot;\n",
+       "                            childTable.id = &quot;df_&quot; + frameId\n",
+       "                            let childDf = rootDf.childFrames[frameId]\n",
+       "                            childTable.df = childDf\n",
+       "                            td.appendChild(childTable)\n",
+       "                            this.renderTable(frameId)\n",
+       "                            if (childDf.nrow !== childDf.totalRows) {\n",
+       "                                const footer = document.createElement(&quot;p&quot;)\n",
+       "                                footer.innerText = `... showing only top ${childDf.nrow} of ${childDf.totalRows} rows`\n",
+       "                                td.appendChild(footer)\n",
+       "                            }\n",
+       "                        } else {\n",
+       "                            td.appendChild(link)\n",
+       "                        }\n",
+       "                    } else if (value.style !== undefined) {\n",
+       "                        td.innerHTML = value.value\n",
+       "                        td.setAttribute(&quot;style&quot;, value.style)\n",
+       "                    } else td.innerHTML = value\n",
+       "                    this.nodeScriptReplace(td)\n",
+       "                }\n",
+       "            }\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptReplace = function (node) {\n",
+       "            if (this.nodeScriptIs(node) === true) {\n",
+       "                node.parentNode.replaceChild(this.nodeScriptClone(node), node);\n",
+       "            } else {\n",
+       "                let i = -1, children = node.childNodes;\n",
+       "                while (++i &lt; children.length) {\n",
+       "                    this.nodeScriptReplace(children[i]);\n",
+       "                }\n",
+       "            }\n",
+       "\n",
+       "            return node;\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptClone = function (node) {\n",
+       "            let script = document.createElement(&quot;script&quot;);\n",
+       "            script.text = node.innerHTML;\n",
+       "\n",
+       "            let i = -1, attrs = node.attributes, attr;\n",
+       "            while (++i &lt; attrs.length) {\n",
+       "                script.setAttribute((attr = attrs[i]).name, attr.value);\n",
+       "            }\n",
+       "            return script;\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptIs = function (node) {\n",
+       "            return node.tagName === 'SCRIPT';\n",
+       "        }\n",
+       "    })()\n",
+       "\n",
+       "    window.call_DataFrame = function (f) {\n",
+       "        return f();\n",
+       "    };\n",
+       "\n",
+       "    let funQueue = window[&quot;kotlinQueues&quot;] &amp;&amp; window[&quot;kotlinQueues&quot;][&quot;DataFrame&quot;];\n",
+       "    if (funQueue) {\n",
+       "        funQueue.forEach(function (f) {\n",
+       "            f();\n",
+       "        });\n",
+       "        funQueue = [];\n",
+       "    }\n",
+       "})()\n",
+       "\n",
+       "&sol;*&lt;!--*&sol;\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;from: String&bsol;&quot;&gt;from&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;London&quot;,&quot;Madrid&quot;,&quot;London&quot;,&quot;Budapest&quot;,&quot;Brussels&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;to: String&bsol;&quot;&gt;to&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;Paris&quot;,&quot;Milan&quot;,&quot;Stockholm&quot;,&quot;Paris&quot;,&quot;London&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;flightNumber: Int&bsol;&quot;&gt;flightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay1: Int?&bsol;&quot;&gt;delay1&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay2: Int?&bsol;&quot;&gt;delay2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay3: Int?&bsol;&quot;&gt;delay3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;airline: String&bsol;&quot;&gt;airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
+       "], id: 486539456, rootId: 486539456, totalRows: 5 } ) });\n",
+       "&sol;*--&gt;*&sol;\n",
+       "\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539456) });\n",
+       "\n",
+       "\n",
+       "        &lt;&sol;script&gt;\n",
+       "        &lt;&sol;html&gt;\"></iframe>\n",
+       "            <script>\n",
+       "                function o_resize_iframe_out_97() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_97\");\n",
+       "                    resize_iframe_out_97(elem);\n",
+       "                    setInterval(resize_iframe_out_97, 5000, elem);\n",
+       "                }\n",
+       "                function resize_iframe_out_97(el) {\n",
+       "                    let h = el.contentWindow.document.body.scrollHeight;\n",
+       "                    el.height = h === 0 ? 0 : h + 41;\n",
+       "                }\n",
+       "            </script>        <html>\n",
+       "        <head>\n",
+       "            <style type=\"text/css\">\n",
+       "                :root {\n",
+       "    --background: #fff;\n",
+       "    --background-odd: #f5f5f5;\n",
+       "    --background-hover: #d9edfd;\n",
+       "    --header-text-color: #474747;\n",
+       "    --text-color: #848484;\n",
+       "    --text-color-dark: #000;\n",
+       "    --text-color-medium: #737373;\n",
+       "    --text-color-pale: #b3b3b3;\n",
+       "    --inner-border-color: #aaa;\n",
+       "    --bold-border-color: #000;\n",
+       "    --link-color: #296eaa;\n",
+       "    --link-color-pale: #296eaa;\n",
+       "    --link-hover: #1a466c;\n",
+       "}\n",
+       "\n",
+       ":root[theme=\"dark\"], :root [data-jp-theme-light=\"false\"], .dataframe_dark{\n",
+       "    --background: #303030;\n",
+       "    --background-odd: #3c3c3c;\n",
+       "    --background-hover: #464646;\n",
+       "    --header-text-color: #dddddd;\n",
+       "    --text-color: #b3b3b3;\n",
+       "    --text-color-dark: #dddddd;\n",
+       "    --text-color-medium: #b2b2b2;\n",
+       "    --text-color-pale: #737373;\n",
+       "    --inner-border-color: #707070;\n",
+       "    --bold-border-color: #777777;\n",
+       "    --link-color: #008dc0;\n",
+       "    --link-color-pale: #97e1fb;\n",
+       "    --link-hover: #00688e;\n",
+       "}\n",
+       "\n",
+       "p.dataframe_description {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe {\n",
+       "    font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n",
+       "    font-size: 12px;\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--text-color-dark);\n",
+       "    border: none;\n",
+       "    border-collapse: collapse;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th, td {\n",
+       "    padding: 6px;\n",
+       "    border: 1px solid transparent;\n",
+       "    text-align: left;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th {\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--header-text-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td {\n",
+       "    vertical-align: top;\n",
+       "    white-space: nowrap;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.bottomBorder {\n",
+       "    border-bottom-color: var(--bold-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:nth-child(odd) {\n",
+       "    background: var(--background-odd);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:nth-child(even) {\n",
+       "    background: var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:hover {\n",
+       "    background: var(--background-hover);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a {\n",
+       "    cursor: pointer;\n",
+       "    color: var(--link-color);\n",
+       "    text-decoration: none;\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover > td a {\n",
+       "    color: var(--link-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a:hover {\n",
+       "    color: var(--link-hover);\n",
+       "    text-decoration: underline;\n",
+       "}\n",
+       "\n",
+       "table.dataframe img {\n",
+       "    max-width: fit-content;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.complex {\n",
+       "    background-color: var(--background);\n",
+       "    border: 1px solid var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .leftBorder {\n",
+       "    border-left-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightBorder {\n",
+       "    border-right-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightAlign {\n",
+       "    text-align: right;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expanderSvg {\n",
+       "    width: 8px;\n",
+       "    height: 8px;\n",
+       "    margin-right: 3px;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expander {\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "}\n",
+       "\n",
+       "/* formatting */\n",
+       "\n",
+       "table.dataframe .null {\n",
+       "    color: var(--text-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .structural {\n",
+       "    color: var(--text-color-medium);\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .dataFrameCaption {\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .numbers {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "\n",
+       "            </style>\n",
+       "        </head>\n",
+       "        <body>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539457\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">from</th><th class=\"bottomBorder\" style=\"text-align:left\">to</th><th class=\"bottomBorder\" style=\"text-align:left\">flightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay3</th><th class=\"bottomBorder\" style=\"text-align:left\">airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "        </body>\n",
+       "        <script>\n",
+       "            document.getElementById(\"static_df_486539457\").style.display = \"none\";\n",
+       "        </script>\n",
+       "        </html>"
+      ],
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"from\",\"to\",\"flightNumber\",\"delay1\",\"delay2\",\"delay3\",\"airline\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"}],\"nrow\":5,\"ncol\":7,\"is_formatted\":false},\"kotlin_dataframe\":[{\"from\":\"London\",\"to\":\"Paris\",\"flightNumber\":10045,\"delay1\":23,\"delay2\":47,\"delay3\":null,\"airline\":\"KLM\"},{\"from\":\"Madrid\",\"to\":\"Milan\",\"flightNumber\":10055,\"delay1\":null,\"delay2\":null,\"delay3\":null,\"airline\":\"Air France\"},{\"from\":\"London\",\"to\":\"Stockholm\",\"flightNumber\":10065,\"delay1\":24,\"delay2\":43,\"delay3\":87,\"airline\":\"British Airways\"},{\"from\":\"Budapest\",\"to\":\"Paris\",\"flightNumber\":10075,\"delay1\":13,\"delay2\":null,\"delay3\":null,\"airline\":\" Air France\"},{\"from\":\"Brussels\",\"to\":\"London\",\"flightNumber\":10085,\"delay1\":67,\"delay2\":32,\"delay3\":null,\"airline\":\"Swiss Air\"}]}"
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 58
   }
  ],
  "metadata": {

--- a/examples/notebooks/puzzles/40 puzzles.ipynb
+++ b/examples/notebooks/puzzles/40 puzzles.ipynb
@@ -22,8 +22,20 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:19:59.395182Z",
-     "start_time": "2025-09-09T10:19:54.390222Z"
+     "end_time": "2025-12-18T11:19:41.542631050Z",
+     "start_time": "2025-12-18T11:19:40.843063224Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_3_jupyter",
+      "Line_4_jupyter",
+      "Line_5_jupyter",
+      "Line_6_jupyter",
+      "Line_7_jupyter",
+      "Line_8_jupyter",
+      "Line_9_jupyter",
+      "Line_10_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -41,10 +53,10 @@
     "\n",
     "Consider the following columns:\n",
     "```[kotlin]\n",
-    "val animal by columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
-    "val age by columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7, 3)\n",
-    "val visits by columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
-    "val priority by columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
+    "columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
+    "columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7, 3)\n",
+    "columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
+    "columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
     "```\n",
     "**2.** Create a DataFrame df from this columns."
    ]
@@ -52,25 +64,32 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:02.727979Z",
-     "start_time": "2025-09-09T10:19:59.649721Z"
+     "end_time": "2025-12-18T11:19:42.256463391Z",
+     "start_time": "2025-12-18T11:19:41.547295069Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_11_jupyter",
+      "Line_12_jupyter",
+      "Line_13_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val animal by columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\")\n",
-    "val age by columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7.0, 3.0)\n",
-    "val visits by columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1)\n",
-    "val priority by columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\")\n",
-    "\n",
-    "val df = dataFrameOf(animal, age, visits, priority)\n",
+    "val df = dataFrameOf(\n",
+    "    \"animal\" to columnOf(\"cat\", \"cat\", \"snake\", \"dog\", \"dog\", \"cat\", \"snake\", \"cat\", \"dog\", \"dog\"),\n",
+    "    \"age\" to columnOf(2.5, 3.0, 0.5, Double.NaN, 5.0, 2.0, 4.5, Double.NaN, 7.0, 3.0),\n",
+    "    \"visits\" to columnOf(1, 3, 2, 3, 2, 3, 1, 1, 2, 1),\n",
+    "    \"priority\" to columnOf(\"yes\", \"yes\", \"no\", \"yes\", \"no\", \"no\", \"no\", \"yes\", \"no\", \"no\"),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_1()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_1\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_1()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_1\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -249,7 +268,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741824&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539264&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -534,10 +553,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741824, rootId: -1073741824, totalRows: 10 } ) });\n",
+       "], id: 486539264, rootId: 486539264, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741824) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539264) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -552,7 +571,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -710,10 +729,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741823\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539265\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741823\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539265\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -734,8 +753,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:03.156449Z",
-     "start_time": "2025-09-09T10:20:03.035219Z"
+     "end_time": "2025-12-18T11:19:42.668067585Z",
+     "start_time": "2025-12-18T11:19:42.493753232Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_15_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -760,8 +784,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:04.574614Z",
-     "start_time": "2025-09-09T10:20:04.227657Z"
+     "end_time": "2025-12-18T11:19:43.024905933Z",
+     "start_time": "2025-12-18T11:19:42.687874922Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_16_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -770,7 +799,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_3()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_3\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_3()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_3\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -949,7 +978,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741820&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539268&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 4, columnsCount = 14&lt;&sol;p&gt;\n",
        "\n",
@@ -1244,10 +1273,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;median: Comparable&lt;*&gt;&bsol;&quot;&gt;median&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;no&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;p75: Comparable&lt;*&gt;&bsol;&quot;&gt;p75&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;yes&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;max: Comparable&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;snake&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;yes&quot;] }, \n",
-       "], id: -1073741820, rootId: -1073741820, totalRows: 4 } ) });\n",
+       "], id: 486539268, rootId: 486539268, totalRows: 4 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741820) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539268) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -1262,7 +1291,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -1420,10 +1449,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741819\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">name</th><th class=\"bottomBorder\" style=\"text-align:left\">type</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th><th class=\"bottomBorder\" style=\"text-align:left\">unique</th><th class=\"bottomBorder\" style=\"text-align:left\">nulls</th><th class=\"bottomBorder\" style=\"text-align:left\">top</th><th class=\"bottomBorder\" style=\"text-align:left\">freq</th><th class=\"bottomBorder\" style=\"text-align:left\">mean</th><th class=\"bottomBorder\" style=\"text-align:left\">std</th><th class=\"bottomBorder\" style=\"text-align:left\">min</th><th class=\"bottomBorder\" style=\"text-align:left\">p25</th><th class=\"bottomBorder\" style=\"text-align:left\">median</th><th class=\"bottomBorder\" style=\"text-align:left\">p75</th><th class=\"bottomBorder\" style=\"text-align:left\">max</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">animal</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">snake</td></tr><tr><td  style=\"vertical-align:top\">age</td><td  style=\"vertical-align:top\">Double</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">8</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">visits</td><td  style=\"vertical-align:top\">Int</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">1.900000</td><td  style=\"vertical-align:top\">0.875595</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">priority</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">yes</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539269\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">name</th><th class=\"bottomBorder\" style=\"text-align:left\">type</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th><th class=\"bottomBorder\" style=\"text-align:left\">unique</th><th class=\"bottomBorder\" style=\"text-align:left\">nulls</th><th class=\"bottomBorder\" style=\"text-align:left\">top</th><th class=\"bottomBorder\" style=\"text-align:left\">freq</th><th class=\"bottomBorder\" style=\"text-align:left\">mean</th><th class=\"bottomBorder\" style=\"text-align:left\">std</th><th class=\"bottomBorder\" style=\"text-align:left\">min</th><th class=\"bottomBorder\" style=\"text-align:left\">p25</th><th class=\"bottomBorder\" style=\"text-align:left\">median</th><th class=\"bottomBorder\" style=\"text-align:left\">p75</th><th class=\"bottomBorder\" style=\"text-align:left\">max</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">animal</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">snake</td></tr><tr><td  style=\"vertical-align:top\">age</td><td  style=\"vertical-align:top\">Double</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">8</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">visits</td><td  style=\"vertical-align:top\">Int</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">1.900000</td><td  style=\"vertical-align:top\">0.875595</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">priority</td><td  style=\"vertical-align:top\">String</td><td  style=\"vertical-align:top\">10</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">no</td><td  style=\"vertical-align:top\">yes</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741819\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539269\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -1444,8 +1473,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:06.002260Z",
-     "start_time": "2025-09-09T10:20:05.722387Z"
+     "end_time": "2025-12-18T11:19:43.282299347Z",
+     "start_time": "2025-12-18T11:19:43.094411261Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_18_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -1464,7 +1498,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_4()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_4\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_5()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_5\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -1643,7 +1677,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741818&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539272&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -1928,25 +1962,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741818, rootId: -1073741818, totalRows: 3 } ) });\n",
+       "], id: 486539272, rootId: 486539272, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741818) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539272) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_4() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_4\");\n",
-       "                    resize_iframe_out_4(elem);\n",
-       "                    setInterval(resize_iframe_out_4, 5000, elem);\n",
+       "                function o_resize_iframe_out_5() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_5\");\n",
+       "                    resize_iframe_out_5(elem);\n",
+       "                    setInterval(resize_iframe_out_5, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_4(el) {\n",
+       "                function resize_iframe_out_5(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -2104,10 +2138,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741817\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539273\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741817\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539273\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -2128,17 +2162,22 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:07.907697Z",
-     "start_time": "2025-09-09T10:20:07.711736Z"
+     "end_time": "2025-12-18T11:19:43.547372659Z",
+     "start_time": "2025-12-18T11:19:43.339126731Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_20_jupyter"
+     ]
     }
    },
    "cell_type": "code",
-   "source": "df[animal, age]",
+   "source": "df.select { animal and age }",
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_7()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_7\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_7()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_7\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -2317,7 +2356,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741812&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539276&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -2600,10 +2639,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;,&quot;dog&quot;,&quot;cat&quot;,&quot;snake&quot;,&quot;cat&quot;,&quot;dog&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741812, rootId: -1073741812, totalRows: 10 } ) });\n",
+       "], id: 486539276, rootId: 486539276, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741812) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539276) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -2618,7 +2657,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -2776,10 +2815,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741811\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539277\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741811\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539277\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -2800,17 +2839,22 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:08.944974Z",
-     "start_time": "2025-09-09T10:20:08.818476Z"
+     "end_time": "2025-12-18T11:19:43.840786386Z",
+     "start_time": "2025-12-18T11:19:43.614032321Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_22_jupyter"
+     ]
     }
    },
    "cell_type": "code",
-   "source": "df[3, 4, 8][animal, age]",
+   "source": "df[3, 4, 8].select { animal and age }",
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_8()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_8\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_9()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_9\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -2989,7 +3033,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741810&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539280&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -3272,25 +3316,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;dog&quot;,&quot;dog&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741810, rootId: -1073741810, totalRows: 3 } ) });\n",
+       "], id: 486539280, rootId: 486539280, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741810) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539280) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_8() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_8\");\n",
-       "                    resize_iframe_out_8(elem);\n",
-       "                    setInterval(resize_iframe_out_8, 5000, elem);\n",
+       "                function o_resize_iframe_out_9() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_9\");\n",
+       "                    resize_iframe_out_9(elem);\n",
+       "                    setInterval(resize_iframe_out_9, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_8(el) {\n",
+       "                function resize_iframe_out_9(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -3448,10 +3492,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741809\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539281\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741809\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539281\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -3472,8 +3516,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:10.601401Z",
-     "start_time": "2025-09-09T10:20:10.368239Z"
+     "end_time": "2025-12-18T11:19:44.130666181Z",
+     "start_time": "2025-12-18T11:19:43.890826650Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_24_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -3482,7 +3531,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_11()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_11\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_11()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_11\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -3661,7 +3710,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741804&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539284&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -3946,10 +3995,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741804, rootId: -1073741804, totalRows: 3 } ) });\n",
+       "], id: 486539284, rootId: 486539284, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741804) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539284) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -3964,7 +4013,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -4122,10 +4171,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741803\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539285\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741803\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539285\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -4146,8 +4195,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:11.365451Z",
-     "start_time": "2025-09-09T10:20:11.155586Z"
+     "end_time": "2025-12-18T11:19:44.432826220Z",
+     "start_time": "2025-12-18T11:19:44.195451619Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_26_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -4156,7 +4210,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_12()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_12\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_13()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_13\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -4335,7 +4389,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741802&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539288&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 2, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -4620,25 +4674,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;] }, \n",
-       "], id: -1073741802, rootId: -1073741802, totalRows: 2 } ) });\n",
+       "], id: 486539288, rootId: 486539288, totalRows: 2 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741802) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539288) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_12() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_12\");\n",
-       "                    resize_iframe_out_12(elem);\n",
-       "                    setInterval(resize_iframe_out_12, 5000, elem);\n",
+       "                function o_resize_iframe_out_13() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_13\");\n",
+       "                    resize_iframe_out_13(elem);\n",
+       "                    setInterval(resize_iframe_out_13, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_12(el) {\n",
+       "                function resize_iframe_out_13(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -4796,10 +4850,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741801\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539289\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741801\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539289\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -4820,8 +4874,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:13.067840Z",
-     "start_time": "2025-09-09T10:20:12.870865Z"
+     "end_time": "2025-12-18T11:19:44.731860002Z",
+     "start_time": "2025-12-18T11:19:44.516203139Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_28_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -4830,7 +4889,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_15()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_15\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_15()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_15\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -5009,7 +5068,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741796&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539292&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 2, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -5294,10 +5353,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741796, rootId: -1073741796, totalRows: 2 } ) });\n",
+       "], id: 486539292, rootId: 486539292, totalRows: 2 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741796) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539292) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -5312,7 +5371,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -5470,10 +5529,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741795\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539293\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741795\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539293\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -5494,8 +5553,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:13.690452Z",
-     "start_time": "2025-09-09T10:20:13.483329Z"
+     "end_time": "2025-12-18T11:19:45.067952922Z",
+     "start_time": "2025-12-18T11:19:44.828539799Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_30_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -5504,7 +5568,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_16()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_16\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_17()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_17\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -5683,7 +5747,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741794&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539296&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 4, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -5968,25 +6032,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741794, rootId: -1073741794, totalRows: 4 } ) });\n",
+       "], id: 486539296, rootId: 486539296, totalRows: 4 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741794) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539296) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_16() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_16\");\n",
-       "                    resize_iframe_out_16(elem);\n",
-       "                    setInterval(resize_iframe_out_16, 5000, elem);\n",
+       "                function o_resize_iframe_out_17() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_17\");\n",
+       "                    resize_iframe_out_17(elem);\n",
+       "                    setInterval(resize_iframe_out_17, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_16(el) {\n",
+       "                function resize_iframe_out_17(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -6144,10 +6208,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741793\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539297\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741793\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539297\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -6168,8 +6232,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:15.695961Z",
-     "start_time": "2025-09-09T10:20:15.204861Z"
+     "end_time": "2025-12-18T11:19:45.321374555Z",
+     "start_time": "2025-12-18T11:19:45.119529698Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_32_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6178,7 +6247,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_19()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_19\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_19()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_19\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -6357,7 +6426,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741788&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539300&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -6642,10 +6711,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741788, rootId: -1073741788, totalRows: 10 } ) });\n",
+       "], id: 486539300, rootId: 486539300, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741788) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539300) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -6660,7 +6729,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -6818,10 +6887,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741787\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">1.500000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539301\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">1.500000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741787\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539301\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -6842,8 +6911,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:16.646710Z",
-     "start_time": "2025-09-09T10:20:16.476888Z"
+     "end_time": "2025-12-18T11:19:45.509286538Z",
+     "start_time": "2025-12-18T11:19:45.377472164Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_34_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6870,8 +6944,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:17.836313Z",
-     "start_time": "2025-09-09T10:20:17.587717Z"
+     "end_time": "2025-12-18T11:19:45.733964446Z",
+     "start_time": "2025-12-18T11:19:45.522355616Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_35_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -6880,7 +6959,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_21()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_21\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_21()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_21\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -7059,7 +7138,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741784&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539304&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -7342,10 +7421,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741784, rootId: -1073741784, totalRows: 3 } ) });\n",
+       "], id: 486539304, rootId: 486539304, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741784) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539304) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -7360,7 +7439,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -7518,10 +7597,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741783\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539305\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2.500000</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741783\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539305\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -7542,8 +7621,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:18.597759Z",
-     "start_time": "2025-09-09T10:20:18.454593Z"
+     "end_time": "2025-12-18T11:19:45.965591312Z",
+     "start_time": "2025-12-18T11:19:45.805912316Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_37_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -7555,7 +7639,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_22()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_22\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_23()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_23\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -7734,7 +7818,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741782&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539308&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -8019,25 +8103,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741782, rootId: -1073741782, totalRows: 10 } ) });\n",
+       "], id: 486539308, rootId: 486539308, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741782) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539308) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_22() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_22\");\n",
-       "                    resize_iframe_out_22(elem);\n",
-       "                    setInterval(resize_iframe_out_22, 5000, elem);\n",
+       "                function o_resize_iframe_out_23() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_23\");\n",
+       "                    resize_iframe_out_23(elem);\n",
+       "                    setInterval(resize_iframe_out_23, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_22(el) {\n",
+       "                function resize_iframe_out_23(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -8195,10 +8279,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741781\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539309\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741781\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539309\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -8219,8 +8303,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:19.769933Z",
-     "start_time": "2025-09-09T10:20:19.591996Z"
+     "end_time": "2025-12-18T11:19:46.367888372Z",
+     "start_time": "2025-12-18T11:19:46.058158419Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_39_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -8229,7 +8318,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_25()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_25\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_25()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_25\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -8408,7 +8497,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741776&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539312&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -8691,10 +8780,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;animal: String&bsol;&quot;&gt;animal&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;cat&quot;,&quot;snake&quot;,&quot;dog&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;count: Int&bsol;&quot;&gt;count&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741776, rootId: -1073741776, totalRows: 3 } ) });\n",
+       "], id: 486539312, rootId: 486539312, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741776) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539312) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -8709,7 +8798,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -8867,10 +8956,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741775\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539313\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">count</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741775\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539313\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -8891,8 +8980,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:20.558950Z",
-     "start_time": "2025-09-09T10:20:20.305732Z"
+     "end_time": "2025-12-18T11:19:46.660623189Z",
+     "start_time": "2025-12-18T11:19:46.449941128Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_41_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -8901,7 +8995,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_26()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_26\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_27()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_27\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -9080,7 +9174,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741774&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539316&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -9365,25 +9459,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741774, rootId: -1073741774, totalRows: 10 } ) });\n",
+       "], id: 486539316, rootId: 486539316, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741774) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539316) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_26() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_26\");\n",
-       "                    resize_iframe_out_26(elem);\n",
-       "                    setInterval(resize_iframe_out_26, 5000, elem);\n",
+       "                function o_resize_iframe_out_27() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_27\");\n",
+       "                    resize_iframe_out_27(elem);\n",
+       "                    setInterval(resize_iframe_out_27, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_26(el) {\n",
+       "                function resize_iframe_out_27(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -9541,10 +9635,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741773\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539317\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741773\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539317\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -9565,8 +9659,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:22.589698Z",
-     "start_time": "2025-09-09T10:20:22.375775Z"
+     "end_time": "2025-12-18T11:19:46.937073806Z",
+     "start_time": "2025-12-18T11:19:46.722579483Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_43_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -9575,7 +9674,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_29()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_29\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_29()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_29\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -9754,7 +9853,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741768&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539320&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -10039,10 +10138,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: Boolean&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;true&quot;,&quot;true&quot;,&quot;false&quot;,&quot;true&quot;,&quot;false&quot;,&quot;false&quot;,&quot;false&quot;,&quot;true&quot;,&quot;false&quot;,&quot;false&quot;] }, \n",
-       "], id: -1073741768, rootId: -1073741768, totalRows: 10 } ) });\n",
+       "], id: 486539320, rootId: 486539320, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741768) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539320) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -10057,7 +10156,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -10215,10 +10314,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741767\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539321\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">true</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">false</td></tr><tr><td  style=\"vertical-align:top\">dog</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">false</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741767\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539321\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -10239,8 +10338,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:23.215530Z",
-     "start_time": "2025-09-09T10:20:23.057774Z"
+     "end_time": "2025-12-18T11:19:47.183097405Z",
+     "start_time": "2025-12-18T11:19:46.992589282Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_45_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -10249,7 +10353,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_30()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_30\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_31()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_31\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -10428,7 +10532,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741766&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539324&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -10713,25 +10817,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;age: Double&bsol;&quot;&gt;age&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: Int&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;priority: String&bsol;&quot;&gt;priority&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;yes&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;,&quot;no&quot;,&quot;yes&quot;,&quot;no&quot;,&quot;no&quot;] }, \n",
-       "], id: -1073741766, rootId: -1073741766, totalRows: 10 } ) });\n",
+       "], id: 486539324, rootId: 486539324, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741766) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539324) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_30() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_30\");\n",
-       "                    resize_iframe_out_30(elem);\n",
-       "                    setInterval(resize_iframe_out_30, 5000, elem);\n",
+       "                function o_resize_iframe_out_31() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_31\");\n",
+       "                    resize_iframe_out_31(elem);\n",
+       "                    setInterval(resize_iframe_out_31, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_30(el) {\n",
+       "                function resize_iframe_out_31(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -10889,10 +10993,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741765\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539325\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">animal</th><th class=\"bottomBorder\" style=\"text-align:left\">age</th><th class=\"bottomBorder\" style=\"text-align:left\">visits</th><th class=\"bottomBorder\" style=\"text-align:left\">priority</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">5.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">snake</td><td  style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">cat</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">yes</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">no</td></tr><tr><td  style=\"vertical-align:top\">corgi</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">no</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741765\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539325\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -10917,8 +11021,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:24.572846Z",
-     "start_time": "2025-09-09T10:20:24.294243Z"
+     "end_time": "2025-12-18T11:19:47.538227593Z",
+     "start_time": "2025-12-18T11:19:47.243994037Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_47_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -10927,7 +11036,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_33()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_33\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_33()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_33\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -11106,7 +11215,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741760&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539328&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -11392,10 +11501,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;3: Double?&bsol;&quot;&gt;3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;2: Double?&bsol;&quot;&gt;2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;visits: DataRow&lt;*&gt;&bsol;&quot;&gt;visits&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 2.5&bsol;n3: 2.5&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;3: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 4.5&bsol;n2: 0.5&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;2: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.5&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;1: 3.0&bsol;n3: NaN&bsol;n2: 6.0&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;1: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;3: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;2: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741760, rootId: -1073741760, totalRows: 3 } ) });\n",
+       "], id: 486539328, rootId: 486539328, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741760) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539328) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -11410,7 +11519,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -11568,10 +11677,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741759\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">animal</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">visits</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">1</th><th class=\"bottomBorder\" style=\"text-align:left\">3</th><th class=\"bottomBorder\" style=\"text-align:left\">2</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">cat</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">null</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">snake</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">dog</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">6.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539329\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">animal</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">visits</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">1</th><th class=\"bottomBorder\" style=\"text-align:left\">3</th><th class=\"bottomBorder\" style=\"text-align:left\">2</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">cat</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">2.500000</td><td  style=\"vertical-align:top\">null</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">snake</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">4.500000</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">0.500000</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">dog</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">6.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741759\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539329\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -11602,7 +11711,7 @@
    "source": [
     "**20.** You have a DataFrame df with a column 'A' of integers. For example:\n",
     "```kotlin\n",
-    "val df = dataFrameOf(\"A\")(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7)\n",
+    "val df = dataFrameOf(\"A\" to columnOf(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7))\n",
     "```\n",
     "How do you filter out rows which contain the same integer as the row immediately above?\n",
     "\n",
@@ -11615,20 +11724,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:25.370850Z",
-     "start_time": "2025-09-09T10:20:25.033558Z"
+     "end_time": "2025-12-18T11:19:47.812973387Z",
+     "start_time": "2025-12-18T11:19:47.592009662Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_49_jupyter",
+      "Line_50_jupyter",
+      "Line_51_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val df = dataFrameOf(\"A\")(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7)\n",
+    "val df = dataFrameOf(\"A\" to columnOf(1, 2, 2, 3, 4, 5, 5, 5, 6, 7, 7))\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_34()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_34\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_35()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_35\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -11807,7 +11923,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741758&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539332&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 11, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -12089,25 +12205,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741758, rootId: -1073741758, totalRows: 11 } ) });\n",
+       "], id: 486539332, rootId: 486539332, totalRows: 11 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741758) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539332) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_34() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_34\");\n",
-       "                    resize_iframe_out_34(elem);\n",
-       "                    setInterval(resize_iframe_out_34, 5000, elem);\n",
+       "                function o_resize_iframe_out_35() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_35\");\n",
+       "                    resize_iframe_out_35(elem);\n",
+       "                    setInterval(resize_iframe_out_35, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_34(el) {\n",
+       "                function resize_iframe_out_35(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -12265,10 +12381,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741757\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539333\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741757\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539333\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -12284,8 +12400,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:26.967333Z",
-     "start_time": "2025-09-09T10:20:26.811413Z"
+     "end_time": "2025-12-18T11:19:48.106029432Z",
+     "start_time": "2025-12-18T11:19:47.883015099Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_53_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -12294,7 +12415,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_37()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_37\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_37()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_37\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -12473,7 +12594,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741752&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539336&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -12755,10 +12876,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741752, rootId: -1073741752, totalRows: 7 } ) });\n",
+       "], id: 486539336, rootId: 486539336, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741752) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539336) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -12773,7 +12894,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -12931,10 +13052,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741751\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539337\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741751\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539337\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -12950,8 +13071,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:27.631518Z",
-     "start_time": "2025-09-09T10:20:27.484179Z"
+     "end_time": "2025-12-18T11:19:48.354220694Z",
+     "start_time": "2025-12-18T11:19:48.153924502Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_55_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -12960,7 +13086,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_38()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_38\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_39()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_39\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -13139,7 +13265,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741750&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539340&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -13421,25 +13547,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741750, rootId: -1073741750, totalRows: 7 } ) });\n",
+       "], id: 486539340, rootId: 486539340, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741750) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539340) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_38() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_38\");\n",
-       "                    resize_iframe_out_38(elem);\n",
-       "                    setInterval(resize_iframe_out_38, 5000, elem);\n",
+       "                function o_resize_iframe_out_39() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_39\");\n",
+       "                    resize_iframe_out_39(elem);\n",
+       "                    setInterval(resize_iframe_out_39, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_38(el) {\n",
+       "                function resize_iframe_out_39(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -13597,10 +13723,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741749\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539341\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741749\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539341\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -13621,8 +13747,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:29.315966Z",
-     "start_time": "2025-09-09T10:20:29.209502Z"
+     "end_time": "2025-12-18T11:19:48.524516883Z",
+     "start_time": "2025-12-18T11:19:48.428439626Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_57_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -13631,7 +13762,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_41()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_41\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_41()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_41\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -13810,7 +13941,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741744&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539344&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 7, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -14092,10 +14223,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;6&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741744, rootId: -1073741744, totalRows: 7 } ) });\n",
+       "], id: 486539344, rootId: 486539344, totalRows: 7 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741744) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539344) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -14110,7 +14241,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -14268,10 +14399,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741743\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539345\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">6</td></tr><tr><td  style=\"vertical-align:top\">7</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741743\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539345\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -14299,8 +14430,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:30.397907Z",
-     "start_time": "2025-09-09T10:20:29.980818Z"
+     "end_time": "2025-12-18T11:19:48.976011050Z",
+     "start_time": "2025-12-18T11:19:48.636984362Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_58_jupyter",
+      "Line_59_jupyter",
+      "Line_60_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -14312,7 +14450,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_42()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_42\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_42()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_42\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -14491,7 +14629,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741742&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539346&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -14772,13 +14910,13 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.476393&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.277764&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.533610&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.992791&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.995942&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.402171&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.439975&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.779849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.634597&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.642784&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.464037&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.331262&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.230575&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.642034&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.082391&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741742, rootId: -1073741742, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.389647&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.788586&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.858807&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.883197&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.931211&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.552994&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.127921&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.673938&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.765814&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.402562&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.853043&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.833489&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.781276&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.929804&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.438368&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539346, rootId: 486539346, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741742) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539346) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -14793,7 +14931,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -14951,14 +15089,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741741\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.476393</td><td  style=\"vertical-align:top\">0.402171</td><td  style=\"vertical-align:top\">0.464037</td></tr><tr><td  style=\"vertical-align:top\">0.277764</td><td  style=\"vertical-align:top\">0.439975</td><td  style=\"vertical-align:top\">0.331262</td></tr><tr><td  style=\"vertical-align:top\">0.533610</td><td  style=\"vertical-align:top\">0.779849</td><td  style=\"vertical-align:top\">0.230575</td></tr><tr><td  style=\"vertical-align:top\">0.992791</td><td  style=\"vertical-align:top\">0.634597</td><td  style=\"vertical-align:top\">0.642034</td></tr><tr><td  style=\"vertical-align:top\">0.995942</td><td  style=\"vertical-align:top\">0.642784</td><td  style=\"vertical-align:top\">0.082391</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539347\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.389647</td><td  style=\"vertical-align:top\">0.552994</td><td  style=\"vertical-align:top\">0.853043</td></tr><tr><td  style=\"vertical-align:top\">0.788586</td><td  style=\"vertical-align:top\">0.127921</td><td  style=\"vertical-align:top\">0.833489</td></tr><tr><td  style=\"vertical-align:top\">0.858807</td><td  style=\"vertical-align:top\">0.673938</td><td  style=\"vertical-align:top\">0.781276</td></tr><tr><td  style=\"vertical-align:top\">0.883197</td><td  style=\"vertical-align:top\">0.765814</td><td  style=\"vertical-align:top\">0.929804</td></tr><tr><td  style=\"vertical-align:top\">0.931211</td><td  style=\"vertical-align:top\">0.402562</td><td  style=\"vertical-align:top\">0.438368</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741741\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539347\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.4763925813135824,\"b\":0.4021705312133531,\"c\":0.464036708774875},{\"a\":0.2777636584540719,\"b\":0.43997477270591434,\"c\":0.33126197700986315},{\"a\":0.5336096049935759,\"b\":0.7798491298160639,\"c\":0.23057468751492816},{\"a\":0.9927906804875166,\"b\":0.6345967324643486,\"c\":0.6420341351149527},{\"a\":0.9959418117402272,\"b\":0.6427843294584921,\"c\":0.08239111462902493}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.38964725344768747,\"b\":0.552993764027322,\"c\":0.8530430376111371},{\"a\":0.7885858820136266,\"b\":0.12792147763728656,\"c\":0.8334889732578966},{\"a\":0.8588073780857777,\"b\":0.673938093076138,\"c\":0.7812759099616297},{\"a\":0.8831974604892261,\"b\":0.765814199023807,\"c\":0.9298044650001936},{\"a\":0.931211129866274,\"b\":0.40256161724758266,\"c\":0.4383683880175443}]}"
      },
      "execution_count": 25,
      "metadata": {},
@@ -14970,8 +15108,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:31.541472Z",
-     "start_time": "2025-09-09T10:20:31.390436Z"
+     "end_time": "2025-12-18T11:19:49.490759745Z",
+     "start_time": "2025-12-18T11:19:49.100396054Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_63_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -14983,7 +15126,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_45()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_45\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_45()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_45\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -15162,7 +15305,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741736&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539352&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -15443,13 +15586,13 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.028859&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.071903&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.018932&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.236317&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.422236&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.045363&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.090308&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.265171&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.121877&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.069079&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.016503&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.018405&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.284103&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.114440&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.491315&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741736, rootId: -1073741736, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.208914&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.205254&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.087467&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.023592&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.340497&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.045568&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.455411&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.097402&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.093791&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.188152&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.254482&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.250157&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.009935&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.070199&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-0.152345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539352, rootId: 486539352, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741736) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539352) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -15464,7 +15607,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -15622,14 +15765,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741735\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.028859</td><td  style=\"vertical-align:top\">-0.045363</td><td  style=\"vertical-align:top\">0.016503</td></tr><tr><td  style=\"vertical-align:top\">-0.071903</td><td  style=\"vertical-align:top\">0.090308</td><td  style=\"vertical-align:top\">-0.018405</td></tr><tr><td  style=\"vertical-align:top\">0.018932</td><td  style=\"vertical-align:top\">0.265171</td><td  style=\"vertical-align:top\">-0.284103</td></tr><tr><td  style=\"vertical-align:top\">0.236317</td><td  style=\"vertical-align:top\">-0.121877</td><td  style=\"vertical-align:top\">-0.114440</td></tr><tr><td  style=\"vertical-align:top\">0.422236</td><td  style=\"vertical-align:top\">0.069079</td><td  style=\"vertical-align:top\">-0.491315</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539353\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-0.208914</td><td  style=\"vertical-align:top\">-0.045568</td><td  style=\"vertical-align:top\">0.254482</td></tr><tr><td  style=\"vertical-align:top\">0.205254</td><td  style=\"vertical-align:top\">-0.455411</td><td  style=\"vertical-align:top\">0.250157</td></tr><tr><td  style=\"vertical-align:top\">0.087467</td><td  style=\"vertical-align:top\">-0.097402</td><td  style=\"vertical-align:top\">0.009935</td></tr><tr><td  style=\"vertical-align:top\">0.023592</td><td  style=\"vertical-align:top\">-0.093791</td><td  style=\"vertical-align:top\">0.070199</td></tr><tr><td  style=\"vertical-align:top\">0.340497</td><td  style=\"vertical-align:top\">-0.188152</td><td  style=\"vertical-align:top\">-0.152345</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741735\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539353\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.028859307546312274,\"b\":-0.045362742553917035,\"c\":0.016503435007604872},{\"a\":-0.07190314426921124,\"b\":0.09030796998263119,\"c\":-0.018404825713420003},{\"a\":0.01893179755205321,\"b\":0.2651713223745412,\"c\":-0.28410311992659454},{\"a\":0.2363168311319106,\"b\":-0.12187711689125746,\"c\":-0.11443971424065336},{\"a\":0.4222360597976458,\"b\":0.06907857751591062,\"c\":-0.4913146373135565}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":3,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":-0.2089140982476947,\"b\":-0.04556758766806013,\"c\":0.25448168591575493},{\"a\":0.20525377104402331,\"b\":-0.4554106333323167,\"c\":0.25015686228829337},{\"a\":0.08746691771126269,\"b\":-0.09740236729837703,\"c\":0.009935449587114675},{\"a\":0.02359208565148385,\"b\":-0.09379117581393526,\"c\":0.0701990901624514},{\"a\":0.3404974181558069,\"b\":-0.1881520944628844,\"c\":-0.15234532369292275}]}"
      },
      "execution_count": 26,
      "metadata": {},
@@ -15654,8 +15797,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:32.627938Z",
-     "start_time": "2025-09-09T10:20:32.029446Z"
+     "end_time": "2025-12-18T11:19:49.906927775Z",
+     "start_time": "2025-12-18T11:19:49.567367152Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_65_jupyter",
+      "Line_66_jupyter",
+      "Line_67_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -15668,7 +15818,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_46()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_46\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_47()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_47\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -15847,7 +15997,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741734&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539356&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -16128,35 +16278,35 @@
        "})()\n",
        "\n",
        "&sol;*&lt;!--*&sol;\n",
-       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.200907&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.756915&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.771118&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.261827&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.752958&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.887191&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.064409&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.988253&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.729440&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.320814&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.254947&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.734192&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.521926&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.209404&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.720208&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;d: Double&bsol;&quot;&gt;d&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.388157&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.110249&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.731664&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.602179&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.767147&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;e: Double&bsol;&quot;&gt;e&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.908765&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.590999&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.022142&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.847507&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.597244&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;f: Double&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.329694&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.704905&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.635532&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.730487&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.057618&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;g: Double&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.952278&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.912019&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.766838&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.126333&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.191310&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.285820&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.652098&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.853087&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.545107&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.203321&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.013636&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.036866&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.906844&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.795482&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.903760&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.095965&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.420558&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.446849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.378680&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.523245&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741734, rootId: -1073741734, totalRows: 5 } ) });\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;a: Double&bsol;&quot;&gt;a&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.841911&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.498208&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.788916&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.553347&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.874932&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;b: Double&bsol;&quot;&gt;b&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.282187&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.847661&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.162458&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.482594&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.162043&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;c: Double&bsol;&quot;&gt;c&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.504844&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.227987&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.183311&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.405461&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.477525&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;d: Double&bsol;&quot;&gt;d&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.316049&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.518230&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.926585&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.369849&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.884059&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;e: Double&bsol;&quot;&gt;e&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.490350&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.126070&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.429727&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.431532&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.292586&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;f: Double&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.593206&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.616324&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.740767&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.177826&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.854866&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;g: Double&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.550719&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.147116&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.930618&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.465287&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.456486&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.814340&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.262463&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.971054&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.262496&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.589303&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.089081&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.323552&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.802308&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.201674&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.140426&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.113149&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.737167&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.230486&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.430214&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.911116&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539356, rootId: 486539356, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741734) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539356) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_46() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_46\");\n",
-       "                    resize_iframe_out_46(elem);\n",
-       "                    setInterval(resize_iframe_out_46, 5000, elem);\n",
+       "                function o_resize_iframe_out_47() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_47\");\n",
+       "                    resize_iframe_out_47(elem);\n",
+       "                    setInterval(resize_iframe_out_47, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_46(el) {\n",
+       "                function resize_iframe_out_47(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -16314,14 +16464,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741733\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.200907</td><td  style=\"vertical-align:top\">0.887191</td><td  style=\"vertical-align:top\">0.254947</td><td  style=\"vertical-align:top\">0.388157</td><td  style=\"vertical-align:top\">0.908765</td><td  style=\"vertical-align:top\">0.329694</td><td  style=\"vertical-align:top\">0.952278</td><td  style=\"vertical-align:top\">0.285820</td><td  style=\"vertical-align:top\">0.013636</td><td  style=\"vertical-align:top\">0.095965</td></tr><tr><td  style=\"vertical-align:top\">0.756915</td><td  style=\"vertical-align:top\">0.064409</td><td  style=\"vertical-align:top\">0.734192</td><td  style=\"vertical-align:top\">0.110249</td><td  style=\"vertical-align:top\">0.590999</td><td  style=\"vertical-align:top\">0.704905</td><td  style=\"vertical-align:top\">0.912019</td><td  style=\"vertical-align:top\">0.652098</td><td  style=\"vertical-align:top\">0.036866</td><td  style=\"vertical-align:top\">0.420558</td></tr><tr><td  style=\"vertical-align:top\">0.771118</td><td  style=\"vertical-align:top\">0.988253</td><td  style=\"vertical-align:top\">0.521926</td><td  style=\"vertical-align:top\">0.731664</td><td  style=\"vertical-align:top\">0.022142</td><td  style=\"vertical-align:top\">0.635532</td><td  style=\"vertical-align:top\">0.766838</td><td  style=\"vertical-align:top\">0.853087</td><td  style=\"vertical-align:top\">0.906844</td><td  style=\"vertical-align:top\">0.446849</td></tr><tr><td  style=\"vertical-align:top\">0.261827</td><td  style=\"vertical-align:top\">0.729440</td><td  style=\"vertical-align:top\">0.209404</td><td  style=\"vertical-align:top\">0.602179</td><td  style=\"vertical-align:top\">0.847507</td><td  style=\"vertical-align:top\">0.730487</td><td  style=\"vertical-align:top\">0.126333</td><td  style=\"vertical-align:top\">0.545107</td><td  style=\"vertical-align:top\">0.795482</td><td  style=\"vertical-align:top\">0.378680</td></tr><tr><td  style=\"vertical-align:top\">0.752958</td><td  style=\"vertical-align:top\">0.320814</td><td  style=\"vertical-align:top\">0.720208</td><td  style=\"vertical-align:top\">0.767147</td><td  style=\"vertical-align:top\">0.597244</td><td  style=\"vertical-align:top\">0.057618</td><td  style=\"vertical-align:top\">0.191310</td><td  style=\"vertical-align:top\">0.203321</td><td  style=\"vertical-align:top\">0.903760</td><td  style=\"vertical-align:top\">0.523245</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539357\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.841911</td><td  style=\"vertical-align:top\">0.282187</td><td  style=\"vertical-align:top\">0.504844</td><td  style=\"vertical-align:top\">0.316049</td><td  style=\"vertical-align:top\">0.490350</td><td  style=\"vertical-align:top\">0.593206</td><td  style=\"vertical-align:top\">0.550719</td><td  style=\"vertical-align:top\">0.814340</td><td  style=\"vertical-align:top\">0.089081</td><td  style=\"vertical-align:top\">0.113149</td></tr><tr><td  style=\"vertical-align:top\">0.498208</td><td  style=\"vertical-align:top\">0.847661</td><td  style=\"vertical-align:top\">0.227987</td><td  style=\"vertical-align:top\">0.518230</td><td  style=\"vertical-align:top\">0.126070</td><td  style=\"vertical-align:top\">0.616324</td><td  style=\"vertical-align:top\">0.147116</td><td  style=\"vertical-align:top\">0.262463</td><td  style=\"vertical-align:top\">0.323552</td><td  style=\"vertical-align:top\">0.737167</td></tr><tr><td  style=\"vertical-align:top\">0.788916</td><td  style=\"vertical-align:top\">0.162458</td><td  style=\"vertical-align:top\">0.183311</td><td  style=\"vertical-align:top\">0.926585</td><td  style=\"vertical-align:top\">0.429727</td><td  style=\"vertical-align:top\">0.740767</td><td  style=\"vertical-align:top\">0.930618</td><td  style=\"vertical-align:top\">0.971054</td><td  style=\"vertical-align:top\">0.802308</td><td  style=\"vertical-align:top\">0.230486</td></tr><tr><td  style=\"vertical-align:top\">0.553347</td><td  style=\"vertical-align:top\">0.482594</td><td  style=\"vertical-align:top\">0.405461</td><td  style=\"vertical-align:top\">0.369849</td><td  style=\"vertical-align:top\">0.431532</td><td  style=\"vertical-align:top\">0.177826</td><td  style=\"vertical-align:top\">0.465287</td><td  style=\"vertical-align:top\">0.262496</td><td  style=\"vertical-align:top\">0.201674</td><td  style=\"vertical-align:top\">0.430214</td></tr><tr><td  style=\"vertical-align:top\">0.874932</td><td  style=\"vertical-align:top\">0.162043</td><td  style=\"vertical-align:top\">0.477525</td><td  style=\"vertical-align:top\">0.884059</td><td  style=\"vertical-align:top\">0.292586</td><td  style=\"vertical-align:top\">0.854866</td><td  style=\"vertical-align:top\">0.456486</td><td  style=\"vertical-align:top\">0.589303</td><td  style=\"vertical-align:top\">0.140426</td><td  style=\"vertical-align:top\">0.911116</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741733\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539357\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":10,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.20090685064331937,\"b\":0.8871912255133791,\"c\":0.2549468111321541,\"d\":0.38815694631380127,\"e\":0.9087653789721286,\"f\":0.3296938927440395,\"g\":0.9522777703806122,\"h\":0.2858200144042208,\"i\":0.013636055573945094,\"j\":0.09596530470652986},{\"a\":0.7569150749029241,\"b\":0.06440905190823076,\"c\":0.7341915384170767,\"d\":0.11024863730405987,\"e\":0.590999032572314,\"f\":0.7049045211724224,\"g\":0.9120191694445311,\"h\":0.6520979901678069,\"i\":0.036866394726266294,\"j\":0.42055787198537553},{\"a\":0.7711179884037822,\"b\":0.9882529014691451,\"c\":0.5219260940599081,\"d\":0.7316640236098008,\"e\":0.02214156003644352,\"f\":0.6355322467903455,\"g\":0.7668379494838335,\"h\":0.8530872406235399,\"i\":0.9068442102269314,\"j\":0.44684852264187824},{\"a\":0.26182665083165513,\"b\":0.7294403477511925,\"c\":0.2094035232312974,\"d\":0.6021794872113193,\"e\":0.8475066241565566,\"f\":0.7304873105946014,\"g\":0.12633259066356395,\"h\":0.5451066654099072,\"i\":0.7954819015909015,\"j\":0.378679721185631},{\"a\":0.7529584519095024,\"b\":0.3208139103643325,\"c\":0.7202083013432629,\"d\":0.767147363074108,\"e\":0.5972443068782157,\"f\":0.05761833328160326,\"g\":0.19130970715775053,\"h\":0.20332141649523094,\"i\":0.9037601846779532,\"j\":0.5232454636011823}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":10,\"is_formatted\":false},\"kotlin_dataframe\":[{\"a\":0.8419114160124052,\"b\":0.282186920782716,\"c\":0.5048443177170018,\"d\":0.31604901017535125,\"e\":0.4903503697680932,\"f\":0.5932062822034694,\"g\":0.5507189032521874,\"h\":0.8143400642944842,\"i\":0.0890806635407565,\"j\":0.11314865188165824},{\"a\":0.49820844533063235,\"b\":0.8476612083057321,\"c\":0.22798742360150803,\"d\":0.5182296202669303,\"e\":0.12607036482076805,\"f\":0.6163241622452882,\"g\":0.1471161686192296,\"h\":0.26246326600812764,\"i\":0.32355220762629744,\"j\":0.7371668074893234},{\"a\":0.788915937670967,\"b\":0.16245843051774012,\"c\":0.18331082327972492,\"d\":0.9265848824100162,\"e\":0.4297273634305062,\"f\":0.7407665914938036,\"g\":0.9306177608421328,\"h\":0.9710544319125589,\"i\":0.802308385674185,\"j\":0.23048565019517087},{\"a\":0.553347476141766,\"b\":0.48259411048976075,\"c\":0.40546089768988547,\"d\":0.3698490765337128,\"e\":0.43153183270372275,\"f\":0.17782580998707898,\"g\":0.465287247289943,\"h\":0.2624963066894521,\"i\":0.20167375143620148,\"j\":0.43021369129837617},{\"a\":0.8749319981380302,\"b\":0.16204312466903636,\"c\":0.4775248119116894,\"d\":0.8840586021809772,\"e\":0.2925857979551013,\"f\":0.8548662347706445,\"g\":0.4564858905910003,\"h\":0.5893027524048042,\"i\":0.1404261330157901,\"j\":0.911116058678073}]}"
      },
      "execution_count": 27,
      "metadata": {},
@@ -16333,8 +16483,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:34.365240Z",
-     "start_time": "2025-09-09T10:20:34.058803Z"
+     "end_time": "2025-12-18T11:19:50.235988942Z",
+     "start_time": "2025-12-18T11:19:49.987687771Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_69_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16343,7 +16498,7 @@
     {
      "data": {
       "text/plain": [
-       "j"
+       "i"
       ]
      },
      "execution_count": 28,
@@ -16361,8 +16516,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:35.327978Z",
-     "start_time": "2025-09-09T10:20:34.825964Z"
+     "end_time": "2025-12-18T11:19:50.387907271Z",
+     "start_time": "2025-12-18T11:19:50.238960093Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_70_jupyter",
+      "Line_71_jupyter",
+      "Line_72_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16374,7 +16536,7 @@
     {
      "data": {
       "text/plain": [
-       "18"
+       "19"
       ]
      },
      "execution_count": 29,
@@ -16398,8 +16560,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:36.465361Z",
-     "start_time": "2025-09-09T10:20:35.654021Z"
+     "end_time": "2025-12-18T11:19:50.641509850Z",
+     "start_time": "2025-12-18T11:19:50.391210050Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_73_jupyter",
+      "Line_74_jupyter",
+      "Line_75_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -16420,7 +16589,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_49()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_49\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_49()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_49\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -16599,7 +16768,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741728&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539360&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -16890,10 +17059,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;h: Double&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.51&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.67&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;i: Double&bsol;&quot;&gt;i&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.76&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.24&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.48&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;j: Double&bsol;&quot;&gt;j&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.01&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.68&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741728, rootId: -1073741728, totalRows: 5 } ) });\n",
+       "], id: 486539360, rootId: 486539360, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741728) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539360) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -16908,7 +17077,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -17066,10 +17235,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741727\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.250000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.430000</td><td  style=\"vertical-align:top\">0.710000</td><td  style=\"vertical-align:top\">0.510000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.670000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">0.160000</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.310000</td><td  style=\"vertical-align:top\">0.400000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.240000</td><td  style=\"vertical-align:top\">0.010000</td></tr><tr><td  style=\"vertical-align:top\">0.490000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.620000</td><td  style=\"vertical-align:top\">0.730000</td><td  style=\"vertical-align:top\">0.260000</td><td  style=\"vertical-align:top\">0.850000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.410000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.050000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.610000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.480000</td><td  style=\"vertical-align:top\">0.680000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539361\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th><th class=\"bottomBorder\" style=\"text-align:left\">i</th><th class=\"bottomBorder\" style=\"text-align:left\">j</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.250000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.430000</td><td  style=\"vertical-align:top\">0.710000</td><td  style=\"vertical-align:top\">0.510000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.040000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.670000</td><td  style=\"vertical-align:top\">0.760000</td><td  style=\"vertical-align:top\">0.160000</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.500000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.310000</td><td  style=\"vertical-align:top\">0.400000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.240000</td><td  style=\"vertical-align:top\">0.010000</td></tr><tr><td  style=\"vertical-align:top\">0.490000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.620000</td><td  style=\"vertical-align:top\">0.730000</td><td  style=\"vertical-align:top\">0.260000</td><td  style=\"vertical-align:top\">0.850000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.410000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.050000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.610000</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">0.480000</td><td  style=\"vertical-align:top\">0.680000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741727\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539361\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -17085,8 +17254,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:37.444264Z",
-     "start_time": "2025-09-09T10:20:36.980547Z"
+     "end_time": "2025-12-18T11:19:51.054313756Z",
+     "start_time": "2025-12-18T11:19:50.738227798Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_77_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -17101,7 +17275,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_50()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_50\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_51()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_51\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -17280,7 +17454,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741726&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539364&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;res&quot;, type = String, size = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -17562,25 +17736,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;res: String&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;e&quot;,&quot;c&quot;,&quot;d&quot;,&quot;h&quot;,&quot;d&quot;] }, \n",
-       "], id: -1073741726, rootId: -1073741726, totalRows: 5 } ) });\n",
+       "], id: 486539364, rootId: 486539364, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741726) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539364) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_50() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_50\");\n",
-       "                    resize_iframe_out_50(elem);\n",
-       "                    setInterval(resize_iframe_out_50, 5000, elem);\n",
+       "                function o_resize_iframe_out_51() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_51\");\n",
+       "                    resize_iframe_out_51(elem);\n",
+       "                    setInterval(resize_iframe_out_51, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_50(el) {\n",
+       "                function resize_iframe_out_51(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -17738,10 +17912,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741725\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">e</td></tr><tr><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">h</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539365\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">e</td></tr><tr><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">h</td></tr><tr><td  style=\"vertical-align:top\">d</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741725\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539365\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -17760,10 +17934,10 @@
    "source": [
     "**25.** A DataFrame has a column of groups 'grps' and a column of integer values 'vals':\n",
     "```kotlin\n",
-    "val grps by column(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\")\n",
-    "val vals by column(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87)\n",
-    "\n",
-    "val df = dataFrameOf(grps, vals)\n",
+    "val df = dataFrameOf(\n",
+    "    \"grps\" to columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\"),\n",
+    "    \"vals\" to columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87),\n",
+    ")\n",
     "```\n",
     "\n",
     "For each group, find the sum of the three greatest values. You should end up with the answer as follows:\n",
@@ -17778,23 +17952,30 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:39.631818Z",
-     "start_time": "2025-09-09T10:20:38.996891Z"
+     "end_time": "2025-12-18T11:19:51.467157852Z",
+     "start_time": "2025-12-18T11:19:51.142193506Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_79_jupyter",
+      "Line_80_jupyter",
+      "Line_81_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val grps by columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\")\n",
-    "val vals by columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87)\n",
-    "\n",
-    "val df = dataFrameOf(grps, vals)\n",
+    "val df = dataFrameOf(\n",
+    "    \"grps\" to columnOf(\"a\", \"a\", \"a\", \"b\", \"b\", \"c\", \"a\", \"a\", \"b\", \"c\", \"c\", \"c\", \"b\", \"b\", \"c\"),\n",
+    "    \"vals\" to columnOf(12, 345, 3, 1, 45, 14, 4, 52, 54, 23, 235, 21, 57, 3, 87),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_52()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_52\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_53()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_53\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -17973,7 +18154,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741722&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539368&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -18256,25 +18437,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;c&quot;,&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;c&quot;,&quot;c&quot;,&quot;c&quot;,&quot;b&quot;,&quot;b&quot;,&quot;c&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;12&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;45&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;54&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;235&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;57&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741722, rootId: -1073741722, totalRows: 15 } ) });\n",
+       "], id: 486539368, rootId: 486539368, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741722) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539368) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_52() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_52\");\n",
-       "                    resize_iframe_out_52(elem);\n",
-       "                    setInterval(resize_iframe_out_52, 5000, elem);\n",
+       "                function o_resize_iframe_out_53() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_53\");\n",
+       "                    resize_iframe_out_53(elem);\n",
+       "                    setInterval(resize_iframe_out_53, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_52(el) {\n",
+       "                function resize_iframe_out_53(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -18432,10 +18613,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741721\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">vals</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">12</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">345</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">45</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">54</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">235</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">21</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">57</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">87</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539369\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">vals</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">12</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">345</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">45</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">54</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">235</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">21</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">57</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">87</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741721\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539369\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -18451,8 +18632,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:40.958555Z",
-     "start_time": "2025-09-09T10:20:40.712890Z"
+     "end_time": "2025-12-18T11:19:51.874156449Z",
+     "start_time": "2025-12-18T11:19:51.536795229Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_83_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -18465,7 +18651,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_55()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_55\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_55()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_55\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -18644,7 +18830,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741716&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539372&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -18927,10 +19113,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;b&quot;,&quot;c&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;res: Int&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;409&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;156&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;345&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741716, rootId: -1073741716, totalRows: 3 } ) });\n",
+       "], id: 486539372, rootId: 486539372, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741716) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539372) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -18945,7 +19131,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -19103,10 +19289,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741715\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">409</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">156</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">345</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539373\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">409</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">156</td></tr><tr><td  style=\"vertical-align:top\">c</td><td  style=\"vertical-align:top\">345</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741715\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539373\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -19147,8 +19333,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:42.098844Z",
-     "start_time": "2025-09-09T10:20:41.524488Z"
+     "end_time": "2025-12-18T11:19:52.289287480Z",
+     "start_time": "2025-12-18T11:19:51.941954661Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_85_jupyter",
+      "Line_86_jupyter",
+      "Line_87_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -19164,7 +19357,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_56()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_56\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_57()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_57\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -19343,7 +19536,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741714&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539376&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;... showing only top 20 of 100 rows&lt;&sol;p&gt;&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 100, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -19626,25 +19819,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: Int&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;34&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;70&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;53&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;80&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;45&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;27&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;70&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;11&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;51&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;46&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;56&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;58&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;48&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;73&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;B: Int&bsol;&quot;&gt;B&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;41&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;33&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;41&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;88&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;68&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;60&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;42&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;29&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;49&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;52&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741714, rootId: -1073741714, totalRows: 100 } ) });\n",
+       "], id: 486539376, rootId: 486539376, totalRows: 100 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741714) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539376) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_56() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_56\");\n",
-       "                    resize_iframe_out_56(elem);\n",
-       "                    setInterval(resize_iframe_out_56, 5000, elem);\n",
+       "                function o_resize_iframe_out_57() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_57\");\n",
+       "                    resize_iframe_out_57(elem);\n",
+       "                    setInterval(resize_iframe_out_57, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_56(el) {\n",
+       "                function resize_iframe_out_57(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -19802,10 +19995,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741713\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">34</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">33</td></tr><tr><td  style=\"vertical-align:top\">22</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">88</td></tr><tr><td  style=\"vertical-align:top\">53</td><td  style=\"vertical-align:top\">68</td></tr><tr><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">59</td></tr><tr><td  style=\"vertical-align:top\">45</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">27</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">8</td></tr><tr><td  style=\"vertical-align:top\">11</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">51</td><td  style=\"vertical-align:top\">60</td></tr><tr><td  style=\"vertical-align:top\">46</td><td  style=\"vertical-align:top\">43</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">17</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">42</td></tr><tr><td  style=\"vertical-align:top\">56</td><td  style=\"vertical-align:top\">29</td></tr><tr><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">49</td></tr><tr><td  style=\"vertical-align:top\">48</td><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">73</td><td  style=\"vertical-align:top\">52</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539377\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">34</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">42</td><td  style=\"vertical-align:top\">33</td></tr><tr><td  style=\"vertical-align:top\">22</td><td  style=\"vertical-align:top\">41</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">88</td></tr><tr><td  style=\"vertical-align:top\">53</td><td  style=\"vertical-align:top\">68</td></tr><tr><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">59</td></tr><tr><td  style=\"vertical-align:top\">45</td><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">27</td><td  style=\"vertical-align:top\">14</td></tr><tr><td  style=\"vertical-align:top\">70</td><td  style=\"vertical-align:top\">8</td></tr><tr><td  style=\"vertical-align:top\">11</td><td  style=\"vertical-align:top\">52</td></tr><tr><td  style=\"vertical-align:top\">51</td><td  style=\"vertical-align:top\">60</td></tr><tr><td  style=\"vertical-align:top\">46</td><td  style=\"vertical-align:top\">43</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">17</td></tr><tr><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">42</td></tr><tr><td  style=\"vertical-align:top\">56</td><td  style=\"vertical-align:top\">29</td></tr><tr><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">49</td></tr><tr><td  style=\"vertical-align:top\">48</td><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">73</td><td  style=\"vertical-align:top\">52</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741713\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539377\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -19821,8 +20014,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:43.816621Z",
-     "start_time": "2025-09-09T10:20:43.416356Z"
+     "end_time": "2025-12-18T11:19:52.799510118Z",
+     "start_time": "2025-12-18T11:19:52.372865385Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_89_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -19835,7 +20033,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_59()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_59\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_59()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_59\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -20014,7 +20212,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741708&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539380&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -20297,10 +20495,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;A: String&bsol;&quot;&gt;A&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;(0, 10]&quot;,&quot;(10, 20]&quot;,&quot;(20, 30]&quot;,&quot;(30, 40]&quot;,&quot;(40, 50]&quot;,&quot;(50, 60]&quot;,&quot;(60, 70]&quot;,&quot;(70, 80]&quot;,&quot;(80, 90]&quot;,&quot;(90, 100]&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;B: Int&bsol;&quot;&gt;B&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;353&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;873&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;321&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;322&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;432&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;754&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;405&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;561&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;657&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;527&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741708, rootId: -1073741708, totalRows: 10 } ) });\n",
+       "], id: 486539380, rootId: 486539380, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741708) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539380) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -20315,7 +20513,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -20473,10 +20671,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741707\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">(0, 10]</td><td  style=\"vertical-align:top\">353</td></tr><tr><td  style=\"vertical-align:top\">(10, 20]</td><td  style=\"vertical-align:top\">873</td></tr><tr><td  style=\"vertical-align:top\">(20, 30]</td><td  style=\"vertical-align:top\">321</td></tr><tr><td  style=\"vertical-align:top\">(30, 40]</td><td  style=\"vertical-align:top\">322</td></tr><tr><td  style=\"vertical-align:top\">(40, 50]</td><td  style=\"vertical-align:top\">432</td></tr><tr><td  style=\"vertical-align:top\">(50, 60]</td><td  style=\"vertical-align:top\">754</td></tr><tr><td  style=\"vertical-align:top\">(60, 70]</td><td  style=\"vertical-align:top\">405</td></tr><tr><td  style=\"vertical-align:top\">(70, 80]</td><td  style=\"vertical-align:top\">561</td></tr><tr><td  style=\"vertical-align:top\">(80, 90]</td><td  style=\"vertical-align:top\">657</td></tr><tr><td  style=\"vertical-align:top\">(90, 100]</td><td  style=\"vertical-align:top\">527</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539381\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">A</th><th class=\"bottomBorder\" style=\"text-align:left\">B</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">(0, 10]</td><td  style=\"vertical-align:top\">353</td></tr><tr><td  style=\"vertical-align:top\">(10, 20]</td><td  style=\"vertical-align:top\">873</td></tr><tr><td  style=\"vertical-align:top\">(20, 30]</td><td  style=\"vertical-align:top\">321</td></tr><tr><td  style=\"vertical-align:top\">(30, 40]</td><td  style=\"vertical-align:top\">322</td></tr><tr><td  style=\"vertical-align:top\">(40, 50]</td><td  style=\"vertical-align:top\">432</td></tr><tr><td  style=\"vertical-align:top\">(50, 60]</td><td  style=\"vertical-align:top\">754</td></tr><tr><td  style=\"vertical-align:top\">(60, 70]</td><td  style=\"vertical-align:top\">405</td></tr><tr><td  style=\"vertical-align:top\">(70, 80]</td><td  style=\"vertical-align:top\">561</td></tr><tr><td  style=\"vertical-align:top\">(80, 90]</td><td  style=\"vertical-align:top\">657</td></tr><tr><td  style=\"vertical-align:top\">(90, 100]</td><td  style=\"vertical-align:top\">527</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741707\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539381\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -20506,7 +20704,7 @@
    "source": [
     "**27.** Consider a DataFrame `df` where there is an integer column 'X':\n",
     "```kotlin\n",
-    "val df = dataFrameOf(\"X\")(7, 2, 0, 3, 4, 2, 5, 0, 3 , 4)\n",
+    "val df = dataFrameOf(\"X\" to columnOf(7, 2, 0, 3, 4, 2, 5, 0, 3, 4))\n",
     "```\n",
     "For each value, count the difference back to the previous zero (or the start of the column, whichever is closer). These values should therefore be\n",
     "\n",
@@ -20520,20 +20718,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:44.400104Z",
-     "start_time": "2025-09-09T10:20:44.117352Z"
+     "end_time": "2025-12-18T11:19:53.262677781Z",
+     "start_time": "2025-12-18T11:19:52.881011560Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_91_jupyter",
+      "Line_92_jupyter",
+      "Line_93_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val df = dataFrameOf(\"X\")(7, 2, 0, 3, 4, 2, 5, 0, 3, 4)\n",
+    "val df = dataFrameOf(\"X\" to columnOf(7, 2, 0, 3, 4, 2, 5, 0, 3, 4))\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_60()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_60\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_61()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_61\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -20712,7 +20917,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741706&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539384&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 10, columnsCount = 1&lt;&sol;p&gt;\n",
        "\n",
@@ -20994,25 +21199,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;X: Int&bsol;&quot;&gt;X&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;5&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741706, rootId: -1073741706, totalRows: 10 } ) });\n",
+       "], id: 486539384, rootId: 486539384, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741706) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539384) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_60() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_60\");\n",
-       "                    resize_iframe_out_60(elem);\n",
-       "                    setInterval(resize_iframe_out_60, 5000, elem);\n",
+       "                function o_resize_iframe_out_61() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_61\");\n",
+       "                    resize_iframe_out_61(elem);\n",
+       "                    setInterval(resize_iframe_out_61, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_60(el) {\n",
+       "                function resize_iframe_out_61(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -21170,10 +21375,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741705\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">X</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539385\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">X</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">7</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">5</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741705\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539385\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -21189,8 +21394,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:46.239893Z",
-     "start_time": "2025-09-09T10:20:46.023751Z"
+     "end_time": "2025-12-18T11:19:53.552737696Z",
+     "start_time": "2025-12-18T11:19:53.347104241Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_95_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -21203,7 +21413,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_62()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_62\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_63()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_63\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -21382,7 +21592,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741702&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539388&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;Y&quot;, type = Int, size = 10&lt;&sol;p&gt;\n",
        "\n",
@@ -21664,25 +21874,25 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;Y: Int&bsol;&quot;&gt;Y&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741702, rootId: -1073741702, totalRows: 10 } ) });\n",
+       "], id: 486539388, rootId: 486539388, totalRows: 10 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741702) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539388) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_62() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_62\");\n",
-       "                    resize_iframe_out_62(elem);\n",
-       "                    setInterval(resize_iframe_out_62, 5000, elem);\n",
+       "                function o_resize_iframe_out_63() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_63\");\n",
+       "                    resize_iframe_out_63(elem);\n",
+       "                    setInterval(resize_iframe_out_63, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_62(el) {\n",
+       "                function resize_iframe_out_63(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -21840,10 +22050,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741701\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">Y</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539389\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">Y</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">3</td></tr><tr><td  style=\"vertical-align:top\">4</td></tr><tr><td  style=\"vertical-align:top\">0</td></tr><tr><td  style=\"vertical-align:top\">1</td></tr><tr><td  style=\"vertical-align:top\">2</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741701\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539389\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -21873,8 +22083,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:47.723910Z",
-     "start_time": "2025-09-09T10:20:46.986249Z"
+     "end_time": "2025-12-18T11:19:54.071017006Z",
+     "start_time": "2025-12-18T11:19:53.641692715Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_97_jupyter",
+      "Line_98_jupyter",
+      "Line_99_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -21889,7 +22106,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_64()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_64\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_65()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_65\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -22068,7 +22285,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741698&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539392&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 8, columnsCount = 8&lt;&sol;p&gt;\n",
        "\n",
@@ -22357,25 +22574,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;f: Int&bsol;&quot;&gt;f&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;59&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;85&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;97&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;35&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;39&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;55&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;97&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;g: Int&bsol;&quot;&gt;g&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;74&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;63&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;80&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;65&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;h: Int&bsol;&quot;&gt;h&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;25&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;81&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;39&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;31&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;38&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741698, rootId: -1073741698, totalRows: 8 } ) });\n",
+       "], id: 486539392, rootId: 486539392, totalRows: 8 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741698) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539392) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_64() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_64\");\n",
-       "                    resize_iframe_out_64(elem);\n",
-       "                    setInterval(resize_iframe_out_64, 5000, elem);\n",
+       "                function o_resize_iframe_out_65() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_65\");\n",
+       "                    resize_iframe_out_65(elem);\n",
+       "                    setInterval(resize_iframe_out_65, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_64(el) {\n",
+       "                function resize_iframe_out_65(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -22533,10 +22750,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741697\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">88</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">85</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">25</td></tr><tr><td  style=\"vertical-align:top\">49</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">52</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">81</td></tr><tr><td  style=\"vertical-align:top\">92</td><td  style=\"vertical-align:top\">41</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">57</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">39</td></tr><tr><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">72</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">50</td><td  style=\"vertical-align:top\">35</td><td  style=\"vertical-align:top\">14</td><td  style=\"vertical-align:top\">31</td></tr><tr><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">33</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">38</td></tr><tr><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">64</td><td  style=\"vertical-align:top\">91</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">76</td><td  style=\"vertical-align:top\">75</td><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">32</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539393\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">a</th><th class=\"bottomBorder\" style=\"text-align:left\">b</th><th class=\"bottomBorder\" style=\"text-align:left\">c</th><th class=\"bottomBorder\" style=\"text-align:left\">d</th><th class=\"bottomBorder\" style=\"text-align:left\">e</th><th class=\"bottomBorder\" style=\"text-align:left\">f</th><th class=\"bottomBorder\" style=\"text-align:left\">g</th><th class=\"bottomBorder\" style=\"text-align:left\">h</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">88</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">23</td></tr><tr><td  style=\"vertical-align:top\">6</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">58</td><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">85</td><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">25</td></tr><tr><td  style=\"vertical-align:top\">49</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">100</td><td  style=\"vertical-align:top\">52</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">81</td></tr><tr><td  style=\"vertical-align:top\">92</td><td  style=\"vertical-align:top\">41</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">57</td><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">63</td><td  style=\"vertical-align:top\">39</td></tr><tr><td  style=\"vertical-align:top\">4</td><td  style=\"vertical-align:top\">59</td><td  style=\"vertical-align:top\">72</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">50</td><td  style=\"vertical-align:top\">35</td><td  style=\"vertical-align:top\">14</td><td  style=\"vertical-align:top\">31</td></tr><tr><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">74</td><td  style=\"vertical-align:top\">33</td><td  style=\"vertical-align:top\">66</td><td  style=\"vertical-align:top\">17</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">38</td></tr><tr><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">64</td><td  style=\"vertical-align:top\">91</td><td  style=\"vertical-align:top\">39</td><td  style=\"vertical-align:top\">80</td><td  style=\"vertical-align:top\">55</td><td  style=\"vertical-align:top\">65</td><td  style=\"vertical-align:top\">2</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">76</td><td  style=\"vertical-align:top\">75</td><td  style=\"vertical-align:top\">18</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">97</td><td  style=\"vertical-align:top\">1</td><td  style=\"vertical-align:top\">32</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741697\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539393\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -22552,8 +22769,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:49.199193Z",
-     "start_time": "2025-09-09T10:20:48.654185Z"
+     "end_time": "2025-12-18T11:19:54.475257403Z",
+     "start_time": "2025-12-18T11:19:54.139804923Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_101_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -22566,7 +22788,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_67()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_67\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_67()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_67\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -22745,7 +22967,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741692&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539396&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -23028,10 +23250,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;index: Int&bsol;&quot;&gt;index&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;name: String&bsol;&quot;&gt;name&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;d&quot;,&quot;c&quot;,&quot;f&quot;] }, \n",
-       "], id: -1073741692, rootId: -1073741692, totalRows: 3 } ) });\n",
+       "], id: 486539396, rootId: 486539396, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741692) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539396) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -23046,7 +23268,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -23204,10 +23426,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741691\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">index</th><th class=\"bottomBorder\" style=\"text-align:left\">name</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">f</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539397\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">index</th><th class=\"bottomBorder\" style=\"text-align:left\">name</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">0</td><td  style=\"vertical-align:top\">d</td></tr><tr><td  style=\"vertical-align:top\">2</td><td  style=\"vertical-align:top\">c</td></tr><tr><td  style=\"vertical-align:top\">3</td><td  style=\"vertical-align:top\">f</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741691\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539397\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -23261,8 +23483,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:50.881413Z",
-     "start_time": "2025-09-09T10:20:49.682553Z"
+     "end_time": "2025-12-18T11:19:55.074975184Z",
+     "start_time": "2025-12-18T11:19:54.581439706Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_103_jupyter",
+      "Line_104_jupyter",
+      "Line_105_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -23280,7 +23509,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_68()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_68\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_69()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_69\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -23459,7 +23688,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741690&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539400&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -23742,25 +23971,25 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;A&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;] }, \n",
-       "], id: -1073741690, rootId: -1073741690, totalRows: 15 } ) });\n",
+       "], id: 486539400, rootId: 486539400, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741690) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539400) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_68() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_68\");\n",
-       "                    resize_iframe_out_68(elem);\n",
-       "                    setInterval(resize_iframe_out_68, 5000, elem);\n",
+       "                function o_resize_iframe_out_69() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_69\");\n",
+       "                    resize_iframe_out_69(elem);\n",
+       "                    setInterval(resize_iframe_out_69, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_68(el) {\n",
+       "                function resize_iframe_out_69(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -23918,10 +24147,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741689\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539401\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741689\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539401\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -23937,8 +24166,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:52.921344Z",
-     "start_time": "2025-09-09T10:20:51.977826Z"
+     "end_time": "2025-12-18T11:19:55.629440336Z",
+     "start_time": "2025-12-18T11:19:55.172126724Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_107_jupyter",
+      "Line_108_jupyter",
+      "Line_109_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -23955,7 +24191,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_70()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_70\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_71()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_71\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -24134,7 +24370,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741686&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539404&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 15, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -24418,25 +24654,25 @@
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;vals: Int&bsol;&quot;&gt;vals&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-17&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-7&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-21&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-14&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-22&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;-19&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;grps: String&bsol;&quot;&gt;grps&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;A&quot;,&quot;A&quot;,&quot;B&quot;,&quot;B&quot;,&quot;A&quot;,&quot;B&quot;,&quot;A&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;patched_values: Any&bsol;&quot;&gt;patched_values&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;28.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;9.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;19.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;16.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;21.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741686, rootId: -1073741686, totalRows: 15 } ) });\n",
+       "], id: 486539404, rootId: 486539404, totalRows: 15 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741686) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539404) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_70() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_70\");\n",
-       "                    resize_iframe_out_70(elem);\n",
-       "                    setInterval(resize_iframe_out_70, 5000, elem);\n",
+       "                function o_resize_iframe_out_71() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_71\");\n",
+       "                    resize_iframe_out_71(elem);\n",
+       "                    setInterval(resize_iframe_out_71, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_70(el) {\n",
+       "                function resize_iframe_out_71(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -24594,10 +24830,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741685\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">patched_values</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">28.000000</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">9.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">19.000000</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">23.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539405\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">vals</th><th class=\"bottomBorder\" style=\"text-align:left\">grps</th><th class=\"bottomBorder\" style=\"text-align:left\">patched_values</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">-17</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-7</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">28</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">28.000000</td></tr><tr><td  style=\"vertical-align:top\">9</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">9.000000</td></tr><tr><td  style=\"vertical-align:top\">16</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-21</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-14</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-22</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">19.000000</td></tr><tr><td  style=\"vertical-align:top\">-2</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">-1</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">16.000000</td></tr><tr><td  style=\"vertical-align:top\">-19</td><td  style=\"vertical-align:top\">B</td><td  style=\"vertical-align:top\">21.000000</td></tr><tr><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">A</td><td  style=\"vertical-align:top\">23.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741685\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539405\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -24616,10 +24852,10 @@
    "source": [
     "**30.** Implement a rolling mean over groups with window size 3, which ignores NaN value. For example, consider the following DataFrame:\n",
     "```kotlin\n",
-    "val group by columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\")\n",
-    "val value by columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0)\n",
-    "\n",
-    "val df = dataFrameOf(group, value)\n",
+    "val df = dataFrameOf(\n",
+    "    \"groups\" to columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\"),\n",
+    "    \"value\" to columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0),\n",
+    ")\n",
     "df\n",
     "\n",
     "group   value\n",
@@ -24658,23 +24894,30 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:55.956419Z",
-     "start_time": "2025-09-09T10:20:54.685746Z"
+     "end_time": "2025-12-18T11:19:56.047538523Z",
+     "start_time": "2025-12-18T11:19:55.719618410Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_111_jupyter",
+      "Line_112_jupyter",
+      "Line_113_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val groups by columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\")\n",
-    "val value by columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0)\n",
-    "\n",
-    "val df = dataFrameOf(groups, value)\n",
+    "val df = dataFrameOf(\n",
+    "    \"groups\" to columnOf(\"a\", \"a\", \"b\", \"b\", \"a\", \"b\", \"b\", \"b\", \"a\", \"b\", \"a\", \"b\"),\n",
+    "    \"value\" to columnOf(1.0, 2.0, 3.0, Double.NaN, 2.0, 3.0, Double.NaN, 1.0, 7.0, 3.0, Double.NaN, 8.0),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_73()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_73\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_73()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_73\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -24853,7 +25096,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741680&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539408&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -25136,10 +25379,10 @@
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;groups: String&bsol;&quot;&gt;groups&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;value: Double&bsol;&quot;&gt;value&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741680, rootId: -1073741680, totalRows: 12 } ) });\n",
+       "], id: 486539408, rootId: 486539408, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741680) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539408) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -25154,7 +25397,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -25312,10 +25555,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741679\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539409\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741679\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539409\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -25331,8 +25574,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:57.287951Z",
-     "start_time": "2025-09-09T10:20:56.616951Z"
+     "end_time": "2025-12-18T11:19:56.601931010Z",
+     "start_time": "2025-12-18T11:19:56.148703247Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_115_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -25348,7 +25596,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_74()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_74\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_75()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_75\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -25527,7 +25775,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741678&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539412&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 3&lt;&sol;p&gt;\n",
        "\n",
@@ -25811,25 +26059,25 @@
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;groups: String&bsol;&quot;&gt;groups&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;a&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;b&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;,&quot;a&quot;,&quot;b&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;value: Double&bsol;&quot;&gt;value&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;7.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;8.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;res: Double&bsol;&quot;&gt;res&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.500000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.666667&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3.666667&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.500000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;4.000000&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741678, rootId: -1073741678, totalRows: 12 } ) });\n",
+       "], id: 486539412, rootId: 486539412, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741678) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539412) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_74() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_74\");\n",
-       "                    resize_iframe_out_74(elem);\n",
-       "                    setInterval(resize_iframe_out_74, 5000, elem);\n",
+       "                function o_resize_iframe_out_75() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_75\");\n",
+       "                    resize_iframe_out_75(elem);\n",
+       "                    setInterval(resize_iframe_out_75, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_74(el) {\n",
+       "                function resize_iframe_out_75(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -25987,10 +26235,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741677\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">3.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td><td  style=\"vertical-align:top\">4.000000</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539413\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">groups</th><th class=\"bottomBorder\" style=\"text-align:left\">value</th><th class=\"bottomBorder\" style=\"text-align:left\">res</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">1.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">2.000000</td><td  style=\"vertical-align:top\">1.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">3.000000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">1.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">7.000000</td><td  style=\"vertical-align:top\">3.666667</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">3.000000</td><td  style=\"vertical-align:top\">2.000000</td></tr><tr><td  style=\"vertical-align:top\">a</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">4.500000</td></tr><tr><td  style=\"vertical-align:top\">b</td><td  style=\"vertical-align:top\">8.000000</td><td  style=\"vertical-align:top\">4.000000</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741677\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539413\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -26019,8 +26267,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:20:58.558932Z",
-     "start_time": "2025-09-09T10:20:58.505722Z"
+     "end_time": "2025-12-18T11:19:56.754450953Z",
+     "start_time": "2025-12-18T11:19:56.683121372Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_117_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26031,8 +26284,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:00.685365Z",
-     "start_time": "2025-09-09T10:20:59.536462Z"
+     "end_time": "2025-12-18T11:19:57.126047058Z",
+     "start_time": "2025-12-18T11:19:56.791536294Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_118_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26078,8 +26336,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:02.442214Z",
-     "start_time": "2025-09-09T10:21:01.069826Z"
+     "end_time": "2025-12-18T11:19:57.565043672Z",
+     "start_time": "2025-12-18T11:19:57.140265113Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_119_jupyter",
+      "Line_120_jupyter",
+      "Line_121_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26089,16 +26354,17 @@
     "\n",
     "val days = (start..end).toList()\n",
     "\n",
-    "val dti = days.toColumn(\"dti\")\n",
-    "val s = List(dti.size()) { Random.nextDouble() }.toColumn(\"s\")\n",
-    "val df = dataFrameOf(dti, s)\n",
+    "val df = dataFrameOf(\n",
+    "    \"dti\" to days.toColumn(),\n",
+    "    \"s\" to List(days.size) { Random.nextDouble() }.toColumn()\n",
+    ")\n",
     "df.head()"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_77()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_77\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_77()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_77\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -26277,7 +26543,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741672&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539416&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -26559,11 +26825,11 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-01-01&quot;,&quot;2015-01-02&quot;,&quot;2015-01-03&quot;,&quot;2015-01-04&quot;,&quot;2015-01-05&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.357134&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.981796&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.327260&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.244478&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.880524&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741672, rootId: -1073741672, totalRows: 5 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.799701&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.542949&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.813556&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.898062&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.539191&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539416, rootId: 486539416, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741672) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539416) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -26578,7 +26844,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -26736,14 +27002,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741671\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-01</td><td  style=\"vertical-align:top\">0.357134</td></tr><tr><td  style=\"vertical-align:top\">2015-01-02</td><td  style=\"vertical-align:top\">0.981796</td></tr><tr><td  style=\"vertical-align:top\">2015-01-03</td><td  style=\"vertical-align:top\">0.327260</td></tr><tr><td  style=\"vertical-align:top\">2015-01-04</td><td  style=\"vertical-align:top\">0.244478</td></tr><tr><td  style=\"vertical-align:top\">2015-01-05</td><td  style=\"vertical-align:top\">0.880524</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539417\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-01</td><td  style=\"vertical-align:top\">0.799701</td></tr><tr><td  style=\"vertical-align:top\">2015-01-02</td><td  style=\"vertical-align:top\">0.542949</td></tr><tr><td  style=\"vertical-align:top\">2015-01-03</td><td  style=\"vertical-align:top\">0.813556</td></tr><tr><td  style=\"vertical-align:top\">2015-01-04</td><td  style=\"vertical-align:top\">0.898062</td></tr><tr><td  style=\"vertical-align:top\">2015-01-05</td><td  style=\"vertical-align:top\">0.539191</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741671\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539417\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"dti\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"dti\":\"2015-01-01\",\"s\":0.357134438243794},{\"dti\":\"2015-01-02\",\"s\":0.9817957414685655},{\"dti\":\"2015-01-03\",\"s\":0.3272601693624704},{\"dti\":\"2015-01-04\",\"s\":0.2444781450031347},{\"dti\":\"2015-01-05\",\"s\":0.8805243026418469}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"dti\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":5,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"dti\":\"2015-01-01\",\"s\":0.7997012481451563},{\"dti\":\"2015-01-02\",\"s\":0.542948925540349},{\"dti\":\"2015-01-03\",\"s\":0.8135564640710455},{\"dti\":\"2015-01-04\",\"s\":0.8980617499274379},{\"dti\":\"2015-01-05\",\"s\":0.5391906092303334}]}"
      },
      "execution_count": 46,
      "metadata": {},
@@ -26760,8 +27026,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:03.542501Z",
-     "start_time": "2025-09-09T10:21:03.319882Z"
+     "end_time": "2025-12-18T11:19:57.887949175Z",
+     "start_time": "2025-12-18T11:19:57.627409636Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_123_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26770,7 +27041,7 @@
     {
      "data": {
       "text/plain": [
-       "27.452590509515105"
+       "25.543176247723252"
       ]
      },
      "execution_count": 47,
@@ -26788,8 +27059,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:04.646806Z",
-     "start_time": "2025-09-09T10:21:04.342642Z"
+     "end_time": "2025-12-18T11:19:58.114859437Z",
+     "start_time": "2025-12-18T11:19:57.914142752Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_124_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -26798,7 +27074,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_79()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_79\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_79()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_79\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -26977,7 +27253,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741668&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539420&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 12, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -27259,11 +27535,11 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;month: kotlinx.datetime.Month&bsol;&quot;&gt;month&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;JANUARY&quot;,&quot;FEBRUARY&quot;,&quot;MARCH&quot;,&quot;APRIL&quot;,&quot;MAY&quot;,&quot;JUNE&quot;,&quot;JULY&quot;,&quot;AUGUST&quot;,&quot;SEPTEMBER&quot;,&quot;OCTOBER&quot;,&quot;NOVEMBER&quot;,&quot;DECEMBER&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.473490&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.553154&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.436992&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.418088&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.507365&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.541990&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.528750&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.481131&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.487592&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.425681&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.561784&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.581119&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741668, rootId: -1073741668, totalRows: 12 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.537513&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.524215&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.459084&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.539626&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.425648&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.489793&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.460490&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.433911&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.475016&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.556229&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.396961&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.521459&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539420, rootId: 486539420, totalRows: 12 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741668) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539420) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -27278,7 +27554,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -27436,14 +27712,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741667\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">month</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">JANUARY</td><td  style=\"vertical-align:top\">0.473490</td></tr><tr><td  style=\"vertical-align:top\">FEBRUARY</td><td  style=\"vertical-align:top\">0.553154</td></tr><tr><td  style=\"vertical-align:top\">MARCH</td><td  style=\"vertical-align:top\">0.436992</td></tr><tr><td  style=\"vertical-align:top\">APRIL</td><td  style=\"vertical-align:top\">0.418088</td></tr><tr><td  style=\"vertical-align:top\">MAY</td><td  style=\"vertical-align:top\">0.507365</td></tr><tr><td  style=\"vertical-align:top\">JUNE</td><td  style=\"vertical-align:top\">0.541990</td></tr><tr><td  style=\"vertical-align:top\">JULY</td><td  style=\"vertical-align:top\">0.528750</td></tr><tr><td  style=\"vertical-align:top\">AUGUST</td><td  style=\"vertical-align:top\">0.481131</td></tr><tr><td  style=\"vertical-align:top\">SEPTEMBER</td><td  style=\"vertical-align:top\">0.487592</td></tr><tr><td  style=\"vertical-align:top\">OCTOBER</td><td  style=\"vertical-align:top\">0.425681</td></tr><tr><td  style=\"vertical-align:top\">NOVEMBER</td><td  style=\"vertical-align:top\">0.561784</td></tr><tr><td  style=\"vertical-align:top\">DECEMBER</td><td  style=\"vertical-align:top\">0.581119</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539421\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">month</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">JANUARY</td><td  style=\"vertical-align:top\">0.537513</td></tr><tr><td  style=\"vertical-align:top\">FEBRUARY</td><td  style=\"vertical-align:top\">0.524215</td></tr><tr><td  style=\"vertical-align:top\">MARCH</td><td  style=\"vertical-align:top\">0.459084</td></tr><tr><td  style=\"vertical-align:top\">APRIL</td><td  style=\"vertical-align:top\">0.539626</td></tr><tr><td  style=\"vertical-align:top\">MAY</td><td  style=\"vertical-align:top\">0.425648</td></tr><tr><td  style=\"vertical-align:top\">JUNE</td><td  style=\"vertical-align:top\">0.489793</td></tr><tr><td  style=\"vertical-align:top\">JULY</td><td  style=\"vertical-align:top\">0.460490</td></tr><tr><td  style=\"vertical-align:top\">AUGUST</td><td  style=\"vertical-align:top\">0.433911</td></tr><tr><td  style=\"vertical-align:top\">SEPTEMBER</td><td  style=\"vertical-align:top\">0.475016</td></tr><tr><td  style=\"vertical-align:top\">OCTOBER</td><td  style=\"vertical-align:top\">0.556229</td></tr><tr><td  style=\"vertical-align:top\">NOVEMBER</td><td  style=\"vertical-align:top\">0.396961</td></tr><tr><td  style=\"vertical-align:top\">DECEMBER</td><td  style=\"vertical-align:top\">0.521459</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741667\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539421\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.Month\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":12,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month\":\"JANUARY\",\"s\":0.47348998916661705},{\"month\":\"FEBRUARY\",\"s\":0.5531539670972504},{\"month\":\"MARCH\",\"s\":0.4369916816007971},{\"month\":\"APRIL\",\"s\":0.4180884808059291},{\"month\":\"MAY\",\"s\":0.507365153168778},{\"month\":\"JUNE\",\"s\":0.5419898168074897},{\"month\":\"JULY\",\"s\":0.5287496128488068},{\"month\":\"AUGUST\",\"s\":0.4811308176003324},{\"month\":\"SEPTEMBER\",\"s\":0.4875916585545935},{\"month\":\"OCTOBER\",\"s\":0.42568119079189526},{\"month\":\"NOVEMBER\",\"s\":0.5617840761646236},{\"month\":\"DECEMBER\",\"s\":0.5811189699208551}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month\",\"s\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.Month\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"}],\"nrow\":12,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month\":\"JANUARY\",\"s\":0.5375128507100408},{\"month\":\"FEBRUARY\",\"s\":0.5242150349941221},{\"month\":\"MARCH\",\"s\":0.4590837094316621},{\"month\":\"APRIL\",\"s\":0.5396262610274204},{\"month\":\"MAY\",\"s\":0.42564847901454406},{\"month\":\"JUNE\",\"s\":0.48979324892116555},{\"month\":\"JULY\",\"s\":0.4604903807995807},{\"month\":\"AUGUST\",\"s\":0.4339111213149513},{\"month\":\"SEPTEMBER\",\"s\":0.4750157287398121},{\"month\":\"OCTOBER\",\"s\":0.5562291918749319},{\"month\":\"NOVEMBER\",\"s\":0.3969606206218127},{\"month\":\"DECEMBER\",\"s\":0.5214586359388804}]}"
      },
      "execution_count": 48,
      "metadata": {},
@@ -27460,8 +27736,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:05.593856Z",
-     "start_time": "2025-09-09T10:21:05.213184Z"
+     "end_time": "2025-12-18T11:19:58.536299106Z",
+     "start_time": "2025-12-18T11:19:58.230471525Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_126_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -27478,7 +27759,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_80()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_80\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_81()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_81\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -27657,7 +27938,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741666&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539424&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 3, columnsCount = 2&lt;&sol;p&gt;\n",
        "\n",
@@ -27939,29 +28220,29 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;month4: Int&bsol;&quot;&gt;month4&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-04-20&quot;,&quot;2015-07-22&quot;,&quot;2015-09-15&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.996142&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.996376&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.998481&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;dti: kotlinx.datetime.LocalDate&bsol;&quot;&gt;dti&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-03-22&quot;,&quot;2015-05-14&quot;,&quot;2015-12-16&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;s: Double&bsol;&quot;&gt;s&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.998280&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.991455&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;0.999891&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;month4: Int&bsol;&quot;&gt;month4&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "{ name: &quot;&lt;span title=&bsol;&quot;max: DataRow&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-04-20&bsol;ns: 0.996142449438107&bsol;nmonth4: 1&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-04-20&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-07-22&bsol;ns: 0.9963756973660238&bsol;nmonth4: 2&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-07-22&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-09-15&bsol;ns: 0.9984806388730291&bsol;nmonth4: 3&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-09-15&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
-       "], id: -1073741666, rootId: -1073741666, totalRows: 3 } ) });\n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;max: DataRow&lt;*&gt;&bsol;&quot;&gt;max&lt;&sol;span&gt;&quot;, children: [1, 2, 3], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-03-22&bsol;ns: 0.9982800125376523&bsol;nmonth4: 1&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-03-22&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-05-14&bsol;ns: 0.9914549696180743&bsol;nmonth4: 2&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-05-14&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;2&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;dti: 2015-12-16&bsol;ns: 0.9998914835120076&bsol;nmonth4: 3&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;{ &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;dti: &lt;&sol;span&gt;2015-12-16&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;s: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;1.0&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;month4: &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;3&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt; }&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "], id: 486539424, rootId: 486539424, totalRows: 3 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741666) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539424) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_80() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_80\");\n",
-       "                    resize_iframe_out_80(elem);\n",
-       "                    setInterval(resize_iframe_out_80, 5000, elem);\n",
+       "                function o_resize_iframe_out_81() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_81\");\n",
+       "                    resize_iframe_out_81(elem);\n",
+       "                    setInterval(resize_iframe_out_81, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_80(el) {\n",
+       "                function resize_iframe_out_81(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -28119,14 +28400,14 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741665\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">month4</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">max</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th><th class=\"bottomBorder\" style=\"text-align:left\">month4</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">1</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-04-20</td><td  style=\"vertical-align:top\">0.996142</td><td  style=\"vertical-align:top\">1</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">2</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-07-22</td><td  style=\"vertical-align:top\">0.996376</td><td  style=\"vertical-align:top\">2</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">3</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-09-15</td><td  style=\"vertical-align:top\">0.998481</td><td  style=\"vertical-align:top\">3</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539425\"><thead><tr><th class=\"rightBorder\" style=\"text-align:left\">month4</th><th class=\"rightBorder leftBorder\" style=\"text-align:left\">max</th><th  style=\"text-align:left\"></th><th  style=\"text-align:left\"></th></tr><tr><th class=\"bottomBorder rightBorder\" style=\"text-align:left\"></th><th class=\"bottomBorder rightBorder leftBorder\" style=\"text-align:left\">dti</th><th class=\"bottomBorder\" style=\"text-align:left\">s</th><th class=\"bottomBorder\" style=\"text-align:left\">month4</th></tr></thead><tbody><tr><td class=\"rightBorder\" style=\"vertical-align:top\">1</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-03-22</td><td  style=\"vertical-align:top\">0.998280</td><td  style=\"vertical-align:top\">1</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">2</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-05-14</td><td  style=\"vertical-align:top\">0.991455</td><td  style=\"vertical-align:top\">2</td></tr><tr><td class=\"rightBorder\" style=\"vertical-align:top\">3</td><td class=\"rightBorder leftBorder\" style=\"vertical-align:top\">2015-12-16</td><td  style=\"vertical-align:top\">0.999891</td><td  style=\"vertical-align:top\">3</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741665\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539425\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
-      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month4\",\"max\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ColumnGroup\"}],\"nrow\":3,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month4\":1,\"max\":{\"data\":{\"dti\":\"2015-04-20\",\"s\":0.996142449438107,\"month4\":1},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":2,\"max\":{\"data\":{\"dti\":\"2015-07-22\",\"s\":0.9963756973660238,\"month4\":2},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":3,\"max\":{\"data\":{\"dti\":\"2015-09-15\",\"s\":0.9984806388730291,\"month4\":3},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}}]}"
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"month4\",\"max\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ColumnGroup\"}],\"nrow\":3,\"ncol\":2,\"is_formatted\":false},\"kotlin_dataframe\":[{\"month4\":1,\"max\":{\"data\":{\"dti\":\"2015-03-22\",\"s\":0.9982800125376523,\"month4\":1},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":2,\"max\":{\"data\":{\"dti\":\"2015-05-14\",\"s\":0.9914549696180743,\"month4\":2},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}},{\"month4\":3,\"max\":{\"data\":{\"dti\":\"2015-12-16\",\"s\":0.9998914835120076,\"month4\":3},\"metadata\":{\"kind\":\"ColumnGroup\",\"columns\":[\"dti\",\"s\",\"month4\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlinx.datetime.LocalDate\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Double\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"}]}}}]}"
      },
      "execution_count": 49,
      "metadata": {},
@@ -28143,8 +28424,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:06.740021Z",
-     "start_time": "2025-09-09T10:21:06.693834Z"
+     "end_time": "2025-12-18T11:19:58.720573737Z",
+     "start_time": "2025-12-18T11:19:58.641394272Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_128_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -28158,8 +28444,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:08.229904Z",
-     "start_time": "2025-09-09T10:21:07.618142Z"
+     "end_time": "2025-12-18T11:19:59.016056372Z",
+     "start_time": "2025-12-18T11:19:58.722834006Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_129_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -28176,7 +28467,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_83()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_83\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_83()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_83\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -28355,7 +28646,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741660&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539428&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;... showing only top 20 of 24 rows&lt;&sol;p&gt;&lt;p class=&quot;dataframe_description&quot;&gt;DataColumn: name = &quot;thirdThursday&quot;, type = kotlinx.datetime.LocalDate, size = 24&lt;&sol;p&gt;\n",
        "\n",
@@ -28637,10 +28928,10 @@
        "\n",
        "&sol;*&lt;!--*&sol;\n",
        "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;thirdThursday: kotlinx.datetime.LocalDate&bsol;&quot;&gt;thirdThursday&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;2015-01-15&quot;,&quot;2015-02-19&quot;,&quot;2015-03-19&quot;,&quot;2015-04-16&quot;,&quot;2015-05-14&quot;,&quot;2015-06-18&quot;,&quot;2015-07-16&quot;,&quot;2015-08-13&quot;,&quot;2015-09-17&quot;,&quot;2015-10-15&quot;,&quot;2015-11-19&quot;,&quot;2015-12-17&quot;,&quot;2016-01-14&quot;,&quot;2016-02-18&quot;,&quot;2016-03-17&quot;,&quot;2016-04-14&quot;,&quot;2016-05-19&quot;,&quot;2016-06-16&quot;,&quot;2016-07-14&quot;,&quot;2016-08-18&quot;] }, \n",
-       "], id: -1073741660, rootId: -1073741660, totalRows: 24 } ) });\n",
+       "], id: 486539428, rootId: 486539428, totalRows: 24 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741660) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539428) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -28655,7 +28946,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -28813,10 +29104,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741659\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">thirdThursday</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-15</td></tr><tr><td  style=\"vertical-align:top\">2015-02-19</td></tr><tr><td  style=\"vertical-align:top\">2015-03-19</td></tr><tr><td  style=\"vertical-align:top\">2015-04-16</td></tr><tr><td  style=\"vertical-align:top\">2015-05-14</td></tr><tr><td  style=\"vertical-align:top\">2015-06-18</td></tr><tr><td  style=\"vertical-align:top\">2015-07-16</td></tr><tr><td  style=\"vertical-align:top\">2015-08-13</td></tr><tr><td  style=\"vertical-align:top\">2015-09-17</td></tr><tr><td  style=\"vertical-align:top\">2015-10-15</td></tr><tr><td  style=\"vertical-align:top\">2015-11-19</td></tr><tr><td  style=\"vertical-align:top\">2015-12-17</td></tr><tr><td  style=\"vertical-align:top\">2016-01-14</td></tr><tr><td  style=\"vertical-align:top\">2016-02-18</td></tr><tr><td  style=\"vertical-align:top\">2016-03-17</td></tr><tr><td  style=\"vertical-align:top\">2016-04-14</td></tr><tr><td  style=\"vertical-align:top\">2016-05-19</td></tr><tr><td  style=\"vertical-align:top\">2016-06-16</td></tr><tr><td  style=\"vertical-align:top\">2016-07-14</td></tr><tr><td  style=\"vertical-align:top\">2016-08-18</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539429\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">thirdThursday</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">2015-01-15</td></tr><tr><td  style=\"vertical-align:top\">2015-02-19</td></tr><tr><td  style=\"vertical-align:top\">2015-03-19</td></tr><tr><td  style=\"vertical-align:top\">2015-04-16</td></tr><tr><td  style=\"vertical-align:top\">2015-05-14</td></tr><tr><td  style=\"vertical-align:top\">2015-06-18</td></tr><tr><td  style=\"vertical-align:top\">2015-07-16</td></tr><tr><td  style=\"vertical-align:top\">2015-08-13</td></tr><tr><td  style=\"vertical-align:top\">2015-09-17</td></tr><tr><td  style=\"vertical-align:top\">2015-10-15</td></tr><tr><td  style=\"vertical-align:top\">2015-11-19</td></tr><tr><td  style=\"vertical-align:top\">2015-12-17</td></tr><tr><td  style=\"vertical-align:top\">2016-01-14</td></tr><tr><td  style=\"vertical-align:top\">2016-02-18</td></tr><tr><td  style=\"vertical-align:top\">2016-03-17</td></tr><tr><td  style=\"vertical-align:top\">2016-04-14</td></tr><tr><td  style=\"vertical-align:top\">2016-05-19</td></tr><tr><td  style=\"vertical-align:top\">2016-06-16</td></tr><tr><td  style=\"vertical-align:top\">2016-07-14</td></tr><tr><td  style=\"vertical-align:top\">2016-08-18</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741659\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539429\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -28841,12 +29132,12 @@
     "\n",
     "Take this monstrosity of a dataframe to use in the following puzzles:\n",
     "```kotlin\n",
-    "val fromTo = listOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\").toColumn(\"From_To\")\n",
-    "val flightNumber = listOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0).toColumn(\"FlightNumber\")\n",
-    "val recentDelays = listOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)).toColumn(\"RecentDelays\")\n",
-    "val airline = listOf(\"KLM(!)\", \"<Air France> (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\").toColumn(\"Airline\")\n",
-    "\n",
-    "val df = dataFrameOf(fromTo, flightNumber, recentDelays, airline)\n",
+    "var df = dataFrameOf(\n",
+    "    \"From_To\" to columnOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\"),\n",
+    "    \"FlightNumber\" to columnOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0),\n",
+    "    \"RecentDelays\" to columnOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)),\n",
+    "    \"Airline\" to columnOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\"),\n",
+    ")\n",
     "```\n",
     "\n",
     "It looks like this:\n",
@@ -28863,25 +29154,32 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:10.011614Z",
-     "start_time": "2025-09-09T10:21:08.536332Z"
+     "end_time": "2025-12-18T11:19:59.743092247Z",
+     "start_time": "2025-12-18T11:19:59.127837817Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_131_jupyter",
+      "Line_132_jupyter",
+      "Line_133_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val fromTo = listOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\").toColumn(\"From_To\")\n",
-    "val flightNumber = listOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0).toColumn(\"FlightNumber\")\n",
-    "val recentDelays = listOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)).toColumn(\"RecentDelays\")\n",
-    "val airline = listOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\").toColumn(\"Airline\")\n",
-    "\n",
-    "var df = dataFrameOf(fromTo, flightNumber, recentDelays, airline)\n",
+    "var df = dataFrameOf(\n",
+    "    \"From_To\" to columnOf(\"LoNDon_paris\", \"MAdrid_miLAN\", \"londON_StockhOlm\", \"Budapest_PaRis\", \"Brussels_londOn\"),\n",
+    "    \"FlightNumber\" to columnOf(10045.0, Double.NaN, 10065.0, Double.NaN, 10085.0),\n",
+    "    \"RecentDelays\" to columnOf(listOf(23, 47), listOf(), listOf(24, 43, 87), listOf(13), listOf(67, 32)),\n",
+    "    \"Airline\" to columnOf(\"KLM(!)\", \"{Air France} (12)\", \"(British Airways. )\", \"12. Air France\", \"'Swiss Air'\"),\n",
+    ")\n",
     "df"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_84()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_84\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_85()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_85\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -29060,7 +29358,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741658&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539432&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -29345,25 +29643,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Double&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;NaN&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085.0&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741658, rootId: -1073741658, totalRows: 5 } ) });\n",
+       "], id: 486539432, rootId: 486539432, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741658) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539432) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_84() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_84\");\n",
-       "                    resize_iframe_out_84(elem);\n",
-       "                    setInterval(resize_iframe_out_84, 5000, elem);\n",
+       "                function o_resize_iframe_out_85() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_85\");\n",
+       "                    resize_iframe_out_85(elem);\n",
+       "                    setInterval(resize_iframe_out_85, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_84(el) {\n",
+       "                function resize_iframe_out_85(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -29521,10 +29819,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741657\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045.000000</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065.000000</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085.000000</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539433\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045.000000</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065.000000</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">NaN</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085.000000</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741657\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539433\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -29549,8 +29847,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:11.999406Z",
-     "start_time": "2025-09-09T10:21:11.582393Z"
+     "end_time": "2025-12-18T11:20:00.173798942Z",
+     "start_time": "2025-12-18T11:19:59.836065273Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_135_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -29564,7 +29867,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_87()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_87\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_87()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_87\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -29743,7 +30046,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741652&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539436&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 4&lt;&sol;p&gt;\n",
        "\n",
@@ -30028,10 +30331,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741652, rootId: -1073741652, totalRows: 5 } ) });\n",
+       "], id: 486539436, rootId: 486539436, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741652) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539436) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -30046,7 +30349,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -30204,10 +30507,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741651\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539437\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From_To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon_paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid_miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON_StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest_PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels_londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741651\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539437\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -30233,8 +30536,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:13.245179Z",
-     "start_time": "2025-09-09T10:21:12.639383Z"
+     "end_time": "2025-12-18T11:20:00.606941273Z",
+     "start_time": "2025-12-18T11:20:00.245568490Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_137_jupyter",
+      "Line_138_jupyter",
+      "Line_139_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -30246,7 +30556,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_88()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_88\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_89()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_89\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -30425,7 +30735,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741650&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539440&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -30711,25 +31021,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741650, rootId: -1073741650, totalRows: 5 } ) });\n",
+       "], id: 486539440, rootId: 486539440, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741650) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539440) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_88() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_88\");\n",
-       "                    resize_iframe_out_88(elem);\n",
-       "                    setInterval(resize_iframe_out_88, 5000, elem);\n",
+       "                function o_resize_iframe_out_89() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_89\");\n",
+       "                    resize_iframe_out_89(elem);\n",
+       "                    setInterval(resize_iframe_out_89, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_88(el) {\n",
+       "                function resize_iframe_out_89(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -30887,10 +31197,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741649\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon</td><td  style=\"vertical-align:top\">paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid</td><td  style=\"vertical-align:top\">miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON</td><td  style=\"vertical-align:top\">StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539441\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">LoNDon</td><td  style=\"vertical-align:top\">paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">MAdrid</td><td  style=\"vertical-align:top\">miLAN</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">londON</td><td  style=\"vertical-align:top\">StockhOlm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">PaRis</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">londOn</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741649\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539441\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -30914,8 +31224,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:14.533957Z",
-     "start_time": "2025-09-09T10:21:14.142724Z"
+     "end_time": "2025-12-18T11:20:00.993293322Z",
+     "start_time": "2025-12-18T11:20:00.698864044Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_141_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -30927,7 +31242,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_91()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_91\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_91()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_91\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -31106,7 +31421,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741644&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539444&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -31392,10 +31707,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM(!)&quot;,&quot;{Air France} (12)&quot;,&quot;(British Airways. )&quot;,&quot;12. Air France&quot;,&quot;&amp;#39;Swiss Air&amp;#39;&quot;] }, \n",
-       "], id: -1073741644, rootId: -1073741644, totalRows: 5 } ) });\n",
+       "], id: 486539444, rootId: 486539444, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741644) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539444) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -31410,7 +31725,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -31568,10 +31883,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741643\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539445\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM(!)</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">{Air France} (12)</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">(British Airways. )</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\">12. Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">&#39;Swiss Air&#39;</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741643\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539445\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -31595,8 +31910,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:15.418855Z",
-     "start_time": "2025-09-09T10:21:15.048348Z"
+     "end_time": "2025-12-18T11:20:01.328403705Z",
+     "start_time": "2025-12-18T11:20:01.074557822Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_143_jupyter"
+     ]
     }
    },
    "cell_type": "code",
@@ -31610,7 +31930,7 @@
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_92()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_92\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_93()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_93\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -31789,7 +32109,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741642&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539448&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 5&lt;&sol;p&gt;\n",
        "\n",
@@ -32075,25 +32395,25 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;FlightNumber: Int&bsol;&quot;&gt;FlightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;RecentDelays: List&lt;Int&gt;&bsol;&quot;&gt;RecentDelays&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;23&bsol;n47&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;[ ]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;24&bsol;n43&bsol;n87&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;13&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;67&bsol;n32&bsol;&quot;&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;[&lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;, &lt;&sol;span&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;span class=&bsol;&quot;structural&bsol;&quot;&gt;]&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
-       "], id: -1073741642, rootId: -1073741642, totalRows: 5 } ) });\n",
+       "], id: 486539448, rootId: 486539448, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741642) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539448) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
        "        &lt;&sol;html&gt;\"></iframe>\n",
        "            <script>\n",
-       "                function o_resize_iframe_out_92() {\n",
-       "                    let elem = document.getElementById(\"iframe_out_92\");\n",
-       "                    resize_iframe_out_92(elem);\n",
-       "                    setInterval(resize_iframe_out_92, 5000, elem);\n",
+       "                function o_resize_iframe_out_93() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_93\");\n",
+       "                    resize_iframe_out_93(elem);\n",
+       "                    setInterval(resize_iframe_out_93, 5000, elem);\n",
        "                }\n",
-       "                function resize_iframe_out_92(el) {\n",
+       "                function resize_iframe_out_93(el) {\n",
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -32251,10 +32571,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741641\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539449\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">RecentDelays</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">[23, 47]</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">[ ]</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">[24, 43, 87]</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">[13]</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">[67, 32]</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741641\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539449\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -32281,20 +32601,27 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:17.414060Z",
-     "start_time": "2025-09-09T10:21:16.638036Z"
+     "end_time": "2025-12-18T11:20:01.740439057Z",
+     "start_time": "2025-12-18T11:20:01.448232137Z"
+    },
+    "executionRelatedData": {
+     "compiledClasses": [
+      "Line_145_jupyter",
+      "Line_146_jupyter",
+      "Line_147_jupyter"
+     ]
     }
    },
    "cell_type": "code",
    "source": [
-    "val prep_df = df2.split { RecentDelays }.into { \"delay_$it\" }\n",
-    "prep_df"
+    "val cleanDf = df2.split { RecentDelays }.into { \"delay_$it\" }\n",
+    "cleanDf"
    ],
    "outputs": [
     {
      "data": {
       "text/html": [
-       "            <iframe onload=\"o_resize_iframe_out_95()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_95\" frameBorder=\"0\" srcdoc=\"        &lt;html theme='dark'&gt;\n",
+       "            <iframe onload=\"o_resize_iframe_out_95()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_95\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
        "        &lt;head&gt;\n",
        "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
        "                :root {\n",
@@ -32473,7 +32800,7 @@
        "            &lt;&sol;style&gt;\n",
        "        &lt;&sol;head&gt;\n",
        "        &lt;body&gt;\n",
-       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_-1073741636&quot;&gt;&lt;&sol;table&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539452&quot;&gt;&lt;&sol;table&gt;\n",
        "\n",
        "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 7&lt;&sol;p&gt;\n",
        "\n",
@@ -32761,10 +33088,10 @@
        "{ name: &quot;&lt;span title=&bsol;&quot;delay_2: Int?&bsol;&quot;&gt;delay_2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;delay_3: Int?&bsol;&quot;&gt;delay_3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
        "{ name: &quot;&lt;span title=&bsol;&quot;Airline: String&bsol;&quot;&gt;Airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
-       "], id: -1073741636, rootId: -1073741636, totalRows: 5 } ) });\n",
+       "], id: 486539452, rootId: 486539452, totalRows: 5 } ) });\n",
        "&sol;*--&gt;*&sol;\n",
        "\n",
-       "call_DataFrame(function() { DataFrame.renderTable(-1073741636) });\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539452) });\n",
        "\n",
        "\n",
        "        &lt;&sol;script&gt;\n",
@@ -32779,7 +33106,7 @@
        "                    let h = el.contentWindow.document.body.scrollHeight;\n",
        "                    el.height = h === 0 ? 0 : h + 41;\n",
        "                }\n",
-       "            </script>        <html theme='dark'>\n",
+       "            </script>        <html>\n",
        "        <head>\n",
        "            <style type=\"text/css\">\n",
        "                :root {\n",
@@ -32937,10 +33264,10 @@
        "            </style>\n",
        "        </head>\n",
        "        <body>\n",
-       "            <table class=\"dataframe\" id=\"static_df_-1073741635\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_3</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539453\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">From</th><th class=\"bottomBorder\" style=\"text-align:left\">To</th><th class=\"bottomBorder\" style=\"text-align:left\">FlightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay_3</th><th class=\"bottomBorder\" style=\"text-align:left\">Airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
        "        </body>\n",
        "        <script>\n",
-       "            document.getElementById(\"static_df_-1073741635\").style.display = \"none\";\n",
+       "            document.getElementById(\"static_df_486539453\").style.display = \"none\";\n",
        "        </script>\n",
        "        </html>"
       ],
@@ -32956,19 +33283,679 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "The dataframe looks much better now!\n"
+   "source": "Data looks much better now! Now, add a finishing `.renameToCamelCase` to get Kotlin-style identifiers.\n"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-09T10:21:18.101398Z",
-     "start_time": "2025-09-09T10:21:18.097885Z"
+     "end_time": "2025-12-18T11:20:02.082661779Z",
+     "start_time": "2025-12-18T11:20:01.832916739Z"
     }
    },
    "cell_type": "code",
-   "source": "",
-   "outputs": [],
-   "execution_count": null
+   "source": "cleanDf.renameToCamelCase()",
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "            <iframe onload=\"o_resize_iframe_out_97()\" style=\"width:100%;\" class=\"result_container\" id=\"iframe_out_97\" frameBorder=\"0\" srcdoc=\"        &lt;html&gt;\n",
+       "        &lt;head&gt;\n",
+       "            &lt;style type=&quot;text&sol;css&quot;&gt;\n",
+       "                :root {\n",
+       "    --background: #fff;\n",
+       "    --background-odd: #f5f5f5;\n",
+       "    --background-hover: #d9edfd;\n",
+       "    --header-text-color: #474747;\n",
+       "    --text-color: #848484;\n",
+       "    --text-color-dark: #000;\n",
+       "    --text-color-medium: #737373;\n",
+       "    --text-color-pale: #b3b3b3;\n",
+       "    --inner-border-color: #aaa;\n",
+       "    --bold-border-color: #000;\n",
+       "    --link-color: #296eaa;\n",
+       "    --link-color-pale: #296eaa;\n",
+       "    --link-hover: #1a466c;\n",
+       "}\n",
+       "\n",
+       ":root[theme=&quot;dark&quot;], :root [data-jp-theme-light=&quot;false&quot;], .dataframe_dark{\n",
+       "    --background: #303030;\n",
+       "    --background-odd: #3c3c3c;\n",
+       "    --background-hover: #464646;\n",
+       "    --header-text-color: #dddddd;\n",
+       "    --text-color: #b3b3b3;\n",
+       "    --text-color-dark: #dddddd;\n",
+       "    --text-color-medium: #b2b2b2;\n",
+       "    --text-color-pale: #737373;\n",
+       "    --inner-border-color: #707070;\n",
+       "    --bold-border-color: #777777;\n",
+       "    --link-color: #008dc0;\n",
+       "    --link-color-pale: #97e1fb;\n",
+       "    --link-hover: #00688e;\n",
+       "}\n",
+       "\n",
+       "p.dataframe_description {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe {\n",
+       "    font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;\n",
+       "    font-size: 12px;\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--text-color-dark);\n",
+       "    border: none;\n",
+       "    border-collapse: collapse;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th, td {\n",
+       "    padding: 6px;\n",
+       "    border: 1px solid transparent;\n",
+       "    text-align: left;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th {\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--header-text-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td {\n",
+       "    vertical-align: top;\n",
+       "    white-space: nowrap;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.bottomBorder {\n",
+       "    border-bottom-color: var(--bold-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:nth-child(odd) {\n",
+       "    background: var(--background-odd);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:nth-child(even) {\n",
+       "    background: var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody &gt; tr:hover {\n",
+       "    background: var(--background-hover);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a {\n",
+       "    cursor: pointer;\n",
+       "    color: var(--link-color);\n",
+       "    text-decoration: none;\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover &gt; td a {\n",
+       "    color: var(--link-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a:hover {\n",
+       "    color: var(--link-hover);\n",
+       "    text-decoration: underline;\n",
+       "}\n",
+       "\n",
+       "table.dataframe img {\n",
+       "    max-width: fit-content;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.complex {\n",
+       "    background-color: var(--background);\n",
+       "    border: 1px solid var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .leftBorder {\n",
+       "    border-left-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightBorder {\n",
+       "    border-right-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightAlign {\n",
+       "    text-align: right;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expanderSvg {\n",
+       "    width: 8px;\n",
+       "    height: 8px;\n",
+       "    margin-right: 3px;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expander {\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "}\n",
+       "\n",
+       "&sol;* formatting *&sol;\n",
+       "\n",
+       "table.dataframe .null {\n",
+       "    color: var(--text-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .structural {\n",
+       "    color: var(--text-color-medium);\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .dataFrameCaption {\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .numbers {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "\n",
+       ":root {\n",
+       "    --scroll-bg: #f5f5f5;\n",
+       "    --scroll-fg: #b3b3b3;\n",
+       "}\n",
+       ":root[theme=&quot;dark&quot;], :root [data-jp-theme-light=&quot;false&quot;]{\n",
+       "    --scroll-bg: #3c3c3c;\n",
+       "    --scroll-fg: #97e1fb;\n",
+       "}\n",
+       "body {\n",
+       "    scrollbar-color: var(--scroll-fg) var(--scroll-bg);\n",
+       "}\n",
+       "body::-webkit-scrollbar {\n",
+       "    width: 10px; &sol;* Mostly for vertical scrollbars *&sol;\n",
+       "    height: 10px; &sol;* Mostly for horizontal scrollbars *&sol;\n",
+       "}\n",
+       "body::-webkit-scrollbar-thumb {\n",
+       "    background-color: var(--scroll-fg);\n",
+       "}\n",
+       "body::-webkit-scrollbar-track {\n",
+       "    background-color: var(--scroll-bg);\n",
+       "}\n",
+       "            &lt;&sol;style&gt;\n",
+       "        &lt;&sol;head&gt;\n",
+       "        &lt;body&gt;\n",
+       "            &lt;table class=&quot;dataframe&quot; id=&quot;df_486539456&quot;&gt;&lt;&sol;table&gt;\n",
+       "\n",
+       "&lt;p class=&quot;dataframe_description&quot;&gt;DataFrame: rowsCount = 5, columnsCount = 7&lt;&sol;p&gt;\n",
+       "\n",
+       "        &lt;&sol;body&gt;\n",
+       "        &lt;script&gt;\n",
+       "            (function () {\n",
+       "    window.DataFrame = window.DataFrame || new (function () {\n",
+       "        this.addTable = function (df) {\n",
+       "            let cols = df.cols;\n",
+       "            for (let i = 0; i &lt; cols.length; i++) {\n",
+       "                for (let c of cols[i].children) {\n",
+       "                    cols[c].parent = i;\n",
+       "                }\n",
+       "            }\n",
+       "            df.nrow = 0\n",
+       "            for (let i = 0; i &lt; df.cols.length; i++) {\n",
+       "                if (df.cols[i].values.length &gt; df.nrow) df.nrow = df.cols[i].values.length\n",
+       "            }\n",
+       "            if (df.id === df.rootId) {\n",
+       "                df.expandedFrames = new Set()\n",
+       "                df.childFrames = {}\n",
+       "                const table = this.getTableElement(df.id)\n",
+       "                table.df = df\n",
+       "                for (let i = 0; i &lt; df.cols.length; i++) {\n",
+       "                    let col = df.cols[i]\n",
+       "                    if (col.parent === undefined &amp;&amp; col.children.length &gt; 0) col.expanded = true\n",
+       "                }\n",
+       "            } else {\n",
+       "                const rootDf = this.getTableData(df.rootId)\n",
+       "                rootDf.childFrames[df.id] = df\n",
+       "            }\n",
+       "        }\n",
+       "\n",
+       "        this.computeRenderData = function (df) {\n",
+       "            let result = []\n",
+       "            let pos = 0\n",
+       "            for (let col = 0; col &lt; df.cols.length; col++) {\n",
+       "                if (df.cols[col].parent === undefined)\n",
+       "                    pos += this.computeRenderDataRec(df.cols, col, pos, 0, result, false, false)\n",
+       "            }\n",
+       "            for (let i = 0; i &lt; result.length; i++) {\n",
+       "                let row = result[i]\n",
+       "                for (let j = 0; j &lt; row.length; j++) {\n",
+       "                    let cell = row[j]\n",
+       "                    if (j === 0)\n",
+       "                        cell.leftBd = false\n",
+       "                    if (j &lt; row.length - 1) {\n",
+       "                        let nextData = row[j + 1]\n",
+       "                        if (nextData.leftBd) cell.rightBd = true\n",
+       "                        else if (cell.rightBd) nextData.leftBd = true\n",
+       "                    } else cell.rightBd = false\n",
+       "                }\n",
+       "            }\n",
+       "            return result\n",
+       "        }\n",
+       "\n",
+       "        this.computeRenderDataRec = function (cols, colId, pos, depth, result, leftBorder, rightBorder) {\n",
+       "            if (result.length === depth) {\n",
+       "                const array = [];\n",
+       "                if (pos &gt; 0) {\n",
+       "                    let j = 0\n",
+       "                    for (let i = 0; j &lt; pos; i++) {\n",
+       "                        let c = result[depth - 1][i]\n",
+       "                        j += c.span\n",
+       "                        let copy = Object.assign({empty: true}, c)\n",
+       "                        array.push(copy)\n",
+       "                    }\n",
+       "                }\n",
+       "                result.push(array)\n",
+       "            }\n",
+       "            const col = cols[colId];\n",
+       "            let size = 0;\n",
+       "            if (col.expanded) {\n",
+       "                let childPos = pos\n",
+       "                for (let i = 0; i &lt; col.children.length; i++) {\n",
+       "                    let child = col.children[i]\n",
+       "                    let childLeft = i === 0 &amp;&amp; (col.children.length &gt; 1 || leftBorder)\n",
+       "                    let childRight = i === col.children.length - 1 &amp;&amp; (col.children.length &gt; 1 || rightBorder)\n",
+       "                    let childSize = this.computeRenderDataRec(cols, child, childPos, depth + 1, result, childLeft, childRight)\n",
+       "                    childPos += childSize\n",
+       "                    size += childSize\n",
+       "                }\n",
+       "            } else {\n",
+       "                for (let i = depth + 1; i &lt; result.length; i++)\n",
+       "                    result[i].push({id: colId, span: 1, leftBd: leftBorder, rightBd: rightBorder, empty: true})\n",
+       "                size = 1\n",
+       "            }\n",
+       "            let left = leftBorder\n",
+       "            let right = rightBorder\n",
+       "            if (size &gt; 1) {\n",
+       "                left = true\n",
+       "                right = true\n",
+       "            }\n",
+       "            result[depth].push({id: colId, span: size, leftBd: left, rightBd: right})\n",
+       "            return size\n",
+       "        }\n",
+       "\n",
+       "        this.getTableElement = function (id) {\n",
+       "            return document.getElementById(&quot;df_&quot; + id)\n",
+       "        }\n",
+       "\n",
+       "        this.getTableData = function (id) {\n",
+       "            return this.getTableElement(id).df\n",
+       "        }\n",
+       "\n",
+       "        this.createExpander = function (isExpanded) {\n",
+       "            const svgNs = &quot;http:&sol;&sol;www.w3.org&sol;2000&sol;svg&quot;\n",
+       "            let svg = document.createElementNS(svgNs, &quot;svg&quot;)\n",
+       "            svg.classList.add(&quot;expanderSvg&quot;)\n",
+       "            let path = document.createElementNS(svgNs, &quot;path&quot;)\n",
+       "            if (isExpanded) {\n",
+       "                svg.setAttribute(&quot;viewBox&quot;, &quot;0 -2 8 8&quot;)\n",
+       "                path.setAttribute(&quot;d&quot;, &quot;M1 0 l-1 1 4 4 4 -4 -1 -1 -3 3Z&quot;)\n",
+       "            } else {\n",
+       "                svg.setAttribute(&quot;viewBox&quot;, &quot;-2 0 8 8&quot;)\n",
+       "                path.setAttribute(&quot;d&quot;, &quot;M1 0 l-1 1 3 3 -3 3 1 1 4 -4Z&quot;)\n",
+       "            }\n",
+       "            path.setAttribute(&quot;fill&quot;, &quot;currentColor&quot;)\n",
+       "            svg.appendChild(path)\n",
+       "            return svg\n",
+       "        }\n",
+       "\n",
+       "        this.renderTable = function (id) {\n",
+       "\n",
+       "            let table = this.getTableElement(id)\n",
+       "\n",
+       "            if (table === null) return\n",
+       "\n",
+       "            table.innerHTML = &quot;&quot;\n",
+       "\n",
+       "            let df = table.df\n",
+       "            let rootDf = df.rootId === df.id ? df : this.getTableData(df.rootId)\n",
+       "\n",
+       "            &sol;&sol; header\n",
+       "            let header = document.createElement(&quot;thead&quot;)\n",
+       "            table.appendChild(header)\n",
+       "\n",
+       "            let renderData = this.computeRenderData(df)\n",
+       "            for (let j = 0; j &lt; renderData.length; j++) {\n",
+       "                let rowData = renderData[j]\n",
+       "                let tr = document.createElement(&quot;tr&quot;);\n",
+       "                let isLastRow = j === renderData.length - 1\n",
+       "                header.appendChild(tr);\n",
+       "                for (let i = 0; i &lt; rowData.length; i++) {\n",
+       "                    let cell = rowData[i]\n",
+       "                    let th = document.createElement(&quot;th&quot;);\n",
+       "                    th.setAttribute(&quot;colspan&quot;, cell.span)\n",
+       "                    let colId = cell.id\n",
+       "                    let col = df.cols[colId];\n",
+       "                    if (!cell.empty) {\n",
+       "                        if (col.children.length === 0) {\n",
+       "                            th.innerHTML = col.name\n",
+       "                        } else {\n",
+       "                            let link = document.createElement(&quot;a&quot;)\n",
+       "                            link.className = &quot;expander&quot;\n",
+       "                            let that = this\n",
+       "                            link.onclick = function () {\n",
+       "                                col.expanded = !col.expanded\n",
+       "                                that.renderTable(id)\n",
+       "                            }\n",
+       "                            link.appendChild(this.createExpander(col.expanded))\n",
+       "                            link.innerHTML += col.name\n",
+       "                            th.appendChild(link)\n",
+       "                        }\n",
+       "                    }\n",
+       "                    let classes = (cell.leftBd ? &quot; leftBorder&quot; : &quot;&quot;) + (cell.rightBd ? &quot; rightBorder&quot; : &quot;&quot;)\n",
+       "                    if (col.rightAlign)\n",
+       "                        classes += &quot; rightAlign&quot;\n",
+       "                    if (isLastRow)\n",
+       "                        classes += &quot; bottomBorder&quot;\n",
+       "                    if (classes.length &gt; 0)\n",
+       "                        th.setAttribute(&quot;class&quot;, classes)\n",
+       "                    tr.appendChild(th)\n",
+       "                }\n",
+       "            }\n",
+       "\n",
+       "            &sol;&sol; body\n",
+       "            let body = document.createElement(&quot;tbody&quot;)\n",
+       "            table.appendChild(body)\n",
+       "\n",
+       "            let columns = renderData.pop()\n",
+       "            for (let row = 0; row &lt; df.nrow; row++) {\n",
+       "                let tr = document.createElement(&quot;tr&quot;);\n",
+       "                body.appendChild(tr)\n",
+       "                for (let i = 0; i &lt; columns.length; i++) {\n",
+       "                    let cell = columns[i]\n",
+       "                    let td = document.createElement(&quot;td&quot;);\n",
+       "                    let colId = cell.id\n",
+       "                    let col = df.cols[colId]\n",
+       "                    let classes = (cell.leftBd ? &quot; leftBorder&quot; : &quot;&quot;) + (cell.rightBd ? &quot; rightBorder&quot; : &quot;&quot;)\n",
+       "                    if (col.rightAlign)\n",
+       "                        classes += &quot; rightAlign&quot;\n",
+       "                    if (classes.length &gt; 0)\n",
+       "                        td.setAttribute(&quot;class&quot;, classes)\n",
+       "                    tr.appendChild(td)\n",
+       "                    let value = col.values[row]\n",
+       "                    if (value.frameId !== undefined) {\n",
+       "                        let frameId = value.frameId\n",
+       "                        let expanded = rootDf.expandedFrames.has(frameId)\n",
+       "                        let link = document.createElement(&quot;a&quot;)\n",
+       "                        link.className = &quot;expander&quot;\n",
+       "                        let that = this\n",
+       "                        link.onclick = function () {\n",
+       "                            if (rootDf.expandedFrames.has(frameId))\n",
+       "                                rootDf.expandedFrames.delete(frameId)\n",
+       "                            else rootDf.expandedFrames.add(frameId)\n",
+       "                            that.renderTable(id)\n",
+       "                        }\n",
+       "                        link.appendChild(this.createExpander(expanded))\n",
+       "                        link.innerHTML += value.value\n",
+       "                        if (expanded) {\n",
+       "                            td.appendChild(link)\n",
+       "                            td.appendChild(document.createElement(&quot;p&quot;))\n",
+       "                            const childTable = document.createElement(&quot;table&quot;)\n",
+       "                            childTable.className = &quot;dataframe&quot;\n",
+       "                            childTable.id = &quot;df_&quot; + frameId\n",
+       "                            let childDf = rootDf.childFrames[frameId]\n",
+       "                            childTable.df = childDf\n",
+       "                            td.appendChild(childTable)\n",
+       "                            this.renderTable(frameId)\n",
+       "                            if (childDf.nrow !== childDf.totalRows) {\n",
+       "                                const footer = document.createElement(&quot;p&quot;)\n",
+       "                                footer.innerText = `... showing only top ${childDf.nrow} of ${childDf.totalRows} rows`\n",
+       "                                td.appendChild(footer)\n",
+       "                            }\n",
+       "                        } else {\n",
+       "                            td.appendChild(link)\n",
+       "                        }\n",
+       "                    } else if (value.style !== undefined) {\n",
+       "                        td.innerHTML = value.value\n",
+       "                        td.setAttribute(&quot;style&quot;, value.style)\n",
+       "                    } else td.innerHTML = value\n",
+       "                    this.nodeScriptReplace(td)\n",
+       "                }\n",
+       "            }\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptReplace = function (node) {\n",
+       "            if (this.nodeScriptIs(node) === true) {\n",
+       "                node.parentNode.replaceChild(this.nodeScriptClone(node), node);\n",
+       "            } else {\n",
+       "                let i = -1, children = node.childNodes;\n",
+       "                while (++i &lt; children.length) {\n",
+       "                    this.nodeScriptReplace(children[i]);\n",
+       "                }\n",
+       "            }\n",
+       "\n",
+       "            return node;\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptClone = function (node) {\n",
+       "            let script = document.createElement(&quot;script&quot;);\n",
+       "            script.text = node.innerHTML;\n",
+       "\n",
+       "            let i = -1, attrs = node.attributes, attr;\n",
+       "            while (++i &lt; attrs.length) {\n",
+       "                script.setAttribute((attr = attrs[i]).name, attr.value);\n",
+       "            }\n",
+       "            return script;\n",
+       "        }\n",
+       "\n",
+       "        this.nodeScriptIs = function (node) {\n",
+       "            return node.tagName === 'SCRIPT';\n",
+       "        }\n",
+       "    })()\n",
+       "\n",
+       "    window.call_DataFrame = function (f) {\n",
+       "        return f();\n",
+       "    };\n",
+       "\n",
+       "    let funQueue = window[&quot;kotlinQueues&quot;] &amp;&amp; window[&quot;kotlinQueues&quot;][&quot;DataFrame&quot;];\n",
+       "    if (funQueue) {\n",
+       "        funQueue.forEach(function (f) {\n",
+       "            f();\n",
+       "        });\n",
+       "        funQueue = [];\n",
+       "    }\n",
+       "})()\n",
+       "\n",
+       "&sol;*&lt;!--*&sol;\n",
+       "call_DataFrame(function() { DataFrame.addTable({ cols: [{ name: &quot;&lt;span title=&bsol;&quot;from: String&bsol;&quot;&gt;from&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;London&quot;,&quot;Madrid&quot;,&quot;London&quot;,&quot;Budapest&quot;,&quot;Brussels&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;to: String&bsol;&quot;&gt;to&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;Paris&quot;,&quot;Milan&quot;,&quot;Stockholm&quot;,&quot;Paris&quot;,&quot;London&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;flightNumber: Int&bsol;&quot;&gt;flightNumber&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10045&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10055&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10065&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10075&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;10085&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay1: Int?&bsol;&quot;&gt;delay1&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;23&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;24&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;13&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;67&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay2: Int?&bsol;&quot;&gt;delay2&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;47&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;43&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;32&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;delay3: Int?&bsol;&quot;&gt;delay3&lt;&sol;span&gt;&quot;, children: [], rightAlign: true, values: [&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;numbers&bsol;&quot;&gt;87&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;,&quot;&lt;span class=&bsol;&quot;formatted&bsol;&quot; title=&bsol;&quot;&bsol;&quot;&gt;&lt;span class=&bsol;&quot;null&bsol;&quot;&gt;null&lt;&sol;span&gt;&lt;&sol;span&gt;&quot;] }, \n",
+       "{ name: &quot;&lt;span title=&bsol;&quot;airline: String&bsol;&quot;&gt;airline&lt;&sol;span&gt;&quot;, children: [], rightAlign: false, values: [&quot;KLM&quot;,&quot;Air France&quot;,&quot;British Airways&quot;,&quot; Air France&quot;,&quot;Swiss Air&quot;] }, \n",
+       "], id: 486539456, rootId: 486539456, totalRows: 5 } ) });\n",
+       "&sol;*--&gt;*&sol;\n",
+       "\n",
+       "call_DataFrame(function() { DataFrame.renderTable(486539456) });\n",
+       "\n",
+       "\n",
+       "        &lt;&sol;script&gt;\n",
+       "        &lt;&sol;html&gt;\"></iframe>\n",
+       "            <script>\n",
+       "                function o_resize_iframe_out_97() {\n",
+       "                    let elem = document.getElementById(\"iframe_out_97\");\n",
+       "                    resize_iframe_out_97(elem);\n",
+       "                    setInterval(resize_iframe_out_97, 5000, elem);\n",
+       "                }\n",
+       "                function resize_iframe_out_97(el) {\n",
+       "                    let h = el.contentWindow.document.body.scrollHeight;\n",
+       "                    el.height = h === 0 ? 0 : h + 41;\n",
+       "                }\n",
+       "            </script>        <html>\n",
+       "        <head>\n",
+       "            <style type=\"text/css\">\n",
+       "                :root {\n",
+       "    --background: #fff;\n",
+       "    --background-odd: #f5f5f5;\n",
+       "    --background-hover: #d9edfd;\n",
+       "    --header-text-color: #474747;\n",
+       "    --text-color: #848484;\n",
+       "    --text-color-dark: #000;\n",
+       "    --text-color-medium: #737373;\n",
+       "    --text-color-pale: #b3b3b3;\n",
+       "    --inner-border-color: #aaa;\n",
+       "    --bold-border-color: #000;\n",
+       "    --link-color: #296eaa;\n",
+       "    --link-color-pale: #296eaa;\n",
+       "    --link-hover: #1a466c;\n",
+       "}\n",
+       "\n",
+       ":root[theme=\"dark\"], :root [data-jp-theme-light=\"false\"], .dataframe_dark{\n",
+       "    --background: #303030;\n",
+       "    --background-odd: #3c3c3c;\n",
+       "    --background-hover: #464646;\n",
+       "    --header-text-color: #dddddd;\n",
+       "    --text-color: #b3b3b3;\n",
+       "    --text-color-dark: #dddddd;\n",
+       "    --text-color-medium: #b2b2b2;\n",
+       "    --text-color-pale: #737373;\n",
+       "    --inner-border-color: #707070;\n",
+       "    --bold-border-color: #777777;\n",
+       "    --link-color: #008dc0;\n",
+       "    --link-color-pale: #97e1fb;\n",
+       "    --link-hover: #00688e;\n",
+       "}\n",
+       "\n",
+       "p.dataframe_description {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe {\n",
+       "    font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n",
+       "    font-size: 12px;\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--text-color-dark);\n",
+       "    border: none;\n",
+       "    border-collapse: collapse;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th, td {\n",
+       "    padding: 6px;\n",
+       "    border: 1px solid transparent;\n",
+       "    text-align: left;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th {\n",
+       "    background-color: var(--background);\n",
+       "    color: var(--header-text-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td {\n",
+       "    vertical-align: top;\n",
+       "    white-space: nowrap;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.bottomBorder {\n",
+       "    border-bottom-color: var(--bold-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:nth-child(odd) {\n",
+       "    background: var(--background-odd);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:nth-child(even) {\n",
+       "    background: var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tbody > tr:hover {\n",
+       "    background: var(--background-hover);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a {\n",
+       "    cursor: pointer;\n",
+       "    color: var(--link-color);\n",
+       "    text-decoration: none;\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover > td a {\n",
+       "    color: var(--link-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe a:hover {\n",
+       "    color: var(--link-hover);\n",
+       "    text-decoration: underline;\n",
+       "}\n",
+       "\n",
+       "table.dataframe img {\n",
+       "    max-width: fit-content;\n",
+       "}\n",
+       "\n",
+       "table.dataframe th.complex {\n",
+       "    background-color: var(--background);\n",
+       "    border: 1px solid var(--background);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .leftBorder {\n",
+       "    border-left-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightBorder {\n",
+       "    border-right-color: var(--inner-border-color);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .rightAlign {\n",
+       "    text-align: right;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expanderSvg {\n",
+       "    width: 8px;\n",
+       "    height: 8px;\n",
+       "    margin-right: 3px;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .expander {\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "}\n",
+       "\n",
+       "/* formatting */\n",
+       "\n",
+       "table.dataframe .null {\n",
+       "    color: var(--text-color-pale);\n",
+       "}\n",
+       "\n",
+       "table.dataframe .structural {\n",
+       "    color: var(--text-color-medium);\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .dataFrameCaption {\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "table.dataframe .numbers {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe td:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "table.dataframe tr:hover .formatted .structural, .null {\n",
+       "    color: var(--text-color-dark);\n",
+       "}\n",
+       "\n",
+       "\n",
+       "            </style>\n",
+       "        </head>\n",
+       "        <body>\n",
+       "            <table class=\"dataframe\" id=\"static_df_486539457\"><thead><tr><th class=\"bottomBorder\" style=\"text-align:left\">from</th><th class=\"bottomBorder\" style=\"text-align:left\">to</th><th class=\"bottomBorder\" style=\"text-align:left\">flightNumber</th><th class=\"bottomBorder\" style=\"text-align:left\">delay1</th><th class=\"bottomBorder\" style=\"text-align:left\">delay2</th><th class=\"bottomBorder\" style=\"text-align:left\">delay3</th><th class=\"bottomBorder\" style=\"text-align:left\">airline</th></tr></thead><tbody><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10045</td><td  style=\"vertical-align:top\">23</td><td  style=\"vertical-align:top\">47</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">KLM</td></tr><tr><td  style=\"vertical-align:top\">Madrid</td><td  style=\"vertical-align:top\">Milan</td><td  style=\"vertical-align:top\">10055</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Air France</td></tr><tr><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">Stockholm</td><td  style=\"vertical-align:top\">10065</td><td  style=\"vertical-align:top\">24</td><td  style=\"vertical-align:top\">43</td><td  style=\"vertical-align:top\">87</td><td  style=\"vertical-align:top\">British Airways</td></tr><tr><td  style=\"vertical-align:top\">Budapest</td><td  style=\"vertical-align:top\">Paris</td><td  style=\"vertical-align:top\">10075</td><td  style=\"vertical-align:top\">13</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\"> Air France</td></tr><tr><td  style=\"vertical-align:top\">Brussels</td><td  style=\"vertical-align:top\">London</td><td  style=\"vertical-align:top\">10085</td><td  style=\"vertical-align:top\">67</td><td  style=\"vertical-align:top\">32</td><td  style=\"vertical-align:top\">null</td><td  style=\"vertical-align:top\">Swiss Air</td></tr></tbody></table>\n",
+       "        </body>\n",
+       "        <script>\n",
+       "            document.getElementById(\"static_df_486539457\").style.display = \"none\";\n",
+       "        </script>\n",
+       "        </html>"
+      ],
+      "application/kotlindataframe+json": "{\"$version\":\"2.2.0\",\"metadata\":{\"columns\":[\"from\",\"to\",\"flightNumber\",\"delay1\",\"delay2\",\"delay3\",\"airline\"],\"types\":[{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.Int?\"},{\"kind\":\"ValueColumn\",\"type\":\"kotlin.String\"}],\"nrow\":5,\"ncol\":7,\"is_formatted\":false},\"kotlin_dataframe\":[{\"from\":\"London\",\"to\":\"Paris\",\"flightNumber\":10045,\"delay1\":23,\"delay2\":47,\"delay3\":null,\"airline\":\"KLM\"},{\"from\":\"Madrid\",\"to\":\"Milan\",\"flightNumber\":10055,\"delay1\":null,\"delay2\":null,\"delay3\":null,\"airline\":\"Air France\"},{\"from\":\"London\",\"to\":\"Stockholm\",\"flightNumber\":10065,\"delay1\":24,\"delay2\":43,\"delay3\":87,\"airline\":\"British Airways\"},{\"from\":\"Budapest\",\"to\":\"Paris\",\"flightNumber\":10075,\"delay1\":13,\"delay2\":null,\"delay3\":null,\"airline\":\" Air France\"},{\"from\":\"Brussels\",\"to\":\"London\",\"flightNumber\":10085,\"delay1\":67,\"delay2\":32,\"delay3\":null,\"airline\":\"Swiss Air\"}]}"
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 58
   }
  ],
  "metadata": {


### PR DESCRIPTION
Didn't do it for random-related examples because I'm still not sure about cleanest replacement for these specific cases