### PR TITLE
public-api-modifier README

### DIFF
--- a/plugins/public-api-modifier/README.md
+++ b/plugins/public-api-modifier/README.md
@@ -1,4 +1,10 @@
 ## :plugins:public-api-modifier
 
-This plugin makes annotated functions internal.
-Helps to produce two artifacts from the same code: one with full API, one with reduced API.
+This compiler plugin makes `@AccessApiOverload` annotated functions internal.
+It could help to produce two artifacts from the same code: one with the full API, one with a reduced API.
+
+This is an exploratory plugin that is NOT actually enabled.
+See https://github.com/Kotlin/dataframe/pull/959 for more information.
+
+You can test it by adding `compilerPluginClasspath(projects.pluginApiModifier)` in
+[`:core`](../../core/build.gradle.kts).


### PR DESCRIPTION
Expanded README of :plugins:public-api-modifier to explain we don't actually use this plugin (yet).

Alternatively, we could remove this plugin from the project and add it as a draft somewhere.