### PR TITLE
Add inplace rename for col(index)

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3900,6 +3900,7 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/RenameColumn
 	public fun into (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun into (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun into (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
+	public fun into (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 	public fun named (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun named (Ljava/lang/String;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun named (Ljava/lang/String;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
@@ -3909,6 +3910,7 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/api/RenameColumn
 	public fun named (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun named (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public fun named (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
+	public fun named (Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/SingleColumn;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/RenameColumnsSelectionDsl$Grammar {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/ColumnsForAggregateSelectionDsl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/ColumnsForAggregateSelectionDsl.kt
@@ -20,8 +20,8 @@ public interface ColumnsForAggregateSelectionDsl<out T> : ColumnsSelectionDsl<T>
     public infix fun <C> ColumnSet<C>.into(name: String): ColumnSet<C> =
         ConfiguredAggregateColumn.withPath(this, pathOf(name))
 
-    public infix fun <C> SingleColumn<C>.into(name: String): SingleColumn<C> =
-        ConfiguredAggregateColumn.withPath(this, pathOf(name))
+    override infix fun <C> SingleColumn<C>.into(newName: String): SingleColumn<C> =
+        ConfiguredAggregateColumn.withPath(this, pathOf(newName))
 
     public infix fun <C> ColumnSet<C>.into(path: ColumnPath): ColumnSet<C> =
         ConfiguredAggregateColumn.withPath(this, path)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
 import org.jetbrains.kotlinx.dataframe.columns.renamedReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.AccessApiLink
@@ -23,6 +24,7 @@ import org.jetbrains.kotlinx.dataframe.documentation.LineBreak
 import org.jetbrains.kotlinx.dataframe.documentation.SelectingColumns
 import org.jetbrains.kotlinx.dataframe.impl.api.renameImpl
 import org.jetbrains.kotlinx.dataframe.impl.columnName
+import org.jetbrains.kotlinx.dataframe.impl.columns.renamedColumn
 import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
 import kotlin.reflect.KProperty
@@ -499,6 +501,12 @@ public interface RenameColumnsSelectionDsl {
         interface KPropertyReceiver
 
         /**
+         * @set [RECEIVER] col(0)
+         * @set [RECEIVER_TYPE] SingleColumn
+         */
+        interface SingleColumnReceiver
+
+        /**
          * @set [PARAM] columnB
          * @set [PARAM_NAME] nameOf
          * @set [PARAM_TYPE] ColumnReference
@@ -619,6 +627,15 @@ public interface RenameColumnsSelectionDsl {
     public infix fun <C> KProperty<C>.named(nameOf: KProperty<*>): ColumnReference<C> =
         toColumnAccessor().named(nameOf.columnName)
 
+    /**
+     * @include [CommonRenameDocs]
+     * @include [CommonRenameDocs.NamedFunctionName]
+     * @include [CommonRenameDocs.SingleColumnReceiver]
+     * @include [CommonRenameDocs.StringParam]
+     */
+    @Interpretable("Named1")
+    public infix fun <C> SingleColumn<C>.named(newName: String): SingleColumn<C> = renamedColumn(newName)
+
     // endregion
 
     // region into
@@ -709,6 +726,15 @@ public interface RenameColumnsSelectionDsl {
     @Deprecated(DEPRECATED_ACCESS_API)
     @AccessApiOverload
     public infix fun <C> KProperty<C>.into(nameOf: KProperty<*>): ColumnReference<C> = named(nameOf)
+
+    /**
+     * @include [CommonRenameDocs]
+     * @include [CommonRenameDocs.IntoFunctionName]
+     * @include [CommonRenameDocs.SingleColumnReceiver]
+     * @include [CommonRenameDocs.StringParam]
+     */
+    @Interpretable("Named1")
+    public infix fun <C> SingleColumn<C>.into(newName: String): SingleColumn<C> = named(newName)
 
     // endregion
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/RenamedSingleColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/RenamedSingleColumn.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.kotlinx.dataframe.impl.columns
+
+import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
+import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
+import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
+
+internal class RenamedSingleColumn<C>(val source: SingleColumn<C>, val name: String) : SingleColumn<C> {
+
+    override fun resolveSingle(context: ColumnResolutionContext): ColumnWithPath<C>? =
+        source.resolveSingle(context)?.let {
+            it.data.rename(name).addPath(it.path)
+        }
+}
+
+internal fun <C> SingleColumn<C>.renamedColumn(newName: String): SingleColumn<C> = RenamedSingleColumn(this, newName)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -156,6 +156,40 @@ class RenameTests : ColumnsSelectionDslTests() {
             df.select { col("age") into col("age2") },
         ).shouldAllBeEqual()
     }
+
+    @Test
+    fun `col by index named`() {
+        val df = dataFrameOf(
+            "col0" to columnOf(1, 4),
+            "col1" to columnOf(2, 5),
+            "col2" to columnOf(3, 6),
+        )
+
+        listOf(
+            df.select { col(0) and (col(1) named "renamed") and col(2) },
+            df.select { col(0) and (col(1) into "renamed") and col(2) },
+            df.select { col(0) and (col<Int>(1) named "renamed") and col(2) },
+            df.select { col(0) and (col<Int>(1) into "renamed") and col(2) },
+        ).shouldAllBeEqual()
+
+        val result = df.select { col(0) and (col(1) named "renamed") and col(2) }
+        result.columnNames() shouldBe listOf("col0", "renamed", "col2")
+        result["renamed"].toList() shouldBe listOf(2, 5)
+    }
+
+    @Test
+    fun `col by index named with convert`() {
+        val df = dataFrameOf(
+            "a" to columnOf(1, 4),
+            "b" to columnOf(2, 5),
+            "c" to columnOf(3, 6),
+        )
+
+        val result = df.convert { col<Int>(0) named "newA" }.with { it * 10 }
+
+        result.columnNames() shouldBe listOf("newA", "b", "c")
+        result["newA"].toList() shouldBe listOf(10, 40)
+    }
 }
 
 class RenameToCamelCaseTests {


### PR DESCRIPTION
We even had a user request once that goes somewhat like
1. there's CSV with columns
2. it would be nice to select columns from df by index and rename them. why not?

This continues recent development of String API in compiler plugin

Once this functionality implemented there, we'll be able to:
```
val df = DataFrame.readCsv("...")
val df1 = df.convert { col<Int>(0) named "newA" }.with { it * 10 }
val v: Int = df1[0].newA
```