### PR TITLE
Migrating kotlin-test to kotlin-test-junit5 explicitly

### DIFF
--- a/dataframe-compiler-plugin-core/build.gradle.kts
+++ b/dataframe-compiler-plugin-core/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 group = "org.jetbrains.kotlinx.dataframe"
 
 dependencies {
-    implementation(project(":core")) {
+    implementation(projects.core) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-datetime-jvm")
@@ -33,8 +33,12 @@ dependencies {
     }
 
     // we assume Kotlin plugin has reflect dependency - we're not bringing our own version
-    testImplementation(kotlin("reflect"))
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.kotlin.test.junit5)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.withType<ShadowJar> {

--- a/plugins/expressions-converter/build.gradle.kts
+++ b/plugins/expressions-converter/build.gradle.kts
@@ -17,8 +17,7 @@ dependencies {
     testImplementation(libs.kotlin.compiler.internal.test.framework)
 
     testRuntimeOnly(projects.core)
-
-    testRuntimeOnly(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit5)
     testRuntimeOnly(libs.kotlin.script.runtime)
     testRuntimeOnly(libs.kotlin.annotations.jvm)
 

--- a/plugins/symbol-processor/build.gradle.kts
+++ b/plugins/symbol-processor/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.h2db)
     testImplementation(libs.h2db)
-    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.kotlin.compile.testing.ksp)
     testImplementation(libs.ktor.server.netty)


### PR DESCRIPTION
Fixes Gradle errors like:

```
org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException: Unable to find a variant with the requested capability: coordinates 'org.jetbrains.kotlin:kotlin-test-framework-junit':
   - Variant 'compile' provides 'org.jetbrains.kotlin:kotlin-test:2.3.10'
   - Variant 'enforced-platform-compile' provides 'org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:2.3.10'
   - Variant 'enforced-platform-runtime' provides 'org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:2.3.10'
   - Variant 'javadoc' provides 'org.jetbrains.kotlin:kotlin-test:2.3.10'
   - Variant 'platform-compile' provides 'org.jetbrains.kotlin:kotlin-test-derived-platform:2.3.10'
   - Variant 'platform-runtime' provides 'org.jetbrains.kotlin:kotlin-test-derived-platform:2.3.10'
   - Variant 'runtime' provides 'org.jetbrains.kotlin:kotlin-test:2.3.10'
   - Variant 'sources' provides 'org.jetbrains.kotlin:kotlin-test:2.3.10'
```

These have started to appear around bumping to Kotlin 2.3.10