### PR TITLE
Added DataFrame.renderToMarkdown(): String function; Improved type rendering in DataFrame.print() and enabled it by default

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6122,6 +6122,11 @@ public final class org/jetbrains/kotlinx/dataframe/io/HtmlKt {
 	public static synthetic fun toStaticHtml$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/io/DisplayConfiguration;Lorg/jetbrains/kotlinx/dataframe/jupyter/CellRenderer;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/io/DataFrameHtmlData;
 }
 
+public final class org/jetbrains/kotlinx/dataframe/io/MarkdownKt {
+	public static final fun renderToMarkdown (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZ)Ljava/lang/String;
+	public static synthetic fun renderToMarkdown$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZILjava/lang/Object;)Ljava/lang/String;
+}
+
 public final class org/jetbrains/kotlinx/dataframe/io/MethodArguments {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/io/MethodArguments$Companion;
 	public fun <init> ()V

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6124,9 +6124,20 @@ public final class org/jetbrains/kotlinx/dataframe/io/HtmlKt {
 	public static synthetic fun toStaticHtml$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lorg/jetbrains/kotlinx/dataframe/io/DisplayConfiguration;Lorg/jetbrains/kotlinx/dataframe/jupyter/CellRenderer;ZZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/io/DataFrameHtmlData;
 }
 
+public final class org/jetbrains/kotlinx/dataframe/io/MarkdownAlignment : java/lang/Enum {
+	public static final field CENTER Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+	public static final field LEFT Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+	public static final field RIGHT Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+	public static final field UNSPECIFIED Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSeparator ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+	public static fun values ()[Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;
+}
+
 public final class org/jetbrains/kotlinx/dataframe/io/MarkdownKt {
-	public static final fun renderToMarkdown (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZ)Ljava/lang/String;
-	public static synthetic fun renderToMarkdown$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZILjava/lang/Object;)Ljava/lang/String;
+	public static final fun renderToMarkdown (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;ZZZ)Ljava/lang/String;
+	public static synthetic fun renderToMarkdown$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jetbrains/kotlinx/dataframe/io/MarkdownAlignment;ZZZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/kotlinx/dataframe/io/MethodArguments {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3848,12 +3848,14 @@ public final class org/jetbrains/kotlinx/dataframe/api/PivotKt {
 public final class org/jetbrains/kotlinx/dataframe/api/PrintKt {
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)V
 	public static final synthetic fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZ)V
-	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)V
+	public static final synthetic fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)V
+	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZ)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataRow;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;)V
 	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZILjava/lang/Object;)V
 	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)V
+	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZILjava/lang/Object;)V
 	public static final fun print-XIlnkTk (Ljava/lang/String;)V
 }
 
@@ -6165,8 +6167,10 @@ public final class org/jetbrains/kotlinx/dataframe/io/RendererDecimalFormat$Comp
 }
 
 public final class org/jetbrains/kotlinx/dataframe/io/StringKt {
-	public static final fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)Ljava/lang/String;
+	public static final synthetic fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)Ljava/lang/String;
+	public static final fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZ)Ljava/lang/String;
 	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/io/SupportedCodeGenerationFormat : org/jetbrains/kotlinx/dataframe/io/SupportedFormat {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3849,13 +3849,13 @@ public final class org/jetbrains/kotlinx/dataframe/api/PrintKt {
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataColumn;)V
 	public static final synthetic fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZ)V
 	public static final synthetic fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)V
-	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZ)V
+	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZLorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/DataRow;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/api/GroupBy;)V
 	public static final fun print (Lorg/jetbrains/kotlinx/dataframe/schema/DataFrameSchema;)V
 	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZILjava/lang/Object;)V
 	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)V
-	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZILjava/lang/Object;)V
+	public static synthetic fun print$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZLorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle;ILjava/lang/Object;)V
 	public static final fun print-XIlnkTk (Ljava/lang/String;)V
 }
 
@@ -6166,11 +6166,58 @@ public final class org/jetbrains/kotlinx/dataframe/io/RendererDecimalFormat$Comp
 	public final fun of-VVLz-gw (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public abstract interface class org/jetbrains/kotlinx/dataframe/io/StringBorderStyle {
+	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle$Companion;
+	public abstract fun getBottomLeft ()Ljava/lang/String;
+	public abstract fun getBottomRight ()Ljava/lang/String;
+	public abstract fun getHeaderSplit ()Ljava/lang/String;
+	public abstract fun getHorizontal ()Ljava/lang/String;
+	public abstract fun getTopLeft ()Ljava/lang/String;
+	public abstract fun getTopRight ()Ljava/lang/String;
+	public abstract fun getVertical ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/io/StringBorderStyle$Companion {
+}
+
+public final class org/jetbrains/kotlinx/dataframe/io/StringBorderStyle$ContinuousWithRoundedCorners : org/jetbrains/kotlinx/dataframe/io/StringBorderStyle {
+	public static final field INSTANCE Lorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle$ContinuousWithRoundedCorners;
+	public fun getBottomLeft ()Ljava/lang/String;
+	public fun getBottomRight ()Ljava/lang/String;
+	public fun getHeaderSplit ()Ljava/lang/String;
+	public fun getHorizontal ()Ljava/lang/String;
+	public fun getTopLeft ()Ljava/lang/String;
+	public fun getTopRight ()Ljava/lang/String;
+	public fun getVertical ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/io/StringBorderStyle$ContinuousWithSquareCorners : org/jetbrains/kotlinx/dataframe/io/StringBorderStyle {
+	public static final field INSTANCE Lorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle$ContinuousWithSquareCorners;
+	public fun getBottomLeft ()Ljava/lang/String;
+	public fun getBottomRight ()Ljava/lang/String;
+	public fun getHeaderSplit ()Ljava/lang/String;
+	public fun getHorizontal ()Ljava/lang/String;
+	public fun getTopLeft ()Ljava/lang/String;
+	public fun getTopRight ()Ljava/lang/String;
+	public fun getVertical ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/dataframe/io/StringBorderStyle$DottedLineWithRounderCorners : org/jetbrains/kotlinx/dataframe/io/StringBorderStyle {
+	public static final field INSTANCE Lorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle$DottedLineWithRounderCorners;
+	public fun getBottomLeft ()Ljava/lang/String;
+	public fun getBottomRight ()Ljava/lang/String;
+	public fun getHeaderSplit ()Ljava/lang/String;
+	public fun getHorizontal ()Ljava/lang/String;
+	public fun getTopLeft ()Ljava/lang/String;
+	public fun getTopRight ()Ljava/lang/String;
+	public fun getVertical ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/kotlinx/dataframe/io/StringKt {
 	public static final synthetic fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZ)Ljava/lang/String;
-	public static final fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZ)Ljava/lang/String;
+	public static final fun renderToString (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZLorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle;)Ljava/lang/String;
 	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;IIZZZZZILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun renderToString$default (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZLorg/jetbrains/kotlinx/dataframe/io/StringBorderStyle;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract interface class org/jetbrains/kotlinx/dataframe/io/SupportedCodeGenerationFormat : org/jetbrains/kotlinx/dataframe/io/SupportedFormat {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -31,9 +31,20 @@ public fun <T> DataFrame<T>.print(
     title: Boolean = false,
 ): Unit = print(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, true)
 
+@Deprecated(message = PRINT, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.print(
     rowsLimit: Int = 20,
     valueLimit: Int = 40,
+    borders: Boolean = false,
+    alignLeft: Boolean = false,
+    columnTypes: Boolean = true,
+    title: Boolean = false,
+    rowIndex: Boolean = true,
+): Unit = print(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex)
+
+public fun <T> DataFrame<T>.print(
+    rowsLimit: Int? = 20,
+    valueLimit: Int? = 40,
     borders: Boolean = false,
     alignLeft: Boolean = false,
     columnTypes: Boolean = true,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -36,7 +36,7 @@ public fun <T> DataFrame<T>.print(
     valueLimit: Int = 40,
     borders: Boolean = false,
     alignLeft: Boolean = false,
-    columnTypes: Boolean = false,
+    columnTypes: Boolean = true,
     title: Boolean = false,
     rowIndex: Boolean = true,
 ): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex))

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/print.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.io.StringBorderStyle
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import org.jetbrains.kotlinx.dataframe.util.PRINT
@@ -50,7 +51,8 @@ public fun <T> DataFrame<T>.print(
     columnTypes: Boolean = true,
     title: Boolean = false,
     rowIndex: Boolean = true,
-): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex))
+    borderStyle: StringBorderStyle = StringBorderStyle.DottedLineWithRounderCorners,
+): Unit = println(renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex, borderStyle))
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
@@ -1,0 +1,52 @@
+package org.jetbrains.kotlinx.dataframe.io
+
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.size
+
+public fun AnyFrame.renderToMarkdown(
+    rowsLimit: Int = 20,
+    valueLimit: Int = 40,
+    alignLeft: Boolean = false,
+    columnTypes: Boolean = false,
+    title: Boolean = false,
+    rowIndex: Boolean = true,
+): String {
+    val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex) { it.replace("|", "\\|") }
+
+    val sb = StringBuilder()
+    if (title) {
+        sb.appendLine("**DataFrame [${size()}]**")
+        sb.appendLine()
+    }
+
+    // header
+    sb.append("|")
+    for ((i, col) in table.header.withIndex()) {
+        val type = table.types?.getOrNull(i)?.takeIf { it.isNotEmpty() }?.let { ":$it" } ?: ""
+        sb.append(" ${col.replace("|", "\\|")}$type |")
+    }
+    sb.appendLine()
+
+    // separator
+    sb.append("|")
+    repeat(table.header.size) {
+        sb.append(if (alignLeft) ":---|" else "---:|")
+    }
+    sb.appendLine()
+
+    // data
+    for (row in 0 until table.rowsCount) {
+        sb.append("|")
+        for (col in table.values.indices) {
+            sb.append(" ${table.values[col][row]} |")
+        }
+        sb.appendLine()
+    }
+
+    // footer
+    if (table.totalRows > rowsLimit) {
+        sb.appendLine()
+        sb.appendLine("*... ${table.totalRows - rowsLimit} more rows*")
+    }
+    return sb.toString()
+}

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.size
 
 public fun AnyFrame.renderToMarkdown(
-    rowsLimit: Int = 20,
-    valueLimit: Int = 40,
+    rowsLimit: Int? = 20,
+    valueLimit: Int? = 40,
     alignLeft: Boolean = false,
     columnTypes: Boolean = false,
     title: Boolean = false,
@@ -44,9 +44,9 @@ public fun AnyFrame.renderToMarkdown(
     }
 
     // footer
-    if (table.totalRows > rowsLimit) {
+    if (table.totalRows > table.rowsCount) {
         sb.appendLine()
-        sb.appendLine("*... ${table.totalRows - rowsLimit} more rows*")
+        sb.appendLine("*... ${table.totalRows - table.rowsCount} more rows*")
     }
     return sb.toString()
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/markdown.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlinx.dataframe.size
 public fun AnyFrame.renderToMarkdown(
     rowsLimit: Int? = 20,
     valueLimit: Int? = 40,
-    alignLeft: Boolean = false,
+    alignment: MarkdownAlignment = MarkdownAlignment.UNSPECIFIED,
     columnTypes: Boolean = false,
     title: Boolean = false,
     rowIndex: Boolean = true,
@@ -30,7 +30,8 @@ public fun AnyFrame.renderToMarkdown(
     // separator
     sb.append("|")
     repeat(table.header.size) {
-        sb.append(if (alignLeft) ":---|" else "---:|")
+        sb.append(alignment.separator)
+        sb.append("|")
     }
     sb.appendLine()
 
@@ -49,4 +50,11 @@ public fun AnyFrame.renderToMarkdown(
         sb.appendLine("*... ${table.totalRows - table.rowsCount} more rows*")
     }
     return sb.toString()
+}
+
+public enum class MarkdownAlignment(public val separator: String) {
+    LEFT(":---"),
+    RIGHT("---:"),
+    CENTER(":---:"),
+    UNSPECIFIED("---"),
 }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -29,6 +29,10 @@ public fun AnyFrame.renderToString(
     rowIndex: Boolean = true,
 ): String {
     val sb = StringBuilder()
+    val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex)
+    val columnLengths = table.values.mapIndexed { col, vals ->
+        (vals + table.header[col]).maxOf { it.length } + 1
+    }
 
     // title
     if (title) {
@@ -36,40 +40,19 @@ public fun AnyFrame.renderToString(
         sb.appendLine()
     }
 
-    // data
-    val rowsCount = rowsLimit.coerceAtMost(nrow)
-    val cols = if (rowIndex) listOf((0 until rowsCount).toColumn()) + columns() else columns()
-    val header = cols.mapIndexed { colIndex, col ->
-        if (columnTypes && (!rowIndex || colIndex > 0)) {
-            "${col.name()}:${renderType(col)}"
-        } else {
-            col.name()
-        }
-    }
-    val values = cols.map {
-        val top = it.take(rowsLimit)
-        val precision = if (top.isNumber()) top.asNumbers().scale() else 0
-        val decimalFormat =
-            if (precision >= 0) RendererDecimalFormat.fromPrecision(precision) else RendererDecimalFormat.of("%e")
-        top.values().map {
-            renderValueForStdout(it, valueLimit, decimalFormat = decimalFormat).truncatedContent
-        }
-    }
-    val columnLengths = values.mapIndexed { col, vals -> (vals + header[col]).map { it.length }.maxOrNull()!! + 1 }
-
     // top border
     if (borders) {
         sb.append("\u230C")
-        for (i in 1 until columnLengths.sum() + columnLengths.size) sb.append('-')
+        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append('-') }
         sb.append("\u230D")
         sb.appendLine()
         sb.append("|")
     }
 
     // header
-    for (col in header.indices) {
+    for (col in table.header.indices) {
         val len = columnLengths[col]
-        val str = header[col]
+        val str = table.header[col]
         val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
         sb.append(padded)
         if (borders) sb.append("|")
@@ -80,18 +63,18 @@ public fun AnyFrame.renderToString(
     if (borders) {
         sb.append("|")
         for (colLength in columnLengths) {
-            for (i in 1..colLength) sb.append('-')
+            repeat(colLength) { sb.append('-') }
             sb.append("|")
         }
         sb.appendLine()
     }
 
     // data
-    for (row in 0 until rowsCount) {
+    for (row in 0 until table.rowsCount) {
         if (borders) sb.append("|")
-        for (col in values.indices) {
+        for (col in table.values.indices) {
             val len = columnLengths[col]
-            val str = values[col][row]
+            val str = table.values[col][row]
             val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
             sb.append(padded)
             if (borders) sb.append("|")
@@ -100,15 +83,50 @@ public fun AnyFrame.renderToString(
     }
 
     // footer
-    if (nrow > rowsLimit) {
+    if (table.totalRows > rowsLimit) {
         sb.appendLine("...")
     } else if (borders) {
         sb.append("\u230E")
-        for (i in 1 until columnLengths.sum() + columnLengths.size) sb.append('-')
+        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append('-') }
         sb.append("\u230F")
         sb.appendLine()
     }
     return sb.toString()
+}
+
+private class PreparedTable(
+    val header: List<String>,
+    val values: List<List<String>>,
+    val rowsCount: Int,
+    val totalRows: Int,
+)
+
+private fun AnyFrame.prepareTable(
+    rowsLimit: Int,
+    valueLimit: Int,
+    columnTypes: Boolean,
+    rowIndex: Boolean,
+    escapeValue: (String) -> String = { it },
+): PreparedTable {
+    val rowsCount = rowsLimit.coerceAtMost(nrow)
+    val cols = if (rowIndex) listOf((0 until rowsCount).toColumn()) + columns() else columns()
+    val header = cols.mapIndexed { colIndex, col ->
+        if (columnTypes && (!rowIndex || colIndex > 0)) {
+            "${col.name()}:${renderType(col)}"
+        } else {
+            col.name()
+        }
+    }
+    val values = cols.map { col ->
+        val top = col.take(rowsLimit)
+        val precision = if (top.isNumber()) top.asNumbers().scale() else 0
+        val decimalFormat =
+            if (precision >= 0) RendererDecimalFormat.fromPrecision(precision) else RendererDecimalFormat.of("%e")
+        top.values().map {
+            escapeValue(renderValueForStdout(it, valueLimit, decimalFormat = decimalFormat).truncatedContent)
+        }
+    }
+    return PreparedTable(header, values, rowsCount, nrow)
 }
 
 internal val valueToStringLimitDefault = 1000

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -100,6 +100,7 @@ public fun AnyFrame.renderToString(
     // footer
     if (table.totalRows > table.rowsCount) {
         sb.appendLine("...")
+        sb.appendLine("${size.ncol} columns x ${size.nrow} rows")
     } else if (borders) {
         sb.append(Borders.BOTTOM_LEFT)
         repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(Borders.HORIZONTAL) }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -26,7 +26,7 @@ public fun AnyFrame.renderToString(
     valueLimit: Int = 40,
     borders: Boolean = false,
     alignLeft: Boolean = false,
-    columnTypes: Boolean = false,
+    columnTypes: Boolean = true,
     title: Boolean = false,
     rowIndex: Boolean = true,
 ): String {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -4,6 +4,8 @@ import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.api.asNumbers
 import org.jetbrains.kotlinx.dataframe.api.columnsCount
+import org.jetbrains.kotlinx.dataframe.api.getColumns
+import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.isNumber
 import org.jetbrains.kotlinx.dataframe.api.take
 import org.jetbrains.kotlinx.dataframe.api.toColumn
@@ -119,7 +121,15 @@ private fun AnyFrame.prepareTable(
     }
     val values = cols.map { col ->
         val top = col.take(rowsLimit)
-        val precision = if (top.isNumber()) top.asNumbers().scale() else 0
+        val precision = if (top.isNumber()) {
+            top.asNumbers().scale()
+        } else if (top.isColumnGroup()) {
+            top.getColumns { colsAtAnyDepth().filter { it.isNumber() } }.maxOfOrNull {
+                it.asNumbers().scale()
+            } ?: 0
+        } else {
+            0
+        }
         val decimalFormat =
             if (precision >= 0) RendererDecimalFormat.fromPrecision(precision) else RendererDecimalFormat.of("%e")
         top.values().map {
@@ -190,13 +200,13 @@ internal fun AnyRow.getVisibleValues(): List<Pair<String, Any?>> {
     return owner.columns().map { it.name() to it[index] }.filter { !it.second.skip() }
 }
 
-internal fun AnyRow.renderToString(): String {
+internal fun AnyRow.renderToString(decimalFormat: RendererDecimalFormat = RendererDecimalFormat.DEFAULT): String {
     val values = getVisibleValues()
     if (values.isEmpty()) return "{ }"
     return values.joinToString(
         prefix = "{ ",
         postfix = " }",
-    ) { "${it.first}:${renderValueForStdout(it.second).truncatedContent}" }
+    ) { "${it.first}:${renderValueForStdout(it.second, decimalFormat = decimalFormat).truncatedContent}" }
 }
 
 internal fun AnyRow.renderToStringTable(forHtml: Boolean = false): String {
@@ -256,6 +266,8 @@ internal fun renderValueToString(value: Any?, decimalFormat: RendererDecimalForm
         is List<*> -> if (value.isEmpty()) "[ ]" else value.toString()
 
         is Array<*> -> if (value.isEmpty()) "[ ]" else value.toList().toString()
+
+        is AnyRow -> value.renderToString(decimalFormat)
 
         else ->
             value?.asArrayAsListOrNull()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -186,8 +186,8 @@ public fun AnyFrame.renderToMarkdown(
     return sb.toString()
 }
 
-internal val valueToStringLimitDefault = 1000
-internal val valueToStringLimitForRowAsTable = 50
+internal const val VALUE_TO_STRING_LIMIT_DEFAULT = 1000
+internal const val VALUE_TO_STRING_LIMIT_FOR_ROW_AS_TABLE = 50
 
 internal fun AnyRow.getVisibleValues(): List<Pair<String, Any?>> {
     fun Any?.skip(): Boolean =
@@ -238,15 +238,15 @@ internal fun renderValueForRowTable(value: Any?, forHtml: Boolean): RenderedCont
         is Collection<*> -> renderCollectionName(value).let { RenderedContent.textWithLength("$it $value", it.length) }
 
         else -> if (forHtml) {
-            renderValueForHtml(value, valueToStringLimitForRowAsTable, RendererDecimalFormat.DEFAULT)
+            renderValueForHtml(value, VALUE_TO_STRING_LIMIT_FOR_ROW_AS_TABLE, RendererDecimalFormat.DEFAULT)
         } else {
-            renderValueForStdout(value, valueToStringLimitForRowAsTable)
+            renderValueForStdout(value, VALUE_TO_STRING_LIMIT_FOR_ROW_AS_TABLE)
         }
     }
 
 internal fun renderValueForStdout(
     value: Any?,
-    limit: Int = valueToStringLimitDefault,
+    limit: Int = VALUE_TO_STRING_LIMIT_DEFAULT,
     decimalFormat: RendererDecimalFormat = RendererDecimalFormat.DEFAULT,
 ): RenderedContent =
     renderValueToString(value, decimalFormat)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -44,11 +44,11 @@ public fun AnyFrame.renderToString(
 
     // top border
     if (borders) {
-        sb.append("\u230C")
+        sb.append(Borders.TOP_LEFT)
         repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append('-') }
-        sb.append("\u230D")
+        sb.append(Borders.TOP_RIGHT)
         sb.appendLine()
-        sb.append("|")
+        sb.append(Borders.VERTICAL)
     }
 
     // header
@@ -57,29 +57,29 @@ public fun AnyFrame.renderToString(
         val str = table.header[col]
         val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
         sb.append(padded)
-        if (borders) sb.append("|")
+        if (borders) sb.append(Borders.VERTICAL)
     }
     sb.appendLine()
 
     // header splitter
     if (borders) {
-        sb.append("|")
+        sb.append(Borders.VERTICAL)
         for (colLength in columnLengths) {
-            repeat(colLength) { sb.append('-') }
-            sb.append("|")
+            repeat(colLength) { sb.append(Borders.HORIZONTAL) }
+            sb.append(Borders.HEADER_SPLIT)
         }
         sb.appendLine()
     }
 
     // data
     for (row in 0 until table.rowsCount) {
-        if (borders) sb.append("|")
+        if (borders) sb.append(Borders.VERTICAL)
         for (col in table.values.indices) {
             val len = columnLengths[col]
             val str = table.values[col][row]
             val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
             sb.append(padded)
-            if (borders) sb.append("|")
+            if (borders) sb.append(Borders.VERTICAL)
         }
         sb.appendLine()
     }
@@ -88,12 +88,22 @@ public fun AnyFrame.renderToString(
     if (table.totalRows > rowsLimit) {
         sb.appendLine("...")
     } else if (borders) {
-        sb.append("\u230E")
-        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append('-') }
-        sb.append("\u230F")
+        sb.append(Borders.BOTTOM_LEFT)
+        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(Borders.HORIZONTAL) }
+        sb.append(Borders.BOTTOM_RIGHT)
         sb.appendLine()
     }
     return sb.toString()
+}
+
+private object Borders {
+    const val TOP_LEFT = "\u230C"
+    const val TOP_RIGHT = "\u230D"
+    const val BOTTOM_LEFT = "\u230E"
+    const val BOTTOM_RIGHT = "\u230F"
+    const val HORIZONTAL = "-"
+    const val VERTICAL = "|"
+    const val HEADER_SPLIT = "|"
 }
 
 private class PreparedTable(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -129,6 +129,53 @@ private fun AnyFrame.prepareTable(
     return PreparedTable(header, values, rowsCount, nrow)
 }
 
+public fun AnyFrame.renderToMarkdown(
+    rowsLimit: Int = 20,
+    valueLimit: Int = 40,
+    alignLeft: Boolean = false,
+    columnTypes: Boolean = false,
+    title: Boolean = false,
+    rowIndex: Boolean = true,
+): String {
+    val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex) { it.replace("|", "\\|") }
+
+    val sb = StringBuilder()
+    if (title) {
+        sb.appendLine("**DataFrame [${size()}]**")
+        sb.appendLine()
+    }
+
+    // header
+    sb.append("|")
+    for (col in table.header) {
+        sb.append(" ${col.replace("|", "\\|")} |")
+    }
+    sb.appendLine()
+
+    // separator
+    sb.append("|")
+    repeat(table.header.size) {
+        sb.append(if (alignLeft) ":---|" else "---:|")
+    }
+    sb.appendLine()
+
+    // data
+    for (row in 0 until table.rowsCount) {
+        sb.append("|")
+        for (col in table.values.indices) {
+            sb.append(" ${table.values[col][row]} |")
+        }
+        sb.appendLine()
+    }
+
+    // footer
+    if (table.totalRows > rowsLimit) {
+        sb.appendLine()
+        sb.appendLine("*... ${table.totalRows - rowsLimit} more rows*")
+    }
+    return sb.toString()
+}
+
 internal val valueToStringLimitDefault = 1000
 internal val valueToStringLimitForRowAsTable = 50
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -33,7 +33,7 @@ public fun AnyFrame.renderToString(
     val sb = StringBuilder()
     val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex)
     val columnLengths = table.values.mapIndexed { col, vals ->
-        (vals + table.header[col]).maxOf { it.length } + 1
+        (vals + table.header[col] + (table.types?.get(col) ?: "")).maxOf { it.length } + 1
     }
 
     // title
@@ -61,6 +61,18 @@ public fun AnyFrame.renderToString(
     }
     sb.appendLine()
 
+    table.types?.let { types ->
+        if (borders) sb.append(Borders.VERTICAL)
+        for (col in table.header.indices) {
+            val len = columnLengths[col]
+            val str = types[col]
+            val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
+            sb.append(padded)
+            if (borders) sb.append(Borders.VERTICAL)
+        }
+        sb.appendLine()
+    }
+
     // header splitter
     if (borders) {
         sb.append(Borders.VERTICAL)
@@ -85,7 +97,7 @@ public fun AnyFrame.renderToString(
     }
 
     // footer
-    if (table.totalRows > rowsLimit) {
+    if (table.totalRows > table.rowsCount) {
         sb.appendLine("...")
     } else if (borders) {
         sb.append(Borders.BOTTOM_LEFT)
@@ -108,6 +120,7 @@ private object Borders {
 
 private class PreparedTable(
     val header: List<String>,
+    val types: List<String>?,
     val values: List<List<String>>,
     val rowsCount: Int,
     val totalRows: Int,
@@ -124,10 +137,21 @@ private fun AnyFrame.prepareTable(
     val cols = if (rowIndex) listOf((0 until rowsCount).toColumn()) + columns() else columns()
     val header = cols.mapIndexed { colIndex, col ->
         if (columnTypes && (!rowIndex || colIndex > 0)) {
-            "${col.name()}:${renderType(col)}"
+            col.name()
         } else {
             col.name()
         }
+    }
+    val types = if (columnTypes) {
+        cols.mapIndexed { colIndex, col ->
+            if (!rowIndex || colIndex > 0) {
+                renderType(col)
+            } else {
+                ""
+            }
+        }
+    } else {
+        null
     }
     val values = cols.map { col ->
         val top = col.take(rowsLimit)
@@ -146,7 +170,7 @@ private fun AnyFrame.prepareTable(
             escapeValue(renderValueForStdout(it, valueLimit, decimalFormat = decimalFormat).truncatedContent)
         }
     }
-    return PreparedTable(header, values, rowsCount, nrow)
+    return PreparedTable(header, types, values, rowsCount, nrow)
 }
 
 public fun AnyFrame.renderToMarkdown(
@@ -167,8 +191,9 @@ public fun AnyFrame.renderToMarkdown(
 
     // header
     sb.append("|")
-    for (col in table.header) {
-        sb.append(" ${col.replace("|", "\\|")} |")
+    for ((i, col) in table.header.withIndex()) {
+        val type = table.types?.getOrNull(i)?.takeIf { it.isNotEmpty() }?.let { ":$it" } ?: ""
+        sb.append(" ${col.replace("|", "\\|")}$type |")
     }
     sb.appendLine()
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -19,11 +19,12 @@ import org.jetbrains.kotlinx.dataframe.jupyter.RenderedContent
 import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.size
+import org.jetbrains.kotlinx.dataframe.util.PRINT
 import java.math.BigDecimal
 
 public fun AnyFrame.renderToString(
-    rowsLimit: Int = 20,
-    valueLimit: Int = 40,
+    rowsLimit: Int? = 20,
+    valueLimit: Int? = 40,
     borders: Boolean = false,
     alignLeft: Boolean = false,
     columnTypes: Boolean = true,
@@ -108,6 +109,17 @@ public fun AnyFrame.renderToString(
     return sb.toString()
 }
 
+@Deprecated(message = PRINT, level = DeprecationLevel.HIDDEN)
+public fun AnyFrame.renderToString(
+    rowsLimit: Int = 20,
+    valueLimit: Int = 40,
+    borders: Boolean = false,
+    alignLeft: Boolean = false,
+    columnTypes: Boolean = true,
+    title: Boolean = false,
+    rowIndex: Boolean = true,
+): String = renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex)
+
 private object Borders {
     const val TOP_LEFT = "\u230C"
     const val TOP_RIGHT = "\u230D"
@@ -127,13 +139,13 @@ internal class PreparedTable(
 )
 
 internal fun AnyFrame.prepareTable(
-    rowsLimit: Int,
-    valueLimit: Int,
+    rowsLimit: Int?,
+    valueLimit: Int?,
     columnTypes: Boolean,
     rowIndex: Boolean,
     escapeValue: (String) -> String = { it },
 ): PreparedTable {
-    val rowsCount = rowsLimit.coerceAtMost(nrow)
+    val rowsCount = rowsLimit?.coerceAtMost(nrow) ?: rowsCount()
     val cols = if (rowIndex) listOf((0..<rowsCount).toColumn()) + columns() else columns()
     val header = cols.map { col -> col.name() }
     val types = if (columnTypes) {
@@ -148,7 +160,7 @@ internal fun AnyFrame.prepareTable(
         null
     }
     val values = cols.map { col ->
-        val top = col.take(rowsLimit)
+        val top = col.take(rowsCount)
         val precision = if (top.isNumber()) {
             top.asNumbers().scale()
         } else if (top.isColumnGroup()) {
@@ -161,7 +173,7 @@ internal fun AnyFrame.prepareTable(
         val decimalFormat =
             if (precision >= 0) RendererDecimalFormat.fromPrecision(precision) else RendererDecimalFormat.of("%e")
         top.values().map {
-            escapeValue(renderValueForStdout(it, valueLimit, decimalFormat = decimalFormat).truncatedContent)
+            escapeValue(renderValueForStdout(it, valueLimit ?: -1, decimalFormat = decimalFormat).truncatedContent)
         }
     }
     return PreparedTable(header, types, values, rowsCount, nrow)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -118,7 +118,7 @@ private object Borders {
     const val HEADER_SPLIT = "|"
 }
 
-private class PreparedTable(
+internal class PreparedTable(
     val header: List<String>,
     val types: List<String>?,
     val values: List<List<String>>,
@@ -126,7 +126,7 @@ private class PreparedTable(
     val totalRows: Int,
 )
 
-private fun AnyFrame.prepareTable(
+internal fun AnyFrame.prepareTable(
     rowsLimit: Int,
     valueLimit: Int,
     columnTypes: Boolean,
@@ -134,14 +134,8 @@ private fun AnyFrame.prepareTable(
     escapeValue: (String) -> String = { it },
 ): PreparedTable {
     val rowsCount = rowsLimit.coerceAtMost(nrow)
-    val cols = if (rowIndex) listOf((0 until rowsCount).toColumn()) + columns() else columns()
-    val header = cols.mapIndexed { colIndex, col ->
-        if (columnTypes && (!rowIndex || colIndex > 0)) {
-            col.name()
-        } else {
-            col.name()
-        }
-    }
+    val cols = if (rowIndex) listOf((0..<rowsCount).toColumn()) + columns() else columns()
+    val header = cols.map { col -> col.name() }
     val types = if (columnTypes) {
         cols.mapIndexed { colIndex, col ->
             if (!rowIndex || colIndex > 0) {
@@ -171,54 +165,6 @@ private fun AnyFrame.prepareTable(
         }
     }
     return PreparedTable(header, types, values, rowsCount, nrow)
-}
-
-public fun AnyFrame.renderToMarkdown(
-    rowsLimit: Int = 20,
-    valueLimit: Int = 40,
-    alignLeft: Boolean = false,
-    columnTypes: Boolean = false,
-    title: Boolean = false,
-    rowIndex: Boolean = true,
-): String {
-    val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex) { it.replace("|", "\\|") }
-
-    val sb = StringBuilder()
-    if (title) {
-        sb.appendLine("**DataFrame [${size()}]**")
-        sb.appendLine()
-    }
-
-    // header
-    sb.append("|")
-    for ((i, col) in table.header.withIndex()) {
-        val type = table.types?.getOrNull(i)?.takeIf { it.isNotEmpty() }?.let { ":$it" } ?: ""
-        sb.append(" ${col.replace("|", "\\|")}$type |")
-    }
-    sb.appendLine()
-
-    // separator
-    sb.append("|")
-    repeat(table.header.size) {
-        sb.append(if (alignLeft) ":---|" else "---:|")
-    }
-    sb.appendLine()
-
-    // data
-    for (row in 0 until table.rowsCount) {
-        sb.append("|")
-        for (col in table.values.indices) {
-            sb.append(" ${table.values[col][row]} |")
-        }
-        sb.appendLine()
-    }
-
-    // footer
-    if (table.totalRows > rowsLimit) {
-        sb.appendLine()
-        sb.appendLine("*... ${table.totalRows - rowsLimit} more rows*")
-    }
-    return sb.toString()
 }
 
 internal const val VALUE_TO_STRING_LIMIT_DEFAULT = 1000

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -33,7 +33,7 @@ public fun AnyFrame.renderToString(
     val sb = StringBuilder()
     val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex)
     val columnLengths = table.values.mapIndexed { col, vals ->
-        (vals + table.header[col] + (table.types?.get(col) ?: "")).maxOf { it.length } + 1
+        (vals + table.header[col] + (table.types?.get(col) ?: "")).maxOf { it.length } + 2
     }
 
     // title

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -30,6 +30,7 @@ public fun AnyFrame.renderToString(
     columnTypes: Boolean = true,
     title: Boolean = false,
     rowIndex: Boolean = true,
+    borderStyle: StringBorderStyle = StringBorderStyle.DottedLineWithRounderCorners,
 ): String {
     val sb = StringBuilder()
     val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex)
@@ -45,11 +46,11 @@ public fun AnyFrame.renderToString(
 
     // top border
     if (borders) {
-        sb.append(Borders.TOP_LEFT)
-        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append('-') }
-        sb.append(Borders.TOP_RIGHT)
+        sb.append(borderStyle.topLeft)
+        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(borderStyle.horizontal) }
+        sb.append(borderStyle.topRight)
         sb.appendLine()
-        sb.append(Borders.VERTICAL)
+        sb.append(borderStyle.vertical)
     }
 
     // header
@@ -58,41 +59,41 @@ public fun AnyFrame.renderToString(
         val str = table.header[col]
         val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
         sb.append(padded)
-        if (borders) sb.append(Borders.VERTICAL)
+        if (borders) sb.append(borderStyle.vertical)
     }
     sb.appendLine()
 
     table.types?.let { types ->
-        if (borders) sb.append(Borders.VERTICAL)
+        if (borders) sb.append(borderStyle.vertical)
         for (col in table.header.indices) {
             val len = columnLengths[col]
             val str = types[col]
             val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
             sb.append(padded)
-            if (borders) sb.append(Borders.VERTICAL)
+            if (borders) sb.append(borderStyle.vertical)
         }
         sb.appendLine()
     }
 
     // header splitter
     if (borders) {
-        sb.append(Borders.VERTICAL)
+        sb.append(borderStyle.vertical)
         for (colLength in columnLengths) {
-            repeat(colLength) { sb.append(Borders.HORIZONTAL) }
-            sb.append(Borders.HEADER_SPLIT)
+            repeat(colLength) { sb.append(borderStyle.horizontal) }
+            sb.append(borderStyle.headerSplit)
         }
         sb.appendLine()
     }
 
     // data
     for (row in 0 until table.rowsCount) {
-        if (borders) sb.append(Borders.VERTICAL)
+        if (borders) sb.append(borderStyle.vertical)
         for (col in table.values.indices) {
             val len = columnLengths[col]
             val str = table.values[col][row]
             val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
             sb.append(padded)
-            if (borders) sb.append(Borders.VERTICAL)
+            if (borders) sb.append(borderStyle.vertical)
         }
         sb.appendLine()
     }
@@ -102,9 +103,9 @@ public fun AnyFrame.renderToString(
         sb.appendLine("...")
         sb.appendLine("${size.ncol} columns x ${size.nrow} rows")
     } else if (borders) {
-        sb.append(Borders.BOTTOM_LEFT)
-        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(Borders.HORIZONTAL) }
-        sb.append(Borders.BOTTOM_RIGHT)
+        sb.append(borderStyle.bottomLeft)
+        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(borderStyle.horizontal) }
+        sb.append(borderStyle.bottomRight)
         sb.appendLine()
     }
     return sb.toString()
@@ -121,14 +122,46 @@ public fun AnyFrame.renderToString(
     rowIndex: Boolean = true,
 ): String = renderToString(rowsLimit, valueLimit, borders, alignLeft, columnTypes, title, rowIndex)
 
-private object Borders {
-    const val TOP_LEFT = "\u230C"
-    const val TOP_RIGHT = "\u230D"
-    const val BOTTOM_LEFT = "\u230E"
-    const val BOTTOM_RIGHT = "\u230F"
-    const val HORIZONTAL = "-"
-    const val VERTICAL = "|"
-    const val HEADER_SPLIT = "|"
+public interface StringBorderStyle {
+    public val topLeft: String
+    public val topRight: String
+    public val bottomLeft: String
+    public val bottomRight: String
+    public val horizontal: String
+    public val vertical: String
+    public val headerSplit: String
+
+    public object DottedLineWithRounderCorners : StringBorderStyle {
+        public override val topLeft: String = "\u230C"
+        public override val topRight: String = "\u230D"
+        public override val bottomLeft: String = "\u230E"
+        public override val bottomRight: String = "\u230F"
+        public override val horizontal: String = "-"
+        public override val vertical: String = "|"
+        public override val headerSplit: String = "|"
+    }
+
+    public object ContinuousWithRoundedCorners : StringBorderStyle {
+        public override val topLeft: String = "╭"
+        public override val topRight: String = "╮"
+        public override val bottomLeft: String = "╰"
+        public override val bottomRight: String = "╯"
+        public override val horizontal: String = "─"
+        public override val vertical: String = "│"
+        public override val headerSplit: String = "┼"
+    }
+
+    public object ContinuousWithSquareCorners : StringBorderStyle {
+        public override val topLeft: String = "┌"
+        public override val topRight: String = "┐"
+        public override val bottomLeft: String = "└"
+        public override val bottomRight: String = "┘"
+        public override val horizontal: String = "─"
+        public override val vertical: String = "│"
+        public override val headerSplit: String = "┼"
+    }
+
+    public companion object
 }
 
 internal class PreparedTable(

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -34,7 +34,7 @@ public fun AnyFrame.renderToString(
 ): String {
     val sb = StringBuilder()
     val table = prepareTable(rowsLimit, valueLimit, columnTypes, rowIndex)
-    val columnLengths = table.values.mapIndexed { col, vals ->
+    val columnWidths = table.values.mapIndexed { col, vals ->
         (vals + table.header[col] + (table.types?.get(col) ?: "")).maxOf { it.length } + 2
     }
 
@@ -47,7 +47,7 @@ public fun AnyFrame.renderToString(
     // top border
     if (borders) {
         sb.append(borderStyle.topLeft)
-        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(borderStyle.horizontal) }
+        repeat(columnWidths.sum() + columnWidths.size - 1) { sb.append(borderStyle.horizontal) }
         sb.append(borderStyle.topRight)
         sb.appendLine()
         sb.append(borderStyle.vertical)
@@ -55,9 +55,9 @@ public fun AnyFrame.renderToString(
 
     // header
     for (col in table.header.indices) {
-        val len = columnLengths[col]
+        val width = columnWidths[col]
         val str = table.header[col]
-        val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
+        val padded = if (alignLeft) str.padEnd(width) else str.padStart(width)
         sb.append(padded)
         if (borders) sb.append(borderStyle.vertical)
     }
@@ -66,9 +66,9 @@ public fun AnyFrame.renderToString(
     table.types?.let { types ->
         if (borders) sb.append(borderStyle.vertical)
         for (col in table.header.indices) {
-            val len = columnLengths[col]
+            val width = columnWidths[col]
             val str = types[col]
-            val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
+            val padded = if (alignLeft) str.padEnd(width) else str.padStart(width)
             sb.append(padded)
             if (borders) sb.append(borderStyle.vertical)
         }
@@ -78,17 +78,17 @@ public fun AnyFrame.renderToString(
     // header splitter
     if (borders) {
         sb.append(borderStyle.vertical)
-        for (colLength in columnLengths) {
-            repeat(colLength) { sb.append(borderStyle.horizontal) }
+        for (colWidth in columnWidths) {
+            repeat(colWidth) { sb.append(borderStyle.horizontal) }
             sb.append(borderStyle.headerSplit)
         }
         sb.appendLine()
     } else {
-        for ((i, colLength) in columnLengths.withIndex()) {
-            val splitterSize = minOf(colLength, 4)
+        for ((i, colWidth) in columnWidths.withIndex()) {
+            val splitterSize = minOf(colWidth, 4)
             val char = if (rowIndex && i == 0) " " else "-"
             val str = char.repeat(splitterSize)
-            val padded = if (alignLeft) str.padEnd(colLength) else str.padStart(colLength)
+            val padded = if (alignLeft) str.padEnd(colWidth) else str.padStart(colWidth)
             sb.append(padded)
         }
         sb.appendLine()
@@ -98,9 +98,9 @@ public fun AnyFrame.renderToString(
     for (row in 0 until table.rowsCount) {
         if (borders) sb.append(borderStyle.vertical)
         for (col in table.values.indices) {
-            val len = columnLengths[col]
+            val width = columnWidths[col]
             val str = table.values[col][row]
-            val padded = if (alignLeft) str.padEnd(len) else str.padStart(len)
+            val padded = if (alignLeft) str.padEnd(width) else str.padStart(width)
             sb.append(padded)
             if (borders) sb.append(borderStyle.vertical)
         }
@@ -113,7 +113,7 @@ public fun AnyFrame.renderToString(
         sb.appendLine("${size.ncol} columns x ${size.nrow} rows")
     } else if (borders) {
         sb.append(borderStyle.bottomLeft)
-        repeat(columnLengths.sum() + columnLengths.size - 1) { sb.append(borderStyle.horizontal) }
+        repeat(columnWidths.sum() + columnWidths.size - 1) { sb.append(borderStyle.horizontal) }
         sb.append(borderStyle.bottomRight)
         sb.appendLine()
     }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/io/string.kt
@@ -83,6 +83,15 @@ public fun AnyFrame.renderToString(
             sb.append(borderStyle.headerSplit)
         }
         sb.appendLine()
+    } else {
+        for ((i, colLength) in columnLengths.withIndex()) {
+            val splitterSize = minOf(colLength, 4)
+            val char = if (rowIndex && i == 0) " " else "-"
+            val str = char.repeat(splitterSize)
+            val padded = if (alignLeft) str.padEnd(colLength) else str.padStart(colLength)
+            sb.append(padded)
+        }
+        sb.appendLine()
     }
 
     // data

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToMarkdownTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToMarkdownTests.kt
@@ -1,0 +1,136 @@
+package org.jetbrains.kotlinx.dataframe.rendering
+
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.io.renderToMarkdown
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Suppress("ktlint:standard:argument-list-wrapping")
+class RenderToMarkdownTests {
+    private val df = dataFrameOf("name", "age", "city")(
+        "Alice", 30, "Berlin",
+        "Bob", 25, "Paris",
+        "Charlie", 35, "London",
+    )
+
+    @Test
+    fun `markdown basic structure`() {
+        val result = df.renderToMarkdown()
+        val expected =
+            """
+            |  | name | age | city |
+            |---:|---:|---:|---:|
+            | 0 | Alice | 30 | Berlin |
+            | 1 | Bob | 25 | Paris |
+            | 2 | Charlie | 35 | London |
+
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown basic structure without index`() {
+        val result = df.renderToMarkdown(rowIndex = false)
+        val expected =
+            """
+            | name | age | city |
+            |---:|---:|---:|
+            | Alice | 30 | Berlin |
+            | Bob | 25 | Paris |
+            | Charlie | 35 | London |
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown with types structure`() {
+        val result = df.renderToMarkdown(columnTypes = true)
+        val expected =
+            """
+            |  | name:String | age:Int | city:String |
+            |---:|---:|---:|---:|
+            | 0 | Alice | 30 | Berlin |
+            | 1 | Bob | 25 | Paris |
+            | 2 | Charlie | 35 | London |
+
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown align left`() {
+        val result = df.renderToMarkdown(alignLeft = true, rowIndex = false)
+        val expected =
+            """
+            | name | age | city |
+            |:---|:---|:---|
+            | Alice | 30 | Berlin |
+            | Bob | 25 | Paris |
+            | Charlie | 35 | London |
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown align right`() {
+        val result = df.renderToMarkdown(alignLeft = false, rowIndex = false)
+        val expected =
+            """
+            | name | age | city |
+            |---:|---:|---:|
+            | Alice | 30 | Berlin |
+            | Bob | 25 | Paris |
+            | Charlie | 35 | London |
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown with title`() {
+        val result = df.renderToMarkdown(title = true, rowIndex = false)
+        val expected =
+            """
+            **DataFrame [3 x 3]**
+
+            | name | age | city |
+            |---:|---:|---:|
+            | Alice | 30 | Berlin |
+            | Bob | 25 | Paris |
+            | Charlie | 35 | London |
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown truncation footer`() {
+        val result = df.renderToMarkdown(rowsLimit = 1, rowIndex = false)
+        val expected =
+            """
+            | name | age | city |
+            |---:|---:|---:|
+            | Alice | 30 | Berlin |
+
+            *... 2 more rows*
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown escapes pipes in values`() {
+        val pipeDf = dataFrameOf("cmd")("a|b")
+        val result = pipeDf.renderToMarkdown(rowIndex = false)
+        val expected =
+            """
+            | cmd |
+            |---:|
+            | a\|b |
+
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToMarkdownTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToMarkdownTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.rendering
 
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.io.MarkdownAlignment
 import org.jetbrains.kotlinx.dataframe.io.renderToMarkdown
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,7 +20,7 @@ class RenderToMarkdownTests {
         val expected =
             """
             |  | name | age | city |
-            |---:|---:|---:|---:|
+            |---|---|---|---|
             | 0 | Alice | 30 | Berlin |
             | 1 | Bob | 25 | Paris |
             | 2 | Charlie | 35 | London |
@@ -34,7 +35,7 @@ class RenderToMarkdownTests {
         val expected =
             """
             | name | age | city |
-            |---:|---:|---:|
+            |---|---|---|
             | Alice | 30 | Berlin |
             | Bob | 25 | Paris |
             | Charlie | 35 | London |
@@ -49,7 +50,7 @@ class RenderToMarkdownTests {
         val expected =
             """
             |  | name:String | age:Int | city:String |
-            |---:|---:|---:|---:|
+            |---|---|---|---|
             | 0 | Alice | 30 | Berlin |
             | 1 | Bob | 25 | Paris |
             | 2 | Charlie | 35 | London |
@@ -60,7 +61,7 @@ class RenderToMarkdownTests {
 
     @Test
     fun `markdown align left`() {
-        val result = df.renderToMarkdown(alignLeft = true, rowIndex = false)
+        val result = df.renderToMarkdown(alignment = MarkdownAlignment.LEFT, rowIndex = false)
         val expected =
             """
             | name | age | city |
@@ -75,11 +76,26 @@ class RenderToMarkdownTests {
 
     @Test
     fun `markdown align right`() {
-        val result = df.renderToMarkdown(alignLeft = false, rowIndex = false)
+        val result = df.renderToMarkdown(alignment = MarkdownAlignment.RIGHT, rowIndex = false)
         val expected =
             """
             | name | age | city |
             |---:|---:|---:|
+            | Alice | 30 | Berlin |
+            | Bob | 25 | Paris |
+            | Charlie | 35 | London |
+            
+            """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `markdown align center`() {
+        val result = df.renderToMarkdown(alignment = MarkdownAlignment.CENTER, rowIndex = false)
+        val expected =
+            """
+            | name | age | city |
+            |:---:|:---:|:---:|
             | Alice | 30 | Berlin |
             | Bob | 25 | Paris |
             | Charlie | 35 | London |
@@ -96,7 +112,7 @@ class RenderToMarkdownTests {
             **DataFrame [3 x 3]**
 
             | name | age | city |
-            |---:|---:|---:|
+            |---|---|---|
             | Alice | 30 | Berlin |
             | Bob | 25 | Paris |
             | Charlie | 35 | London |
@@ -111,7 +127,7 @@ class RenderToMarkdownTests {
         val expected =
             """
             | name | age | city |
-            |---:|---:|---:|
+            |---|---|---|
             | Alice | 30 | Berlin |
 
             *... 2 more rows*
@@ -127,7 +143,7 @@ class RenderToMarkdownTests {
         val expected =
             """
             | cmd |
-            |---:|
+            |---|
             | a\|b |
 
             """.trimIndent()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -19,7 +19,7 @@ class RenderToStringTests {
 
     @Test
     fun `default rendering`() {
-        val result = df.renderToString()
+        val result = df.renderToString(columnTypes = false)
         val expected = """
             |      name age   city
             | 0   Alice  30 Berlin
@@ -32,7 +32,7 @@ class RenderToStringTests {
 
     @Test
     fun `no index rendering`() {
-        val result = df.renderToString(rowIndex = false)
+        val result = df.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
             |    name age   city
             |   Alice  30 Berlin
@@ -45,7 +45,7 @@ class RenderToStringTests {
 
     @Test
     fun `with borders`() {
-        val result = df.renderToString(borders = true, rowIndex = false)
+        val result = df.renderToString(borders = true, rowIndex = false, columnTypes = false)
         val expected = """
             |⌌---------------------⌍
             ||    name| age|   city|
@@ -61,7 +61,7 @@ class RenderToStringTests {
 
     @Test
     fun `align left`() {
-        val result = df.renderToString(alignLeft = true, rowIndex = false)
+        val result = df.renderToString(alignLeft = true, rowIndex = false, columnTypes = false)
         val expected = """
             |name    age city   
             |Alice   30  Berlin 
@@ -139,7 +139,7 @@ class RenderToStringTests {
 
     @Test
     fun `with title`() {
-        val result = df.renderToString(title = true, rowIndex = false)
+        val result = df.renderToString(title = true, rowIndex = false, columnTypes = false)
         val expected = """
             |DataFrame [3 x 3]
             |
@@ -159,7 +159,7 @@ class RenderToStringTests {
                 "l" from { "a"<Double>() }
                 "r" from { "a"<Double>() }
             }
-        }.renderToString()
+        }.renderToString(columnTypes = false)
         val expected = """
             |     a            group
             | 0 0.0 { l:0.0, r:0.0 }
@@ -170,7 +170,7 @@ class RenderToStringTests {
 
     @Test
     fun `rows limit truncates`() {
-        val result = df.renderToString(rowsLimit = 2, rowIndex = false)
+        val result = df.renderToString(rowsLimit = 2, rowIndex = false, columnTypes = false)
         val expected = """
             |  name age   city
             | Alice  30 Berlin
@@ -187,7 +187,7 @@ class RenderToStringTests {
             1, "hello",
             2, null,
         )
-        val result = nullDf.renderToString(rowIndex = false)
+        val result = nullDf.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
          | a     b
          | 1 hello

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -21,10 +21,10 @@ class RenderToStringTests {
     fun `default rendering`() {
         val result = df.renderToString(columnTypes = false)
         val expected = """
-            |      name age   city
-            | 0   Alice  30 Berlin
-            | 1     Bob  25  Paris
-            | 2 Charlie  35 London
+            |        name  age    city
+            |  0    Alice   30  Berlin
+            |  1      Bob   25   Paris
+            |  2  Charlie   35  London
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -34,10 +34,10 @@ class RenderToStringTests {
     fun `no index rendering`() {
         val result = df.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
-            |    name age   city
-            |   Alice  30 Berlin
-            |     Bob  25  Paris
-            | Charlie  35 London
+            |     name  age    city
+            |    Alice   30  Berlin
+            |      Bob   25   Paris
+            |  Charlie   35  London
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -47,13 +47,13 @@ class RenderToStringTests {
     fun `with borders`() {
         val result = df.renderToString(borders = true, rowIndex = false, columnTypes = false)
         val expected = """
-            |⌌---------------------⌍
-            ||    name| age|   city|
-            ||--------|----|-------|
-            ||   Alice|  30| Berlin|
-            ||     Bob|  25|  Paris|
-            || Charlie|  35| London|
-            |⌎---------------------⌏
+            |⌌------------------------⌍
+            ||     name|  age|    city|
+            ||---------|-----|--------|
+            ||    Alice|   30|  Berlin|
+            ||      Bob|   25|   Paris|
+            ||  Charlie|   35|  London|
+            |⌎------------------------⌏
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -63,10 +63,10 @@ class RenderToStringTests {
     fun `align left`() {
         val result = df.renderToString(alignLeft = true, rowIndex = false, columnTypes = false)
         val expected = """
-            |name    age city   
-            |Alice   30  Berlin 
-            |Bob     25  Paris  
-            |Charlie 35  London 
+            |name     age  city    
+            |Alice    30   Berlin  
+            |Bob      25   Paris   
+            |Charlie  35   London  
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -74,11 +74,12 @@ class RenderToStringTests {
 
     @Test
     fun `with column types`() {
-        val result = df.take(0).renderToString(columnTypes = true)
+        val result = df.take(1).renderToString(columnTypes = true)
         val expected =
             """
-            |    name age   city
-            |  String Int String
+            |       name  age    city
+            |     String  Int  String
+            |  0   Alice   30  Berlin
             |
             """.trimMargin()
         assertEquals(expected, result)
@@ -94,9 +95,9 @@ class RenderToStringTests {
         }.renderToString(columnTypes = true)
         val expected =
             """
-            |        a                group
-            |   Double {l:Double, r:Double}
-            | 0    0.0     { l:0.0, r:0.0 }
+            |          a                 group
+            |     Double  {l:Double, r:Double}
+            |  0     0.0      { l:0.0, r:0.0 }
             |
             """.trimMargin()
         assertEquals(expected, result)
@@ -112,9 +113,9 @@ class RenderToStringTests {
         }.groupBy("a").toDataFrame().renderToString(columnTypes = true)
         val expected =
             """
-            |        a                                    group
-            |   Double   [a:Double, group:{l:Double, r:Double}]
-            | 0    0.0 [1 x 2] { a:0.000000, group:{ l:0.000...
+            |          a                                     group
+            |     Double    [a:Double, group:{l:Double, r:Double}]
+            |  0     0.0  [1 x 2] { a:0.000000, group:{ l:0.000...
             |
             """.trimMargin()
         assertEquals(expected, result)
@@ -124,14 +125,14 @@ class RenderToStringTests {
     fun `with types and borders`() {
         val result = df.renderToString(borders = true, rowIndex = false, columnTypes = true)
         val expected = """
-            |⌌---------------------⌍
-            ||    name| age|   city|
-            ||  String| Int| String|
-            ||--------|----|-------|
-            ||   Alice|  30| Berlin|
-            ||     Bob|  25|  Paris|
-            || Charlie|  35| London|
-            |⌎---------------------⌏
+            |⌌------------------------⌍
+            ||     name|  age|    city|
+            ||   String|  Int|  String|
+            ||---------|-----|--------|
+            ||    Alice|   30|  Berlin|
+            ||      Bob|   25|   Paris|
+            ||  Charlie|   35|  London|
+            |⌎------------------------⌏
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -143,10 +144,10 @@ class RenderToStringTests {
         val expected = """
             |DataFrame [3 x 3]
             |
-            |    name age   city
-            |   Alice  30 Berlin
-            |     Bob  25  Paris
-            | Charlie  35 London
+            |     name  age    city
+            |    Alice   30  Berlin
+            |      Bob   25   Paris
+            |  Charlie   35  London
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -161,8 +162,8 @@ class RenderToStringTests {
             }
         }.renderToString(columnTypes = false)
         val expected = """
-            |     a            group
-            | 0 0.0 { l:0.0, r:0.0 }
+            |       a             group
+            |  0  0.0  { l:0.0, r:0.0 }
             |
         """.trimMargin()
         assertEquals(expected, result)
@@ -172,9 +173,9 @@ class RenderToStringTests {
     fun `rows limit truncates`() {
         val result = df.renderToString(rowsLimit = 2, rowIndex = false, columnTypes = false)
         val expected = """
-            |  name age   city
-            | Alice  30 Berlin
-            |   Bob  25  Paris
+            |   name  age    city
+            |  Alice   30  Berlin
+            |    Bob   25   Paris
             |...
             |
         """.trimMargin()
@@ -189,9 +190,9 @@ class RenderToStringTests {
         )
         val result = nullDf.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
-         | a     b
-         | 1 hello
-         | 2  null
+         |  a      b
+         |  1  hello
+         |  2   null
          |
         """.trimMargin()
         assertEquals(expected, result)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.kotlinx.dataframe.rendering
 
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.groupBy
 import org.jetbrains.kotlinx.dataframe.api.take
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -196,5 +199,22 @@ class RenderToStringTests {
          |
         """.trimMargin()
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun `render rows unlimited`() {
+        val result = List(500) { it }.toDataFrame {
+            "i" from { it }
+            "hash" from { it.hashCode().toString() }
+        }.renderToString(rowsLimit = null)
+
+        // header + data + empty newline
+        result.lines().size shouldBe 503
+    }
+
+    @Test
+    fun `render values unlimited`() {
+        val result = dataFrameOf("a")("abc".repeat(100)).renderToString(valueLimit = null)
+        result.lines().maxOf { it.length } shouldBeGreaterThan 300
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.rendering
 
+import org.jetbrains.kotlinx.dataframe.api.add
+import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import kotlin.test.Test
@@ -88,6 +90,22 @@ class RenderToStringTests {
             |
         """.trimMargin()
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun renderDoubles() {
+        val res = dataFrameOf("a" to columnOf(0.0)).add {
+            "group" {
+                "l" from { "a"<Double>() }
+                "r" from { "a"<Double>() }
+            }
+        }.renderToString()
+        val expected = """
+            |     a            group
+            | 0 0.0 { l:0.0, r:0.0 }
+            |
+        """.trimMargin()
+        assertEquals(expected, res)
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -180,6 +180,7 @@ class RenderToStringTests {
             |  Alice   30  Berlin
             |    Bob   25   Paris
             |...
+            |3 columns x 3 rows
             |
         """.trimMargin()
         assertEquals(expected, result)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -1,0 +1,121 @@
+package org.jetbrains.kotlinx.dataframe.rendering
+
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.io.renderToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Suppress("ktlint:standard:argument-list-wrapping")
+class RenderToStringTests {
+    private val df = dataFrameOf("name", "age", "city")(
+        "Alice", 30, "Berlin",
+        "Bob", 25, "Paris",
+        "Charlie", 35, "London",
+    )
+
+    @Test
+    fun `default rendering`() {
+        val result = df.renderToString()
+        val expected = """
+            |      name age   city
+            | 0   Alice  30 Berlin
+            | 1     Bob  25  Paris
+            | 2 Charlie  35 London
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `no index rendering`() {
+        val result = df.renderToString(rowIndex = false)
+        val expected = """
+            |    name age   city
+            |   Alice  30 Berlin
+            |     Bob  25  Paris
+            | Charlie  35 London
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `with borders`() {
+        val result = df.renderToString(borders = true, rowIndex = false)
+        val expected = """
+            |⌌---------------------⌍
+            ||    name| age|   city|
+            ||--------|----|-------|
+            ||   Alice|  30| Berlin|
+            ||     Bob|  25|  Paris|
+            || Charlie|  35| London|
+            |⌎---------------------⌏
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `align left`() {
+        val result = df.renderToString(alignLeft = true, rowIndex = false)
+        val expected = """
+            |name    age city   
+            |Alice   30  Berlin 
+            |Bob     25  Paris  
+            |Charlie 35  London 
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `with column types`() {
+        val result = df.renderToString(columnTypes = true, rowIndex = false)
+        val header = result.lines().first()
+        assertEquals(""" name:String age:Int city:String""", header)
+    }
+
+    @Test
+    fun `with title`() {
+        val result = df.renderToString(title = true, rowIndex = false)
+        val expected = """
+            |DataFrame [3 x 3]
+            |
+            |    name age   city
+            |   Alice  30 Berlin
+            |     Bob  25  Paris
+            | Charlie  35 London
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `rows limit truncates`() {
+        val result = df.renderToString(rowsLimit = 2, rowIndex = false)
+        val expected = """
+            |  name age   city
+            | Alice  30 Berlin
+            |   Bob  25  Paris
+            |...
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `nullable values`() {
+        val nullDf = dataFrameOf("a", "b")(
+            1, "hello",
+            2, null,
+        )
+        val result = nullDf.renderToString(rowIndex = false)
+        val expected = """
+         | a     b
+         | 1 hello
+         | 2  null
+         |
+        """.trimMargin()
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -3,6 +3,8 @@ package org.jetbrains.kotlinx.dataframe.rendering
 import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.take
 import org.jetbrains.kotlinx.dataframe.io.renderToString
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -72,9 +74,67 @@ class RenderToStringTests {
 
     @Test
     fun `with column types`() {
-        val result = df.renderToString(columnTypes = true, rowIndex = false)
-        val header = result.lines().first()
-        assertEquals(""" name:String age:Int city:String""", header)
+        val result = df.take(0).renderToString(columnTypes = true)
+        val expected =
+            """
+            |    name age   city
+            |  String Int String
+            |
+            """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `columngroup with column types`() {
+        val result = dataFrameOf("a" to columnOf(0.0)).add {
+            "group" {
+                "l" from { "a"<Double>() }
+                "r" from { "a"<Double>() }
+            }
+        }.renderToString(columnTypes = true)
+        val expected =
+            """
+            |        a                group
+            |   Double {l:Double, r:Double}
+            | 0    0.0     { l:0.0, r:0.0 }
+            |
+            """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `framecol with column types`() {
+        val result = dataFrameOf("a" to columnOf(0.0)).add {
+            "group" {
+                "l" from { "a"<Double>() }
+                "r" from { "a"<Double>() }
+            }
+        }.groupBy("a").toDataFrame().renderToString(columnTypes = true)
+        val expected =
+            """
+            |        a                                    group
+            |   Double   [a:Double, group:{l:Double, r:Double}]
+            | 0    0.0 [1 x 2] { a:0.000000, group:{ l:0.000...
+            |
+            """.trimMargin()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `with types and borders`() {
+        val result = df.renderToString(borders = true, rowIndex = false, columnTypes = true)
+        val expected = """
+            |⌌---------------------⌍
+            ||    name| age|   city|
+            ||  String| Int| String|
+            ||--------|----|-------|
+            ||   Alice|  30| Berlin|
+            ||     Bob|  25|  Paris|
+            || Charlie|  35| London|
+            |⌎---------------------⌏
+            |
+        """.trimMargin()
+        assertEquals(expected, result)
     }
 
     @Test
@@ -94,7 +154,7 @@ class RenderToStringTests {
 
     @Test
     fun renderDoubles() {
-        val res = dataFrameOf("a" to columnOf(0.0)).add {
+        val result = dataFrameOf("a" to columnOf(0.0)).add {
             "group" {
                 "l" from { "a"<Double>() }
                 "r" from { "a"<Double>() }
@@ -105,7 +165,7 @@ class RenderToStringTests {
             | 0 0.0 { l:0.0, r:0.0 }
             |
         """.trimMargin()
-        assertEquals(expected, res)
+        assertEquals(expected, result)
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/rendering/RenderToStringTests.kt
@@ -25,6 +25,7 @@ class RenderToStringTests {
         val result = df.renderToString(columnTypes = false)
         val expected = """
             |        name  age    city
+            |        ---- ----    ----
             |  0    Alice   30  Berlin
             |  1      Bob   25   Paris
             |  2  Charlie   35  London
@@ -38,6 +39,7 @@ class RenderToStringTests {
         val result = df.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
             |     name  age    city
+            |     ---- ----    ----
             |    Alice   30  Berlin
             |      Bob   25   Paris
             |  Charlie   35  London
@@ -67,6 +69,7 @@ class RenderToStringTests {
         val result = df.renderToString(alignLeft = true, rowIndex = false, columnTypes = false)
         val expected = """
             |name     age  city    
+            |----     ---- ----    
             |Alice    30   Berlin  
             |Bob      25   Paris   
             |Charlie  35   London  
@@ -82,6 +85,7 @@ class RenderToStringTests {
             """
             |       name  age    city
             |     String  Int  String
+            |       ---- ----    ----
             |  0   Alice   30  Berlin
             |
             """.trimMargin()
@@ -100,6 +104,7 @@ class RenderToStringTests {
             """
             |          a                 group
             |     Double  {l:Double, r:Double}
+            |       ----                  ----
             |  0     0.0      { l:0.0, r:0.0 }
             |
             """.trimMargin()
@@ -118,6 +123,7 @@ class RenderToStringTests {
             """
             |          a                                     group
             |     Double    [a:Double, group:{l:Double, r:Double}]
+            |       ----                                      ----
             |  0     0.0  [1 x 2] { a:0.000000, group:{ l:0.000...
             |
             """.trimMargin()
@@ -148,6 +154,7 @@ class RenderToStringTests {
             |DataFrame [3 x 3]
             |
             |     name  age    city
+            |     ---- ----    ----
             |    Alice   30  Berlin
             |      Bob   25   Paris
             |  Charlie   35  London
@@ -166,6 +173,7 @@ class RenderToStringTests {
         }.renderToString(columnTypes = false)
         val expected = """
             |       a             group
+            |    ----              ----
             |  0  0.0  { l:0.0, r:0.0 }
             |
         """.trimMargin()
@@ -177,6 +185,7 @@ class RenderToStringTests {
         val result = df.renderToString(rowsLimit = 2, rowIndex = false, columnTypes = false)
         val expected = """
             |   name  age    city
+            |   ---- ----    ----
             |  Alice   30  Berlin
             |    Bob   25   Paris
             |...
@@ -195,6 +204,7 @@ class RenderToStringTests {
         val result = nullDf.renderToString(rowIndex = false, columnTypes = false)
         val expected = """
          |  a      b
+         |---   ----
          |  1  hello
          |  2   null
          |
@@ -209,8 +219,8 @@ class RenderToStringTests {
             "hash" from { it.hashCode().toString() }
         }.renderToString(rowsLimit = null)
 
-        // header + data + empty newline
-        result.lines().size shouldBe 503
+        // header + separator + data + empty newline
+        result.lines().size shouldBe 504
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -2176,15 +2176,15 @@ class DataFrameTests : BaseTest() {
     fun `render to string`() {
         val expected =
             """
-                 name age    city weight
-               String Int String?   Int?
-            0   Alice  15  London     54
-            1     Bob  45   Dubai     87
-            2 Charlie  20  Moscow   null
-            3 Charlie  40   Milan   null
-            4     Bob  30   Tokyo     68
-            5   Alice  20    null     55
-            6 Charlie  30  Moscow     90
+                  name  age     city  weight
+                String  Int  String?    Int?
+            0    Alice   15   London      54
+            1      Bob   45    Dubai      87
+            2  Charlie   20   Moscow    null
+            3  Charlie   40    Milan    null
+            4      Bob   30    Tokyo      68
+            5    Alice   20     null      55
+            6  Charlie   30   Moscow      90
             """.trimIndent()
 
         typed.toString().trimIndent() shouldBe expected

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -2176,14 +2176,15 @@ class DataFrameTests : BaseTest() {
     fun `render to string`() {
         val expected =
             """
-                 name age   city weight
-            0   Alice  15 London     54
-            1     Bob  45  Dubai     87
-            2 Charlie  20 Moscow   null
-            3 Charlie  40  Milan   null
-            4     Bob  30  Tokyo     68
-            5   Alice  20   null     55
-            6 Charlie  30 Moscow     90
+                 name age    city weight
+               String Int String?   Int?
+            0   Alice  15  London     54
+            1     Bob  45   Dubai     87
+            2 Charlie  20  Moscow   null
+            3 Charlie  40   Milan   null
+            4     Bob  30   Tokyo     68
+            5   Alice  20    null     55
+            6 Charlie  30  Moscow     90
             """.trimIndent()
 
         typed.toString().trimIndent() shouldBe expected

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -2178,6 +2178,7 @@ class DataFrameTests : BaseTest() {
             """
                   name  age     city  weight
                 String  Int  String?    Int?
+                  ---- ----     ----    ----
             0    Alice   15   London      54
             1      Bob   45    Dubai      87
             2  Charlie   20   Moscow    null


### PR DESCRIPTION
fixes #525 
First, i added more tests on original renderToString. Then a little refactoring to extract common logic. +new function

Original rendering has some quirks that can be seen in test asserts. For now i just preserved it as is, but probably let's improve it as well - it will be more obvious with new tests 