### PR TITLE
Removed usage of deprecated column accessor overload from Youtube.ipynb

### DIFF
--- a/examples/notebooks/dev/youtube/Youtube.ipynb
+++ b/examples/notebooks/dev/youtube/Youtube.ipynb
@@ -5088,16 +5088,14 @@
    },
    "cell_type": "code",
    "source": [
-    "val view by column<Int>()\n",
-    "\n",
     "val channels = joined.groupBy { channel }.sortByCount().aggregate {\n",
-    "    viewCount.sum() into view\n",
+    "    viewCount.sum() into \"view\"\n",
     "\n",
     "    val last = maxBy { publishedAt }\n",
     "    last.title into \"last title\"\n",
     "    last.publishedAt into \"time\"\n",
     "    last.viewCount into \"viewCount\"\n",
-    "}.sortByDesc(view).flatten()\n",
+    "}.sortByDesc(\"view\").flatten()\n",
     "channels"
    ],
    "outputs": [

--- a/examples/notebooks/youtube/Youtube.ipynb
+++ b/examples/notebooks/youtube/Youtube.ipynb
@@ -5088,16 +5088,14 @@
    },
    "cell_type": "code",
    "source": [
-    "val view by column<Int>()\n",
-    "\n",
     "val channels = joined.groupBy { channel }.sortByCount().aggregate {\n",
-    "    viewCount.sum() into view\n",
+    "    viewCount.sum() into \"view\"\n",
     "\n",
     "    val last = maxBy { publishedAt }\n",
     "    last.title into \"last title\"\n",
     "    last.publishedAt into \"time\"\n",
     "    last.viewCount into \"viewCount\"\n",
-    "}.sortByDesc(view).flatten()\n",
+    "}.sortByDesc(\"view\").flatten()\n",
     "channels"
    ],
    "outputs": [


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/1159

Checked all notebooks, found only one usage of deprecated api