### PR TITLE
Add column selector overloads for GroupBy.sortByKey

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sort.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sort.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataFrameExpression
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.Selector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
@@ -218,6 +219,16 @@ public fun <T, G> GroupBy<T, G>.sortByKeyDesc(nullsLast: Boolean = false): Group
 public fun <T, G> GroupBy<T, G>.sortByKey(nullsLast: Boolean = false): GroupBy<T, G> =
     toDataFrame()
         .sortBy { keys.columns().toColumnSet().nullsLast(nullsLast) }
+        .asGroupBy(groups)
+
+public fun <T, G, C> GroupBy<T, G>.sortByKey(columns: ColumnsSelector<T, C>): GroupBy<T, G> =
+    toDataFrame()
+        .sortBy { columns.toColumnSet() }
+        .asGroupBy(groups)
+
+public fun <T, G, C> GroupBy<T, G>.sortByKeyDesc(columns: ColumnsSelector<T, C>): GroupBy<T, G> =
+    toDataFrame()
+        .sortBy { columns.toColumnSet().desc() }
         .asGroupBy(groups)
 
 // endregion


### PR DESCRIPTION
## Summary

Adds `ColumnsSelector` overloads for `sortByKey` and `sortByKeyDesc` so users can specify which key columns to sort by.

## Why this matters

The existing `sortByKey()` sorts by all key columns with the same order. If you group by `name` and `age` but only want to sort by `age`, there's no way to express that without dropping down to raw `sortBy`.

## Changes

- `core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sort.kt`: Added two new overloads accepting `ColumnsSelector<T, C>`, following the same pattern as `GroupBy.sortBy(selector)`.

## Testing

- Syntax verified
- Follows the identical pattern as the existing `sortBy`/`sortByDesc` overloads that accept `SortColumnsSelector`

Fixes #1523

This contribution was developed with AI assistance (Claude Code).