### PR TITLE
Migrated deprecated usages in sort.kt, fixed toDataFrame visibilities test, clarified row[col] deprecation

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -277,7 +277,7 @@ internal const val DEPRECATED_ACCESS_API =
     "It's recommended to migrate to the String or Extension Properties Access API https://kotlin.github.io/dataframe/apilevels.html"
 
 internal const val DEPRECATED_DATA_ROW_COLUMN_REFERENCE_GET =
-    "Accessing a DataRow by ColumnReference (row[col]) is deprecated. Prefer String or extension property access (e.g., row[\"name\"] or row.name). The reverse indexing col[row] remains supported."
+    "Accessing a DataRow by ColumnReference (row[col]) is deprecated. Prefer String or extension property access (e.g., row[\"name\"] or row.name). The reverse indexing col[row] and colAccessor.getValue(row) remains supported"
 
 internal const val IDENTITY_FUNCTION = "This overload is an identity function and can be omitted."
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/sort.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/sort.kt
@@ -71,8 +71,9 @@ class SortDataColumn {
             ),
         )
 
-        col.sortWith { df1, df2 -> df1[a] - df2[a] } shouldBe sortedCol
-        col.sortWith(compareBy { it[a] }) shouldBe sortedCol
+        col.sortWith { df1, df2 -> a.getValue(df1) - a.getValue(df2) } shouldBe sortedCol
+        col.sortWith(compareBy { a.getValue(it) }) shouldBe sortedCol
+        col.sortWith(compareBy { a.getValue(it) }) shouldBe sortedCol
     }
 
     @Test
@@ -82,8 +83,8 @@ class SortDataColumn {
             maxOf { salaryInUsd } into "salary"
             maxBy { salaryInUsd } into "extra"
         }
-        aggregate.sortBy(pathOf("L", "salary"))[0][pathOf("L", "salary")] shouldBe null
-        aggregate.sortByDesc(pathOf("L", "salary"))[0][pathOf("L", "salary")] shouldBe 600_000
+        aggregate.sortBy { pathOf("L", "salary") }[0][pathOf("L", "salary")] shouldBe null
+        aggregate.sortByDesc { pathOf("L", "salary") }[0][pathOf("L", "salary")] shouldBe 600_000
     }
 
     @Test
@@ -94,7 +95,7 @@ class SortDataColumn {
             maxBy { salaryInUsd } into "extra"
         }
         shouldThrowMessage("Can not use ColumnGroup as sort column") {
-            aggregate.sortBy(pathOf("L", "extra"))
+            aggregate.sortBy { pathOf("L", "extra") }
         }
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -28,17 +28,18 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.typeOf
 
 class CreateDataFrameTests {
+    open class CreateDataFrameData {
+        private val a = 1
+        protected val b = 2
+        internal val c = 3
+
+        @Suppress("RedundantVisibilityModifier")
+        public val d = 4
+    }
 
     @Test
     fun `visibility test`() {
-        class Data {
-            private val a = 1
-            protected val b = 2
-            internal val c = 3
-            public val d = 4
-        }
-
-        listOf(Data()).toDataFrame() shouldBe dataFrameOf("d")(4)
+        listOf(CreateDataFrameData()).toDataFrame() shouldBe dataFrameOf("d")(4)
     }
 
     @Test


### PR DESCRIPTION
In the sort.kt `col.sortWith { df1, df2 -> df1[a] - df2[a] }` could not be migrated to a[df1], only a.getValue(df1) works for ColumnAccessor. So i updated deprecation message
We could use [this commit](https://github.com/Kotlin/dataframe/commit/087b7ca41edbe17dbc49ee6fb97ffe69b0ad909c) as illustration of migrations in guides