### PR TITLE
Added more targets for DisableInterpretation to help combine use of plugin together with library code

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
@@ -37,8 +37,19 @@ public annotation class Interpretable(val interpreter: String)
  */
 public annotation class Refine
 
+/**
+ * Disables plugin transformation of calls to @Refine functions, making
+ * dataframe code compile and work in context where plugin is not supported, for example inline functions or property getters,
+ * or not needed.
+ */
 @Retention(AnnotationRetention.SOURCE)
-@Target(AnnotationTarget.FILE, AnnotationTarget.EXPRESSION)
+@Target(
+    AnnotationTarget.FILE,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+)
 public annotation class DisableInterpretation
 
 @Target(AnnotationTarget.PROPERTY)


### PR DESCRIPTION
We need a way to make this code compile and work with plugin enabled in the project. Now it doesn't because declaring local classes is impossible in inline

```
inline fun <reified T> DataFrame<T>.doSomething(): DataFrame<T> { 
 ...
}
```

Let's add more targets to DisableInterpretation:
```
@DisableInterpretation
inline fun <reified T> DataFrame<T>.doSomething(): DataFrame<T> { 
 ...
}
```