### PR TITLE
set the dataframe-compiler-plugin-core module back to java 8

### DIFF
--- a/dataframe-compiler-plugin-core/build.gradle.kts
+++ b/dataframe-compiler-plugin-core/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.withType
 
 plugins {
     with(convention.plugins) {
-        alias(kotlinJvm11)
+        alias(kotlinJvm8)
     }
     with(libs.plugins) {
         alias(shadow)


### PR DESCRIPTION
set the dataframe-compiler-plugin-core module back to java 8