### PR TITLE
Removed remaining data modifiers from intermediate operations classes: Corr, SplitWithTransform for cleaner public API

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1692,10 +1692,6 @@ public final class org/jetbrains/kotlinx/dataframe/api/CopyKt {
 
 public final class org/jetbrains/kotlinx/dataframe/api/Corr {
 	public fun <init> (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)V
-	public final fun copy (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/api/Corr;
-	public static synthetic fun copy$default (Lorg/jetbrains/kotlinx/dataframe/api/Corr;Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/Corr;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4186,10 +4186,6 @@ public final class org/jetbrains/kotlinx/dataframe/api/SplitKt {
 public final class org/jetbrains/kotlinx/dataframe/api/SplitWithTransform {
 	public fun <init> (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ZLkotlin/reflect/KType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ZLkotlin/reflect/KType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ZLkotlin/reflect/KType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/kotlinx/dataframe/api/SplitWithTransform;
-	public static synthetic fun copy$default (Lorg/jetbrains/kotlinx/dataframe/api/SplitWithTransform;Lorg/jetbrains/kotlinx/dataframe/DataFrame;Lkotlin/jvm/functions/Function2;ZLkotlin/reflect/KType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/api/SplitWithTransform;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/corr.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/corr.kt
@@ -111,7 +111,9 @@ internal fun AnyCol.isSuitableForCorr() = isSubtypeOf<Number>() || type() == typ
  *
  * See [Grammar][CorrDocs.Grammar] for more details.
  */
-public data class Corr<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>)
+public class Corr<T, C>(internal val df: DataFrame<T>, internal val columns: ColumnsSelector<T, C>) {
+    override fun toString(): String = "Corr(df=$df, columns=$columns)"
+}
 
 /**
  * Computes the pearson correlation between all suitable columns in this [DataFrame],

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -50,14 +50,17 @@ public class Split<T, C>(
     override fun toString(): String = "Split(df=$df, columns=$columns)"
 }
 
-public data class SplitWithTransform<T, C, R>(
+public class SplitWithTransform<T, C, R>(
     internal val df: DataFrame<T>,
     internal val columns: ColumnsSelector<T, C?>,
     internal val inward: Boolean,
     internal val tartypeOf: KType,
     internal val default: R? = null,
     internal val transform: DataRow<T>.(C) -> Iterable<R>,
-)
+) {
+    override fun toString(): String =
+        "SplitWithTransform(df=$df, columns=$columns, inward=$inward, tartypeOf=$tartypeOf, default=$default, transform=$transform)"
+}
 
 public typealias ColumnNamesGenerator<C> = ColumnWithPath<C>.(extraColumnIndex: Int) -> String
 
@@ -72,7 +75,8 @@ public fun <T> Split<T, String>.default(value: String?): SplitWithTransform<T, S
     by { it.splitDefault() }.default(value)
 
 @Interpretable("SplitWithTransformDefault")
-public fun <T, C, R> SplitWithTransform<T, C, R>.default(value: R?): SplitWithTransform<T, C, R> = copy(default = value)
+public fun <T, C, R> SplitWithTransform<T, C, R>.default(value: R?): SplitWithTransform<T, C, R> =
+    SplitWithTransform(df, columns, inward, tartypeOf, default = value, transform)
 
 // endregion
 
@@ -264,7 +268,15 @@ public fun <T> Split<T, String>.into(
 public fun <T, C, R> SplitWithTransform<T, C, R>.inward(
     names: Iterable<String>,
     extraNamesGenerator: ColumnNamesGenerator<C>? = null,
-): DataFrame<T> = copy(inward = true).into(names.toList(), extraNamesGenerator)
+): DataFrame<T> =
+    SplitWithTransform(
+        df,
+        columns,
+        inward = true,
+        tartypeOf,
+        default,
+        transform,
+    ).into(names.toList(), extraNamesGenerator)
 
 @Refine
 @Interpretable("SplitWithTransformInward0")


### PR DESCRIPTION
Minor but still an API  change, we already did this for most other classes. 

copy, component* functions will be removed with this change:
<img width="1590" height="892" alt="Image" src="https://github.com/user-attachments/assets/6242d41a-35fa-4aaf-bc42-5492167fb431" />

<img width="1284" height="910" alt="Image" src="https://github.com/user-attachments/assets/30f45521-d934-45f4-94a4-089479d26421" />