### PR TITLE
Added kdocs for DataFrame.concat, updated its signature for better plugin support, annotated DataFrameBuilder APIs for plugin support

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowSchemaApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowSchemaApi.kt
@@ -8,4 +8,4 @@ public inline fun <reified T : DataRowSchema> dataFrameOf(vararg rows: T): DataF
     rows.asIterable().toDataFrame()
 
 public inline fun <reified T : DataRowSchema> DataFrame<T>.append(vararg rows: T): DataFrame<T> =
-    concat(dataFrameOf(*rows))
+    listOf(this, rows.asIterable().toDataFrame()).concat()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/concat.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/concat.kt
@@ -31,7 +31,24 @@ public fun <T> DataRow<T>.concat(vararg rows: DataRow<T>): DataFrame<T> = (listO
 
 public fun <T> DataFrame<T>.concat(vararg frames: DataFrame<T>): DataFrame<T> = concatImpl(listOf(this) + frames)
 
-public infix fun <T> DataFrame<T>.concat(frame: DataFrame<T>): DataFrame<T> = concatImpl(listOf(this) + frame)
+/**
+ * Vertically concat rows from two DataFrames with different schemas.
+ * Use [Iterable.concat] to concatenate DataFrames with identical schemas.
+ *
+ * #### Schema unification
+ * If input DataFrame objects have different schemas, every column in the resulting DataFrame will get the lowest common type of the original columns with the same name.
+ *
+ * Rows of columns missing in either DataFrame will be filled with `null` values.
+ *
+ * Example: `[A: Int, B: String]` concat `[A: Double, C: Float]` yields `[A: Number, B: String?, C: Float?]`.
+ *
+ * For more information: {@include [DocumentationUrls.Concat]}
+ *
+ */
+@Refine
+@Interpretable("DataFrameConcat")
+public infix fun <T, T1> DataFrame<T>.concat(frame: DataFrame<T1>): DataFrame<Any> =
+    concatImpl(listOf(this) + frame).cast()
 
 @JvmName("concatT")
 public fun <T> DataFrame<T>.concat(rows: Iterable<DataRow<T>>): DataFrame<T> = (rows() + rows).concat()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -413,6 +413,8 @@ public class DataFrameBuilder(private val header: List<String>) {
             )
         }
 
+    @Refine
+    @Interpretable("DataFrameBuilderFillValue")
     public inline fun <reified C> fill(nrow: Int, value: C): DataFrame<*> =
         withColumns { name ->
             DataColumn.createValueColumn(
@@ -431,8 +433,12 @@ public class DataFrameBuilder(private val header: List<String>) {
             )
         }
 
+    @Refine
+    @Interpretable("DataFrameBuilderNulls")
     public inline fun <reified C> nulls(nrow: Int): DataFrame<*> = fill<C?>(nrow, null)
 
+    @Refine
+    @Interpretable("DataFrameBuilderFillIndexed")
     public inline fun <reified C> fillIndexed(nrow: Int, crossinline init: (Int, String) -> C): DataFrame<*> =
         withColumns { name ->
             DataColumn.createByInference(
@@ -441,6 +447,8 @@ public class DataFrameBuilder(private val header: List<String>) {
             )
         }
 
+    @Refine
+    @Interpretable("DataFrameBuilderFill")
     public inline fun <reified C> fill(nrow: Int, crossinline init: (Int) -> C): DataFrame<*> =
         withColumns { name ->
             DataColumn.createByInference(
@@ -458,22 +466,38 @@ public class DataFrameBuilder(private val header: List<String>) {
             )
         }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomInt")
     public fun randomInt(nrow: Int): DataFrame<*> = fillNotNull(nrow) { Random.nextInt() }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomIntRange")
     public fun randomInt(nrow: Int, range: IntRange): DataFrame<*> = fillNotNull(nrow) { Random.nextInt(range) }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomDouble")
     public fun randomDouble(nrow: Int): DataFrame<*> = fillNotNull(nrow) { Random.nextDouble() }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomDoubleRange")
     public fun randomDouble(nrow: Int, range: ClosedRange<Double>): DataFrame<*> =
         fillNotNull(nrow) { Random.nextDouble(range.start, range.endInclusive) }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomFloat")
     public fun randomFloat(nrow: Int): DataFrame<*> = fillNotNull(nrow) { Random.nextFloat() }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomLong")
     public fun randomLong(nrow: Int): DataFrame<*> = fillNotNull(nrow) { Random.nextLong() }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomLongRange")
     public fun randomLong(nrow: Int, range: ClosedRange<Long>): DataFrame<*> =
         fillNotNull(nrow) { Random.nextLong(range.start, range.endInclusive) }
 
+    @Refine
+    @Interpretable("DataFrameBuilderRandomBoolean")
     public fun randomBoolean(nrow: Int): DataFrame<*> = fillNotNull(nrow) { Random.nextBoolean() }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
@@ -190,4 +190,7 @@ internal interface DocumentationUrls {
 
     /** [See "Summary statistics" on the documentation website.]({@include [Url]}/summarystatistics.html) */
     typealias Statistics = Nothing
+
+    /** [See `concat` on the documentation website.]({@include [Url]}/concat.html) */
+    typealias Concat = Nothing
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/PlaylistJsonTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/PlaylistJsonTest.kt
@@ -194,7 +194,7 @@ class PlaylistJsonTest {
 
     @Test
     fun union() {
-        val merged = item.concat(item)
+        val merged = listOf(item, item).concat()
         merged.rowsCount() shouldBe item.rowsCount() * 2
         val group = merged.snippet
         group.rowsCount() shouldBe item.snippet.rowsCount() * 2

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
@@ -278,7 +278,7 @@ class DataFrameTreeTests : BaseTest() {
 
     @Test
     fun distinct() {
-        val duplicated = typed2.concat(typed2)
+        val duplicated = listOf(typed2, typed2).concat()
         duplicated.rowsCount() shouldBe typed2.rowsCount() * 2
         val dist = duplicated.nameAndCity.distinct()
         dist shouldBe typed2.nameAndCity.distinct()


### PR DESCRIPTION
dataFrameOf().randomDouble and others:
Since we're unlikely to deprecate these soon, i think why not support them in compiler plugin

For concat i think it'll be clearer both with and without plugin, and easier for implementation
