### PR TITLE
API change: Rename to

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3937,6 +3937,8 @@ public final class org/jetbrains/kotlinx/dataframe/api/RenameKt {
 	public static final fun rename (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnAccessor;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
 	public static final fun renameToCamelCase (Lorg/jetbrains/kotlinx/dataframe/DataFrame;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun renameToCamelCase (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;
+	public static final fun to (Lorg/jetbrains/kotlinx/dataframe/api/RenameClause;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
+	public static final fun to (Lorg/jetbrains/kotlinx/dataframe/api/RenameClause;[Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 	public static final fun toCamelCase (Lorg/jetbrains/kotlinx/dataframe/api/RenameClause;)Lorg/jetbrains/kotlinx/dataframe/DataFrame;
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlinx.dataframe.impl.columnName
 import org.jetbrains.kotlinx.dataframe.impl.columns.renamedColumn
 import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
+import org.jetbrains.kotlinx.dataframe.util.RENAME_INTO
 import kotlin.reflect.KProperty
 
 // region DataFrame
@@ -38,8 +39,8 @@ import kotlin.reflect.KProperty
  * returns a [RenameClause],
  * which serves as an intermediate step.
  * The [RenameClause] object provides methods to rename selected columns using:
- * - [into(name)][RenameClause.into] - renames selected columns to the specified names.
- * - [into { nameExpression }][RenameClause.into] - renames selected columns using a provided
+ * - [to(name)][RenameClause.to] - renames selected columns to the specified names.
+ * - [to { nameExpression }][RenameClause.to] - renames selected columns using a provided
  * expression assuming column with its path and returning a new name.
  * - [toCamelCase()][RenameClause.toCamelCase] - renames all selected columns to "camelCase".
  *
@@ -72,10 +73,10 @@ internal interface RenameDocs {
      * [**`rename`**][rename]**`  { `**`columnsSelector: `[`ColumnsSelector`][ColumnsSelector]`  `**`}`**
      *
      * {@include [Indent]}
-     * `| `__`.`__[**`into`**][RenameClause.into]**`(`**`name: `[`String`][String]**`)`**
+     * `| `__`.`__[**`to`**][RenameClause.to]**`(`**`newNames: `[`String`][String]**`, ..)`**
      *
      * {@include [Indent]}
-     * `| `__`.`__[**`into`**][RenameClause.into]**`  { `**`nameExpression: (`[`ColumnWithPath`][ColumnWithPath]`) -> `[String]` `**`}`**
+     * `| `__`.`__[**`to`**][RenameClause.to]**`  { `**`nameExpression: (`[`ColumnWithPath`][ColumnWithPath]`) -> `[String]` `**`}`**
      *
      * {@include [Indent]}
      * `| `__`.`__[**`toCamelCase`**][RenameClause.toCamelCase]**`()`**
@@ -115,7 +116,7 @@ private typealias CommonRenameDocs = Nothing
 @Interpretable("RenameMapping")
 public fun <T> DataFrame<T>.rename(vararg mappings: Pair<String, String>): DataFrame<T> =
     rename { mappings.map { it.first.toColumnAccessor() }.toColumnSet() }
-        .into(*mappings.map { it.second }.toTypedArray())
+        .to(*mappings.map { it.second }.toTypedArray())
 
 /**
  * @include [CommonRenameDocs]
@@ -123,10 +124,10 @@ public fun <T> DataFrame<T>.rename(vararg mappings: Pair<String, String>): DataF
  * ### Examples:
  * ```kotlin
  * // Rename "col1" to "width" and "col2" to "length"
- * df.rename { col1 and col2 }.into("width", "length")
+ * df.rename { col1 and col2 }.to("width", "length")
  *
  * // Rename all columns using their full path, delimited by "->"
- * df.rename { colsAtAnyDepth() }.into { it.path.joinToString("->") }
+ * df.rename { colsAtAnyDepth() }.to { it.path.joinToString("->") }
  *
  * // Renames all numeric columns to "camelCase"
  * df.rename { colsOf<Number>() }.toCamelCase()
@@ -151,7 +152,7 @@ public fun <T, C> DataFrame<T>.rename(vararg cols: KProperty<C>): RenameClause<T
  * ### Examples:
  * ```kotlin
  * // Rename "col1" to "width" and "col2" to "length"
- * df.rename("col1", "col2").into("width", "length")
+ * df.rename("col1", "col2").to("width", "length")
  *
  * // Renames "arrival_date" and "passport-ID" columns to "camelCase"
  * df.rename("arrival_date", "passport-ID").toCamelCase()
@@ -172,8 +173,8 @@ public fun <T> DataFrame<T>.rename(vararg cols: String): RenameClause<T, Any?> =
  * in the [DataFrame], but their names will be changed.
  *
  * Use the following methods to perform the conversion:
- * - [into(name)][RenameClause.into] — renames selected columns to the specified names.
- * - [into { nameExpression }][RenameClause.into] — renames selected columns using a custom expression,
+ * - [to(name)][RenameClause.to] — renames selected columns to the specified names.
+ * - [to { nameExpression }][RenameClause.to] — renames selected columns using a custom expression,
  *   which takes the column and its path and returns a new name.
  * - [toCamelCase()][RenameClause.toCamelCase] — renames all selected columns to `camelCase`.
  *
@@ -226,9 +227,12 @@ public fun <T> DataFrame<T>.renameToCamelCase(): DataFrame<T> =
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
 public fun <T, C> RenameClause<T, C>.into(vararg newColumns: ColumnReference<*>): DataFrame<T> =
-    into(*newColumns.map { it.name() }.toTypedArray())
+    to(*newColumns.map { it.name() }.toTypedArray())
 
 /**
+ * __NOTE:__ While you can keep using 'into', we recommend using [to][RenameClause.to] for
+ *  * better readability and more natural English.
+ *
  * Renames the columns selected with [rename] to the specified [newNames],
  * preserving their values and positions within the [DataFrame].
  *
@@ -254,14 +258,46 @@ public fun <T, C> RenameClause<T, C>.into(vararg newColumns: ColumnReference<*>)
  */
 @Refine
 @Interpretable("RenameInto")
+@Deprecated(message = RENAME_INTO, replaceWith = ReplaceWith("to(*newNames)"))
 public fun <T, C> RenameClause<T, C>.into(vararg newNames: String): DataFrame<T> = renameImpl(newNames)
+
+/**
+ * Renames the columns selected with [rename] to the specified [newNames],
+ * preserving their values and positions within the [DataFrame].
+ *
+ * The mapping is positional: [newNames] are applied in the order
+ * the columns were selected — the first selected column is renamed to the first name,
+ * the second to the second, and so on.
+ *
+ * For more information: {@include [DocumentationUrls.Rename]}
+ *
+ * Check out [Grammar][RenameDocs.Grammar].
+ *
+ * ### Examples:
+ * ```kotlin
+ * // Rename "col1" to "width" and "col2" to "length"
+ * df.rename("col1", "col2").to("width", "length")
+ *
+ * // Rename "col1" to "width" and "col2" to "length"
+ * df.rename { col1 and col2 }.to("width", "length")
+ * ```
+ *
+ * @param newNames The new names for the selected columns, applied in order of selecting.
+ * @return A new [DataFrame] with the columns renamed.
+ */
+@Refine
+@Interpretable("RenameInto")
+public fun <T, C> RenameClause<T, C>.to(vararg newNames: String): DataFrame<T> = renameImpl(newNames)
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
 public fun <T, C> RenameClause<T, C>.into(vararg newNames: KProperty<*>): DataFrame<T> =
-    into(*newNames.map { it.name }.toTypedArray())
+    to(*newNames.map { it.name }.toTypedArray())
 
 /**
+ * __NOTE:__ While you can keep using 'into', we recommend using [to][RenameClause.to] for
+ * better readability and more natural English.
+ *
  * Renames the columns selected with [rename] by applying the [transform] expression
  * to each of them. This expression receives the column together with its full path
  * (as [ColumnWithPath]) and must return the new name for that column.
@@ -286,8 +322,36 @@ public fun <T, C> RenameClause<T, C>.into(vararg newNames: KProperty<*>): DataFr
  */
 @Refine
 @Interpretable("RenameIntoLambda")
+@Deprecated(message = RENAME_INTO, replaceWith = ReplaceWith("to(transform)"))
 public fun <T, C> RenameClause<T, C>.into(transform: (ColumnWithPath<C>) -> String): DataFrame<T> =
     renameImpl(transform)
+
+/**
+ * Renames the columns selected with [rename] by applying the [transform] expression
+ * to each of them. This expression receives the column together with its full path
+ * (as [ColumnWithPath]) and must return the new name for that column.
+ * The operation preserves the original columns’ values and their positions within the [DataFrame].
+ *
+ * For more information: {@include [DocumentationUrls.Rename]}
+ *
+ * Check out [Grammar][RenameDocs.Grammar] for more details.
+ *
+ * ### Examples:
+ * ```kotlin
+ * // Rename all columns using their full path, delimited by "->"
+ * df.rename { colsAtAnyDepth() }.to { it.path.joinToString("->") }
+ *
+ * // Rename all `String` columns with uppercase
+ * df.rename { colsOf<String>() }.to { it.name.uppercase() }
+ * ```
+ *
+ * @param transform A function that takes a [ColumnWithPath] for each selected column
+ * and returns the new column name.
+ * @return A new [DataFrame] with the columns renamed.
+ */
+@Refine
+@Interpretable("RenameIntoLambda")
+public fun <T, C> RenameClause<T, C>.to(transform: (ColumnWithPath<C>) -> String): DataFrame<T> = renameImpl(transform)
 
 /**
  * Renames the columns, previously selected with [rename] to "camelCase" format.
@@ -321,7 +385,7 @@ public fun <T, C> RenameClause<T, C>.into(transform: (ColumnWithPath<C>) -> Stri
  */
 @Refine
 @Interpretable("RenameToCamelCaseClause")
-public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> = into { it.renameToCamelCase().name() }
+public fun <T, C> RenameClause<T, C>.toCamelCase(): DataFrame<T> = to { it.renameToCamelCase().name() }
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/GroupByImpl.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinx.dataframe.api.isColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.pathOf
 import org.jetbrains.kotlinx.dataframe.api.remove
 import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.AggregatableInternal
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.GroupByReceiverImpl
@@ -63,7 +64,7 @@ internal class GroupByImpl<T, G>(
         if (groupedColumnName == null || groupedColumnName == groups.name()) {
             df
         } else {
-            df.rename(groups).into(groupedColumnName)
+            df.rename(groups).to(groupedColumnName)
         }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt
@@ -304,4 +304,8 @@ internal const val ALL_COLS_EXCEPT_REPLACE = "this.allColsExcept { other }"
 internal const val ALL_COLS_EXCEPT_REPLACE_VARARG = "this.allColsExcept { others.toColumnSet() }"
 internal const val EXCEPT_REPLACE = "this.except { other }"
 internal const val EXCEPT_REPLACE_VARARG = "this.except { others.toColumnSet() }"
+
+internal const val RENAME_INTO =
+    "'into' has been replaced with 'to', because 'rename to' is more common in English. You can keep using 'into', but we advise using 'to'."
+
 // endregion

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/allExcept.kt
@@ -18,7 +18,7 @@ class AllExceptTests : ColumnsSelectionDslTests() {
 
     @Test
     fun `issue 761`() {
-        val renamed = df.rename { colsAtAnyDepth() except name.firstName }.into { it.name.uppercase() }
+        val renamed = df.rename { colsAtAnyDepth() except name.firstName }.to { it.name.uppercase() }
         renamed.columnNames() shouldBe listOf("NAME", "AGE", "CITY", "WEIGHT", "ISHAPPY")
         renamed.getColumnGroup("NAME").columnNames() shouldBe listOf("firstName", "LASTNAME")
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -304,7 +304,7 @@ class ConstructorsTests {
 
                 else -> error("Unexpected column name: $it")
             }
-        }.rename { all() }.into { names[it.name.toInt() - 1] }
+        }.rename { all() }.to { names[it.name.toInt() - 1] }
 
         val df4 = dataFrameOf(names).invoke {
             when (it) {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.junit.Test
 
 @Suppress("ktlint:standard:argument-list-wrapping")
@@ -72,7 +73,7 @@ class FlattenTests {
         val grouped = df
             .group("a", "b").into("e")
             .group("e", "c").into("f")
-            .rename { "f"["e"] }.into("a")
+            .rename { "f"["e"] }.to("a")
         val flattened = grouped.flatten { "f"["a"] }
         flattened.getColumnGroup("f").columnNames() shouldBe listOf("a", "b", "c")
         flattened.ungroup("f") shouldBe df

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/format.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldNotBe
 import org.jetbrains.kotlinx.dataframe.api.FormattingDsl.blue
 import org.jetbrains.kotlinx.dataframe.api.FormattingDsl.red
 import org.jetbrains.kotlinx.dataframe.api.FormattingDsl.rgb
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.io.DisplayConfiguration
 import org.jetbrains.kotlinx.dataframe.samples.api.TestBase
 import org.jetbrains.kotlinx.dataframe.samples.api.age
@@ -329,7 +330,7 @@ class FormatTests : TestBase() {
             .groupBy("city").toDataFrame()
             .add("cityCopy") { "city"<String>() }
             .group("city").into("cityGroup")
-            .rename("cityCopy").into("city")
+            .rename("cityCopy").to("city")
 
         val formatted = df.format("city").with { bold and italic and textColor(green) }
         val html = formatted.toHtml().toString()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.impl.columns.asAnyFrameColumn
 import org.jetbrains.kotlinx.dataframe.samples.api.age
 import org.junit.Test
@@ -27,8 +28,8 @@ class RenameTests : ColumnsSelectionDslTests() {
             4, 5, 6,
         )
 
-        simpleDf.rename { all() }.into { it.name + "_renamed" } shouldBe renamedDf
-        simpleDf.rename { all() }.into("a_renamed", "b_renamed", "c_renamed") shouldBe renamedDf
+        simpleDf.rename { all() }.to { it.name + "_renamed" } shouldBe renamedDf
+        simpleDf.rename { all() }.to("a_renamed", "b_renamed", "c_renamed") shouldBe renamedDf
     }
 
     @Test
@@ -54,7 +55,7 @@ class RenameTests : ColumnsSelectionDslTests() {
 
         groupedDf
             .rename { "group" and "group"["a"] }
-            .into { it.name + "_renamed" } shouldBe renamedDf
+            .to { it.name + "_renamed" } shouldBe renamedDf
     }
 
     @Test
@@ -66,7 +67,7 @@ class RenameTests : ColumnsSelectionDslTests() {
 
         groupedDf
             .rename { colsAtAnyDepth() }
-            .into { it.name + "_renamed" } shouldBe renamedDf
+            .to { it.name + "_renamed" } shouldBe renamedDf
     }
 
     @Test
@@ -80,7 +81,7 @@ class RenameTests : ColumnsSelectionDslTests() {
 
         doubleGroupedDf
             .rename { colsAtAnyDepth() }
-            .into { it.name + "_renamed" } shouldBe renamedDf
+            .to { it.name + "_renamed" } shouldBe renamedDf
     }
 
     interface Person2 {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Join.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Join.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.api.leftJoin
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.rightJoin
 import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.explainer.TransformDataFrameExpressions
 import org.junit.Test
@@ -55,7 +56,7 @@ class Join : TestBase() {
     @Test
     @TransformDataFrameExpressions
     fun joinWithMatch_properties() {
-        val other = other.rename { name }.into("fullName").cast<Right>()
+        val other = other.rename { name }.to("fullName").cast<Right>()
         val joined =
             // SampleStart
             df.join(other) { name match right.fullName }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Modify.kt
@@ -1067,7 +1067,7 @@ class Modify : TestBase() {
             .filter { isHappy && age > 100 }
             .move { name.firstName and name.lastName }.after { isHappy }
             .merge { age and weight }.by { "Age: ${it[0]}, weight: ${it[1]}" }.into("info")
-            .rename { isHappy }.into("isOK")
+            .rename { isHappy }.to("isOK")
         // SampleEnd
     }
 
@@ -1183,11 +1183,11 @@ class Modify : TestBase() {
 
         // SampleStart
         df.move { response.data }.toTop()
-        df.rename { response.data }.into("description")
+        df.rename { response.data }.to("description")
         // SampleEnd
 
         df.move { response.data }.toTop().alsoDebug()
-        df.rename { response.data }.into("description").alsoDebug()
+        df.rename { response.data }.to("description").alsoDebug()
     }
 
     @Ignore
@@ -1265,7 +1265,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun rename_properties() {
         // SampleStart
-        df.rename { name }.into("fullName")
+        df.rename { name }.to("fullName")
         // SampleEnd
     }
 
@@ -1273,7 +1273,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun rename_strings() {
         // SampleStart
-        df.rename("name").into("fullName")
+        df.rename("name").to("fullName")
         // SampleEnd
     }
 
@@ -1281,7 +1281,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun renameExpression_properties() {
         // SampleStart
-        df.rename { age }.into {
+        df.rename { age }.to {
             val mean = it.data.mean()
             "age [mean = $mean]"
         }
@@ -1292,7 +1292,7 @@ class Modify : TestBase() {
     @TransformDataFrameExpressions
     fun renameExpression_strings() {
         // SampleStart
-        df.rename("age").into {
+        df.rename("age").to {
             val mean = it.data.cast<Int>().mean()
             "age [mean = $mean]"
         }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -1042,13 +1042,13 @@ class DataFrameTests : BaseTest() {
             this.getColumnOrNull("age") shouldBe null
         }
         typed.rename("name" to "name2", "age" to "age2").check()
-        typed.rename { name and age }.into("name2", "age2").check()
-        typed.rename { name and age }.into { it.name + "2" }.check()
+        typed.rename { name and age }.to("name2", "age2").check()
+        typed.rename { name and age }.to { it.name + "2" }.check()
     }
 
     @Test
     fun `select with rename`() {
-        val expected = typed.select { name and age }.rename { all() }.into { it.name + 2 }
+        val expected = typed.select { name and age }.rename { all() }.to { it.name + 2 }
         typed.select { name into "name2" and age.into("age2") } shouldBe expected
     }
 
@@ -1613,7 +1613,7 @@ class DataFrameTests : BaseTest() {
     @Test
     fun `replace with rename`() {
         val res = typed.replace { age }.with { it.rename("age2") }
-        res shouldBe typed.rename { age }.into("age2")
+        res shouldBe typed.rename { age }.to("age2")
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -1633,7 +1633,7 @@ class DataFrameTests : BaseTest() {
         val res = typed.replace { age }.with { 2021 - age named "year" }
         val expected = typed
             .convert { age }.with { 2021 - age }
-            .rename { age }.into("year")
+            .rename { age }.to("year")
         res shouldBe expected
     }
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTreeTests.kt
@@ -84,6 +84,7 @@ import org.jetbrains.kotlinx.dataframe.api.single
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.split
 import org.jetbrains.kotlinx.dataframe.api.sumOf
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.toColumn
 import org.jetbrains.kotlinx.dataframe.api.toColumnAccessor
 import org.jetbrains.kotlinx.dataframe.api.toStr
@@ -546,7 +547,7 @@ class DataFrameTreeTests : BaseTest() {
             colsAtAnyDepth().filter { !it.isColumnGroup() }
         }.into { pathOf(it.path.joinToString(".")) }
         val grouped = joined.group { nameContains(".") }.into { it.name().substringBefore(".") }
-        val expected = typed2.rename { nameAndCity.allCols() }.into { it.path.joinToString(".") }
+        val expected = typed2.rename { nameAndCity.allCols() }.to({ it.path.joinToString(".") })
         grouped shouldBe expected
     }
 
@@ -559,7 +560,7 @@ class DataFrameTreeTests : BaseTest() {
 
     @Test
     fun rename() {
-        val res = typed2.rename { nameAndCity.allCols() }.into { it.name().capitalize() }
+        val res = typed2.rename { nameAndCity.allCols() }.to { it.name().capitalize() }
         res.nameAndCity.columnNames() shouldBe typed2.nameAndCity.columnNames().map { it.capitalize() }
     }
 

--- a/docs/StardustDocs/resources/snippets/org.jetbrains.kotlinx.dataframe.samples.api.Join.joinWithMatch.html
+++ b/docs/StardustDocs/resources/snippets/org.jetbrains.kotlinx.dataframe.samples.api.Join.joinWithMatch.html
@@ -178,7 +178,7 @@ summary {
 </head>
 <body>
                                 <details>
-                                <summary>other.into(&quot;fullName&quot;).cast&lt;Right&gt;()</summary>
+                                <summary>other.to(&quot;fullName&quot;).cast&lt;Right&gt;()</summary>
                                                                 <details>
                                 <summary>Input DataFrame: rowsCount = 7, columnsCount = 3</summary>
                                  <table class="dataframe" id="df_0"></table>

--- a/docs/StardustDocs/topics/MigrationTo_1_0.md
+++ b/docs/StardustDocs/topics/MigrationTo_1_0.md
@@ -162,19 +162,20 @@ The next functions and classes raise `ERROR` in 1.0 and will be removed in 1.1.
 
 The next functions and classes raise `WARNING` in 1.0 and `ERROR` in 1.1.
 
-| 0.15                                                                                                     | 1.0                                                                                                                           | Reason                                                                  |
-|----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| `df.split { columns }.default(..)` / `df.split { columns }.into(..)` / `df.split { columns }.inward(..)` | `df.split { columns }.by(..).default(..)` / `df.split { columns }.by(..).into(..)` / `df.split { columns }.by(..).inward(..)` | Removed a shortcut to clarify the behaviour; Only for `String` columns. |
-| `dataFrameOf(header, values)`                                                                            | `dataFrameOf(header).withValues(values)`                                                                                      | Replaced with another function.                                         |
-| `df.generateCode(..)`                                                                                    | `df.generateInterfaces(..)`                                                                                                   | Replaced with another function.                                         |
-| `df.select { mapToColumn(name, infer) { body } }`                                                        | `df.select { expr(name, infer) { body } }`                                                                                    | Removed duplicated functionality.                                       |
-| `stringCol.length()`                                                                                     | `stringCol.map { it?.length ?: 0 }`                                                                                           | Removed a shortcut to clarify the behaviour; Only for `String` columns. |
-| `stringCol.lowercase()` / `stringCol.uppercase()`                                                        | `stringCol.map { it?.lowercase() }` / `stringCol.map { it?.uppercase() }`                                                     | Removed a shortcut to clarify the behaviour; Only for `String` columns. |
-| `df.add(columns)` / `df.add(dataframes)`                                                                 | `df.addAll(columns)` / `df.addAll(dataframes)`                                                                                | Renamed to to improve completion.                                       |
-| `row.isEmpty()` / `row.isNotEmpty()`                                                                     | `row.values().all { it == null }` / `row.values().all { it == null }`                                                         | Removed a shortcut to clarify the behaviour;                            |
-| `row.getRow(index)` /  `row.getRowOrNull(index)` / `row.getRows(indices)`                                | `row.df().getRow(index)` /  `row.df().getRowOrNull(index)` / `row.df().getRows(indices)`                                      | Removed a shortcut to clarify the behaviour;                            |
-| `df.copy()`                                                                                              | `df.columns().toDataFrame().cast()`                                                                                           | Removed a shortcut to clarify the behaviour;                            |
-| `KeyValueProperty<T>`                                                                                    | `NameValueProperty<T>`                                                                                                        | Removed duplicated functionality.                                       |
+| 0.15                                                                                                     | 1.0                                                                                                                           | Reason                                                                       |
+|----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `df.split { columns }.default(..)` / `df.split { columns }.into(..)` / `df.split { columns }.inward(..)` | `df.split { columns }.by(..).default(..)` / `df.split { columns }.by(..).into(..)` / `df.split { columns }.by(..).inward(..)` | Removed a shortcut to clarify the behaviour; Only for `String` columns.      |
+| `dataFrameOf(header, values)`                                                                            | `dataFrameOf(header).withValues(values)`                                                                                      | Replaced with another function.                                              |
+| `df.generateCode(..)`                                                                                    | `df.generateInterfaces(..)`                                                                                                   | Replaced with another function.                                              |
+| `df.select { mapToColumn(name, infer) { body } }`                                                        | `df.select { expr(name, infer) { body } }`                                                                                    | Removed duplicated functionality.                                            |
+| `stringCol.length()`                                                                                     | `stringCol.map { it?.length ?: 0 }`                                                                                           | Removed a shortcut to clarify the behaviour; Only for `String` columns.      |
+| `stringCol.lowercase()` / `stringCol.uppercase()`                                                        | `stringCol.map { it?.lowercase() }` / `stringCol.map { it?.uppercase() }`                                                     | Removed a shortcut to clarify the behaviour; Only for `String` columns.      |
+| `df.add(columns)` / `df.add(dataframes)`                                                                 | `df.addAll(columns)` / `df.addAll(dataframes)`                                                                                | Renamed to to improve completion.                                            |
+| `row.isEmpty()` / `row.isNotEmpty()`                                                                     | `row.values().all { it == null }` / `row.values().all { it == null }`                                                         | Removed a shortcut to clarify the behaviour;                                 |
+| `row.getRow(index)` /  `row.getRowOrNull(index)` / `row.getRows(indices)`                                | `row.df().getRow(index)` /  `row.df().getRowOrNull(index)` / `row.df().getRows(indices)`                                      | Removed a shortcut to clarify the behaviour;                                 |
+| `df.copy()`                                                                                              | `df.columns().toDataFrame().cast()`                                                                                           | Removed a shortcut to clarify the behaviour;                                 |
+| `KeyValueProperty<T>`                                                                                    | `NameValueProperty<T>`                                                                                                        | Removed duplicated functionality.                                            |
+| `rename { columns }.into(..)` (will remain WARNING)                                                      | `rename { columns }.to(..)`                                                                                                   | Renamed to better reflect the English sentence "rename this column to that". |
 
 ## Parsing and Converting Date-Time
 
@@ -197,12 +198,14 @@ while still allowing you to use Java types if you need them.
 ```kotlin
 df.parse()
 ```
+
 </td>
 <td>
 
 ```kotlin
 df.parse()
 ```
+
 </td>
 <td>Default parsing behavior remains largely unchanged.</td>
 </tr>
@@ -213,12 +216,13 @@ df.parse()
 df.parse(
     ParserOptions(
         skipTypes = setOf(
-            typeOf<kotlinx.datetime.LocalDate>(), 
+            typeOf<kotlinx.datetime.LocalDate>(),
             ...,
-        ),
     ),
+),
 )
 ```
+
 </td>
 <td>
 
@@ -227,6 +231,7 @@ df.parse(
     ParserOptions(dateTime = DateTimeParserOptions.Java),
 )
 ```
+
 </td>
 <td>If you want to force parsing to Java date-time types, you no longer have use skipTypes, you can simply change the `dateTime` argument.</td>
 </tr>
@@ -238,12 +243,14 @@ DataFrame.parser.addSkipType(
     typeOf<kotlinx.datetime.LocalDate>(),
 )
 ```
+
 </td>
 <td>
 
 ```kotlin
 DataFrame.parser.dateTimeLibrary = ParseDateTimeLibrary.JAVA
 ```
+
 </td>
 <td>The same logic applies for the <a href="parse.md#global-parser-options">global parser options</a>.</td>
 </tr>
@@ -253,6 +260,7 @@ DataFrame.parser.dateTimeLibrary = ParseDateTimeLibrary.JAVA
 ```kotlin
 ParserOptions(dateTimeFormatter = myFormatter)
 ```
+
 </td>
 <td>
 Kotlin:
@@ -263,6 +271,7 @@ ParserOptions(
         .withFormat<_>(myKotlinFormat),
 )
 ```
+
 </td>
 <td rowspan="2">You now need to explicitly specify you expect Java or Kotlin date-time types via `DateTimeParserOptions.X`. Then you can specify the relevant options, like a `kotlinx.datetime.format.DateTimeFormat` or `java.time.DateTimeFormatter`. These are typed now too, optionally for Java.</td>
 </tr>
@@ -276,6 +285,7 @@ ParserOptions(
         .withFormatter<java.time.LocalDateTime>(myJavaFormatter),
 )
 ```
+
 </td>
 </tr>
 <tr>
@@ -287,6 +297,7 @@ ParserOptions(
     dateTimeFormatter = myFormatter,
 )
 ```
+
 </td>
 <td>
 
@@ -297,6 +308,7 @@ ParserOptions(
         .withFormatter<java.time.LocalDateTime>(myFormatter),
 )
 ```
+
 </td>
 <td>Locale for date-time only works for Java types. If you need Kotlin types ánd a locale use <a href="convert.md">convert</a> to convert to Kotlin types afterwards.</td>
 </tr>
@@ -306,6 +318,7 @@ ParserOptions(
 ```kotlin
 ParserOptions(dateTimePattern = "MM/dd yyyy")
 ```
+
 </td>
 <td>
 Kotlin:
@@ -317,6 +330,7 @@ ParserOptions(
         .withPattern<kotlinx.datetime.LocalDate>("MM/dd yyyy"),
 )
 ```
+
 </td>
 <td rowspan="2">Again, you now need to specify the target date-time library and the expected type for your pattern (optionally for Java). In Kotlin you also need to opt-in, because using `DateTimeFormat` instead is <a href="https://github.com/Kotlin/kotlinx-datetime#using-unicode-format-strings-like-yyyy-mm-dd">recommended</a>.</td>
 </tr>
@@ -330,6 +344,7 @@ ParserOptions(
         .withPattern<java.time.LocalDate>("MM/dd yyyy"),
 )
 ```
+
 </td>
 </tr>
 <tr>
@@ -338,6 +353,7 @@ ParserOptions(
 ```kotlin
 DataFrame.parser.addDateTimePattern("MM/dd yyyy")
 ```
+
 </td>
 <td>
 Kotlin:
@@ -347,6 +363,7 @@ Kotlin:
 DataFrame.parser
     .addDateTimeUnicodePattern<kotlinx.datetime.LocalDate>("MM/dd yyyy")
 ```
+
 </td>
 <td rowspan="2">Same idea. Though you can now also use `...addDateTimeFormat()` / `...addJavaDateTimeFormatter()`, which we would recommend more.</td>
 </tr>
@@ -358,6 +375,7 @@ Java:
 DataFrame.parser
     .addJavaDateTimePattern<java.time.LocalDate>("MM/dd yyyy")
 ```
+
 </td>
 </tr>
 <tr>
@@ -366,6 +384,7 @@ DataFrame.parser
 ```kotlin
 convert { stringCols }.toLocalDate(pattern = "MM/dd yyyy")
 ```
+
 </td>
 <td>
 Kotlin:
@@ -374,6 +393,7 @@ Kotlin:
 @OptIn(FormatStringsInDatetimeFormats::class)
 convert { stringCols }.toLocalDate(pattern = "MM/dd yyyy")
 ```
+
 </td>
 <td rowspan="2">Same logic applies to convert: you need to opt-in to use patterns for Kotlin types and specify "Java" for Java types.</td>
 </tr>
@@ -384,6 +404,7 @@ Java:
 ```kotlin
 convert { stringCols }.toJavaLocalDate(pattern = "MM/dd yyyy")
 ```
+
 </td>
 </tr>
 <tr>
@@ -392,6 +413,7 @@ convert { stringCols }.toJavaLocalDate(pattern = "MM/dd yyyy")
 ```kotlin
 stringCol.convertToLocalDate(locale = Locale.GERMAN)
 ```
+
 </td>
 <td>
 
@@ -400,6 +422,7 @@ stringCol
     .convertToJavaLocalDate(locale = Locale.GERMAN)
     .convertToLocalDate()
 ```
+
 </td>
 <td>If you need to supply a locale to be able to parse date-time types, parse to Java types first, then convert to Kotlin ones.</td>
 </tr>

--- a/docs/StardustDocs/topics/concepts/apiLevels.md
+++ b/docs/StardustDocs/topics/concepts/apiLevels.md
@@ -30,8 +30,8 @@ to any other library working with dataframes:
 // Get the "fullName" column
 df["fullName"]
 
-// Rename the "fullName" column into "name"
-df.rename("fullName").into("name")
+// Rename the "fullName" column to "name"
+df.rename("fullName").to("name")
 ```
 
 <!---END-->
@@ -84,8 +84,8 @@ and completely name- and typesafe:
 // Get "fullName" column
 df.fullName
 
-// Rename "fullName" column into "name"
-df.rename { fullName }.into("name")
+// Rename "fullName" column to "name"
+df.rename { fullName }.to("name")
 
 // Select the "firstName" column from the "fullName" column group
 // and the "age" column

--- a/docs/StardustDocs/topics/guides/quickstart.md
+++ b/docs/StardustDocs/topics/guides/quickstart.md
@@ -145,10 +145,10 @@ Rename "full_name" and "stargazers_count" columns:
 <!---FUN notebook_test_quickstart_7-->
 
 ```kotlin
-// Rename "full_name" column into "name"
-val dfRenamed = dfFiltered.rename { full_name }.into("name")
-    // And "stargazers_count" into "starsCount"
-    .rename { stargazers_count }.into("starsCount")
+// Rename "full_name" column to "name"
+val dfRenamed = dfFiltered.rename { full_name }.to("name")
+    // And "stargazers_count" to "starsCount"
+    .rename { stargazers_count }.to("starsCount")
 dfRenamed
 ```
 

--- a/docs/StardustDocs/topics/operations.md
+++ b/docs/StardustDocs/topics/operations.md
@@ -26,7 +26,7 @@ df.update { age }.where { city == "Paris" }.with { it - 5 }
     .filter { isHappy && age > 100 }
     .move { name.firstName and name.lastName }.after { isHappy }
     .merge { age and weight }.by { "Age: ${it[0]}, weight: ${it[1]}" }.into("info")
-    .rename { isHappy }.into("isOK")
+    .rename { isHappy }.to("isOK")
 ```
 
 <!---END-->

--- a/docs/StardustDocs/topics/rename.md
+++ b/docs/StardustDocs/topics/rename.md
@@ -5,8 +5,8 @@
 Renames one or several columns without changing its location in [`DataFrame`](DataFrame.md).
 
 ```kotlin
-df.rename { columns }.into(name)
-df.rename { columns }.into { nameExpression }
+df.rename { columns }.to(name)
+df.rename { columns }.to { nameExpression }
 
 nameExpression = (DataColumn) -> String
 ```
@@ -20,14 +20,14 @@ See [column selectors](ColumnSelectors.md) for how to select the columns for thi
 <tab title="Properties">
 
 ```kotlin
-df.rename { name }.into("fullName")
+df.rename { name }.to("fullName")
 ```
 
 </tab>
 <tab title="Strings">
 
 ```kotlin
-df.rename("name").into("fullName")
+df.rename("name").to("fullName")
 ```
 
 </tab></tabs>
@@ -40,7 +40,7 @@ df.rename("name").into("fullName")
 <tab title="Properties">
 
 ```kotlin
-df.rename { age }.into {
+df.rename { age }.to {
     val mean = it.data.mean()
     "age [mean = $mean]"
 }
@@ -50,7 +50,7 @@ df.rename { age }.into {
 <tab title="Strings">
 
 ```kotlin
-df.rename("age").into {
+df.rename("age").to {
     val mean = it.data.cast<Int>().mean()
     "age [mean = $mean]"
 }

--- a/docs/StardustDocs/topics/unfold.md
+++ b/docs/StardustDocs/topics/unfold.md
@@ -54,7 +54,7 @@ val df = initialData.unfold("response")
 
 ```kotlin
 df.move { response.data }.toTop()
-df.rename { response.data }.into("description")
+df.rename { response.data }.to("description")
 ```
 
 <!---END-->

--- a/examples/notebooks/dev/quickstart/quickstart.ipynb
+++ b/examples/notebooks/dev/quickstart/quickstart.ipynb
@@ -2816,7 +2816,7 @@
    "cell_type": "markdown",
    "source": [
     "Columns can be renamed using the `.rename { }` operation, which also uses the [Columns Selection DSL](https://kotlin.github.io/dataframe/columnselectors.html) to select a column to rename.\n",
-    "The `rename` operation does not perform the renaming immediately; instead, it creates an intermediate object that must be finalized into a new `DataFrame` by calling the `.into()` function with the new column name.\n",
+    "The `rename` operation does not perform the renaming immediately; instead, it creates an intermediate object that must be finalized into a new `DataFrame` by calling the `.to()` function with the new column name.\n",
     "\n",
     "Rename \"full_name\" and \"stargazers_count\" columns:"
    ]
@@ -2830,11 +2830,11 @@
    },
    "cell_type": "code",
    "source": [
-    "// Rename \"full_name\" column into \"name\"\n",
+    "// Rename \"full_name\" column to \"name\"\n",
     "val dfRenamed = dfFiltered\n",
-    "    .rename { full_name }.into(\"name\")\n",
-    "    // And \"stargazers_count\" into \"starsCount\"\n",
-    "    .rename { stargazers_count }.into(\"starsCount\")\n",
+    "    .rename { full_name }.to(\"name\")\n",
+    "    // And \"stargazers_count\" to \"starsCount\"\n",
+    "    .rename { stargazers_count }.to(\"starsCount\")\n",
     "dfRenamed"
    ],
    "outputs": [

--- a/examples/projects/dev/kotlin-dataframe-plugin-gradle-example/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/plugin/Main.kt
+++ b/examples/projects/dev/kotlin-dataframe-plugin-gradle-example/src/main/kotlin/org/jetbrains/kotlinx/dataframe/examples/plugin/Main.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.max
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.renameToCamelCase
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.io.readCsv
 import org.jetbrains.kotlinx.dataframe.io.writeCsv
@@ -72,7 +73,7 @@ fun main() {
         // new names corresponding to the column names.
         .renameToCamelCase()
         // Rename "stargazersCount" column to "stars".
-        .rename { stargazersCount }.into("stars")
+        .rename { stargazersCount }.to("stars")
         // And we can immediately use the updated name in the filtering.
         .filter { stars > 50 }
         // Convert values in the "topic" column (which were `String` initially)

--- a/examples/projects/dev/kotlin-dataframe-plugin-maven-example/src/main/kotlin/Main.kt
+++ b/examples/projects/dev/kotlin-dataframe-plugin-maven-example/src/main/kotlin/Main.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.max
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.renameToCamelCase
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.io.readCsv
 import org.jetbrains.kotlinx.dataframe.io.writeCsv
@@ -72,7 +73,7 @@ fun main() {
         // new names corresponding to the column names.
         .renameToCamelCase()
         // Rename "stargazersCount" column to "stars".
-        .rename { stargazersCount }.into("stars")
+        .rename { stargazersCount }.to("stars")
         // And we can immediately use the updated name in the filtering.
         .filter { stars > 50 }
         // Convert values in the "topic" column (which were `String` initially)

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Generate.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Generate.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.generateDataClasses
 import org.jetbrains.kotlinx.dataframe.api.generateInterfaces
-import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.sumOf
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.toList
 import org.jetbrains.kotlinx.dataframe.samples.DataFrameSampleHelper
 import org.junit.Test
@@ -96,7 +96,7 @@ class Generate : DataFrameSampleHelper("generate_docs", "api") {
         df.cast<Customer>()
             .add("ordersTotal") { orders.sumOf { it.amount } }
             .filter { user.startsWith("A") }
-            .rename { user }.into("customer")
+            .rename { user }.to("customer")
         // SampleEnd
         //   .saveDfHtmlSample()
     }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Parse.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Parse.kt
@@ -15,11 +15,11 @@ import org.jetbrains.kotlinx.dataframe.api.addJavaDateTimePattern
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.convertTo
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
-import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.named
 import org.jetbrains.kotlinx.dataframe.api.parse
 import org.jetbrains.kotlinx.dataframe.api.parser
 import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.samples.DataFrameSampleHelper
 import org.jetbrains.kotlinx.dataframe.util.renderType
@@ -39,7 +39,7 @@ class Parse : DataFrameSampleHelper(subFolder = "api", sampleName = "parse") {
 
     private fun AnyFrame.withTypes() =
         this
-            .rename { colsAtAnyDepth() }.into { "${it.name()}: ${renderType(it.type())}" }
+            .rename { colsAtAnyDepth() }.to { "${it.name()}: ${renderType(it.type())}" }
 
     @Test
     fun dfParse() {

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/concepts/AccessApis.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/concepts/AccessApis.kt
@@ -8,10 +8,10 @@ import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.dropNulls
 import org.jetbrains.kotlinx.dataframe.api.filter
-import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.named
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.io.read
 import org.junit.Ignore
 import org.junit.Test
@@ -44,8 +44,8 @@ class AccessApis {
         // Get the "fullName" column
         df["fullName"]
 
-        // Rename the "fullName" column into "name"
-        df.rename("fullName").into("name")
+        // Rename the "fullName" column to "name"
+        df.rename("fullName").to("name")
         // SampleEnd
     }
 
@@ -71,8 +71,8 @@ class AccessApis {
         // Get "fullName" column
         df.fullName
 
-        // Rename "fullName" column into "name"
-        df.rename { fullName }.into("name")
+        // Rename "fullName" column to "name"
+        df.rename { fullName }.to("name")
 
         // Select the "firstName" column from the "fullName" column group
         // and the "age" column

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/guides/quickstart.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/guides/quickstart.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.api.sortByDesc
 import org.jetbrains.kotlinx.dataframe.api.sumOf
 import org.jetbrains.kotlinx.dataframe.api.take
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.io.readCsv
@@ -54,9 +55,9 @@ class QuickStartGuide : DataFrameSampleHelper("quickstart", "guides") {
 
     private fun getDfRenamed() =
         getDfFiltered()
-            .rename { full_name }.into("name")
-            // And "stargazers_count" into "starsCount"
-            .rename { stargazers_count }.into("starsCount")
+            .rename { full_name }.to("name")
+            // And "stargazers_count" to "starsCount"
+            .rename { stargazers_count }.to("starsCount")
 
     private fun getDfUpdated() =
         getDfRenamed()
@@ -130,10 +131,10 @@ class QuickStartGuide : DataFrameSampleHelper("quickstart", "guides") {
     fun notebook_test_quickstart_7() {
         val dfFiltered = getDfFiltered()
         // SampleStart
-        // Rename "full_name" column into "name"
-        val dfRenamed = dfFiltered.rename { full_name }.into("name")
-            // And "stargazers_count" into "starsCount"
-            .rename { stargazers_count }.into("starsCount")
+        // Rename "full_name" column to "name"
+        val dfRenamed = dfFiltered.rename { full_name }.to("name")
+            // And "stargazers_count" to "starsCount"
+            .rename { stargazers_count }.to("starsCount")
         dfRenamed
             // SampleEnd
             .saveDfHtmlSample()


### PR DESCRIPTION
Fixes https://github.com/Kotlin/dataframe/issues/555

I made `into` deprecated by warning indefinitely, so people that are familiar with `into` (or, AI) can still find it. And while I found no clashes with `to` for `Pair`-creation, I can see someone might want to avoid that confusion, so they can still use `into`.

The compiler plugin should also keep working, as I used the same interpretable annotation.

All usage, (dev) examples, and docs of rename `into` have been updated to `to`.