### PR TITLE
Improved error message in `readCsv` when `colTypes` causes parsing exception

### DIFF
--- a/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readDelim.kt
+++ b/dataframe-csv/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/io/readDelim.kt
@@ -159,16 +159,24 @@ internal fun readDelimImpl(
                 /* sinkFactory = */ ListSink.SINK_FACTORY,
             )
         } catch (e: CsvReaderException) {
-            // catch case when the file is empty and header needs to be inferred from it.
-            if (e.message ==
-                "Can't proceed because hasHeaderRow is set but input file is empty or shorter than skipHeaderRows"
-            ) {
-                return@readDelimImpl DataFrame.empty()
+            when {
+                // catch case when the file is empty and header needs to be inferred from it.
+                e.message == FILE_EMPTY_EXCEPTION_MESSAGE ->
+                    return@readDelimImpl DataFrame.empty()
+
+                // provide extra information when an incorrect parser type is supplied
+                INCORRECT_PARSER_TYPE_EXCEPTION_MESSAGE in e.cause?.message.orEmpty() && colTypes.isNotEmpty() ->
+                    throw IllegalStateException(
+                        "Could not read delimiter-separated data. Check `colTypes`, you may have supplied the wrong type for a column. Cause: ${e.cause?.message}",
+                        e,
+                    )
+
+                else ->
+                    throw IllegalStateException(
+                        "Could not read delimiter-separated data: CsvReaderException: ${e.message}: ${e.cause?.message ?: ""}",
+                        e,
+                    )
             }
-            throw IllegalStateException(
-                "Could not read delimiter-separated data: CsvReaderException: ${e.message}: ${e.cause?.message ?: ""}",
-                e,
-            )
         }
     }
 
@@ -184,6 +192,12 @@ internal fun readDelimImpl(
 
     return dataFrameOf(cols)
 }
+
+private const val FILE_EMPTY_EXCEPTION_MESSAGE =
+    "Can't proceed because hasHeaderRow is set but input file is empty or shorter than skipHeaderRows"
+
+private const val INCORRECT_PARSER_TYPE_EXCEPTION_MESSAGE =
+    "Parsing failed on input, with nothing left to fall back to."
 
 @Suppress("UNCHECKED_CAST")
 private fun CsvReader.ResultColumn.toDataColumn(

--- a/dataframe-csv/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/DelimCsvTsvTests.kt
+++ b/dataframe-csv/src/test/kotlin/org/jetbrains/kotlinx/dataframe/io/DelimCsvTsvTests.kt
@@ -5,8 +5,10 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.datetime.LocalDateTime
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -863,6 +865,19 @@ class DelimCsvTsvTests {
             '{"firstName":"Jane","lastName":"Doe"}'
             
             """.trimIndent()
+    }
+
+    @Test
+    fun `incorrect colTypes exception`() {
+        shouldThrow<IllegalStateException> {
+            DataFrame.readCsvStr(
+                """
+                a
+                abc
+                """.trimIndent(),
+                colTypes = mapOf("a" to ColType.Int),
+            )
+        }.message!!.shouldContain("Check `colTypes`")
     }
 
     companion object {


### PR DESCRIPTION
Fixes #1692

Providing a more information when readCsv with colTypes causes a parsing exception. 

We cannot detect which exact column is causing the problem, but we can at least point the user to `colTypes`.
For example:
```
Could not read delimiter-separated data. Check `colTypes`, you may have supplied the wrong type for a column. Cause: Parsing failed on input, with nothing left to fall back to. Parser io.deephaven.csv.parsers.IntParser successfully parsed 0 items before failure.
```
