### PR TITLE
relaxing error for unexpected folder in examples/projects to warning

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
@@ -169,9 +169,10 @@ private fun setupGenerateAndRunTestTasks(folder: File, isDev: Boolean) {
         .plus("Test")
 
     val isAndroid = folder.isAndroid()
-    val buildSystem = folder.detectBuildSystem() ?: error(
-        "Could not detect build system in example project folder '$folder'. We only support ${BuildSystem.entries.toList()}.",
-    )
+    val buildSystem = folder.detectBuildSystem()
+        ?: return logger.warn(
+            "Could not detect build system in example project folder '$folder'. We only support ${BuildSystem.entries.toList()}.",
+        )
 
     val generateTask = tasks.register("generate$testClassName") {
         group = buildExampleProjectsGroup


### PR DESCRIPTION
Small annoyance in the dfbuild.buildExampleProjects convention plugin that made the entire build fail if there was still a folder in `examples/projects(/dev)` after checking out another branch. Now it just skips over those folders and provides a warning message.