### PR TITLE
Disallowing `ValueColumn<AnyFrame>` because FrameColumn should be used

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -334,6 +334,11 @@ internal fun convertToDataFrame(
         val shouldCreateFrameCol = kClass == DataFrame::class && !nullable
         val shouldCreateColumnGroup = kClass == DataRow::class
 
+        if (shouldCreateFrameCol && shouldCreateValueCol) {
+            throw IllegalArgumentException(
+                "You cannot create a `ValueColumn<DataFrame<*>>`, a `FrameColumn` should be used instead. If you used `preserve(DataFrame::class)`, please remove it.",
+            )
+        }
         when {
             hasExceptions -> DataColumn.createByInference(it.columnName, values, nullable = nullable)
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ValueColumnImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ValueColumnImpl.kt
@@ -1,12 +1,17 @@
 package org.jetbrains.kotlinx.dataframe.impl.columns
 
+import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
+import org.jetbrains.kotlinx.dataframe.core.BuildConfig
+import org.jetbrains.kotlinx.dataframe.impl.nothingType
 import kotlin.reflect.KType
+import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.withNullability
+import kotlin.reflect.typeOf
 
 @JvmInline
 internal value class StatisticResult(val value: Any?)
@@ -47,6 +52,22 @@ internal open class ValueColumnImpl<T>(
 ) : DataColumnImpl<T>(values, name, type, distinct),
     ValueColumn<T>,
     ValueColumnInternal<T> {
+
+    init {
+        // This only runs with `kotlin.dataframe.debug=true` in gradle.properties.
+        if (BuildConfig.DEBUG) {
+            // check if not all values are non-nullable AnyFrame; a FrameColumn should be created in that case
+            if (values.isNotEmpty() && values.all { it is AnyFrame }) {
+                throw IllegalArgumentException(
+                    "ValueColumnImpl cannot just contain AnyFrame values. A FrameColumn should be created instead.",
+                )
+            }
+        }
+        // check if the type is not non-nullable AnyFrame; a FrameColumn should be created in that case
+        if (type.isSubtypeOf(typeOf<AnyFrame>()) && type != nothingType) {
+            throw IllegalArgumentException("ValueColumnImpl cannot contain AnyFrame values. Use FrameColumn instead.")
+        }
+    }
 
     override fun distinct() = ValueColumnImpl(toSet().toList(), name, type, defaultValue, distinct)
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.datetime.DateTimePeriod
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -157,17 +159,23 @@ class CreateDataFrameTests {
         df.a[0].v shouldBe 7
 
         val df2 = data.toDataFrame {
-            preserve(B::row)
             properties {
-                preserve(DataFrame::class)
+                preserve(B::row)
             }
         }
-        df2.frame.kind shouldBe ColumnKind.Value
-        df2.frame.type shouldBe typeOf<DataFrame<A>>()
+
         df2["row"].kind shouldBe ColumnKind.Value
         df2["row"].type shouldBe typeOf<DataRow<A>>()
         df2.list.kind shouldBe ColumnKind.Frame
         df2.a.kind() shouldBe ColumnKind.Group
+
+        shouldThrow<IllegalArgumentException> {
+            data.toDataFrame {
+                properties {
+                    preserve(DataFrame::class)
+                }
+            }
+        }.message!! shouldContain "If you used `preserve(DataFrame::class)`, please remove it"
     }
 
     class ExcludeTestData(val s: String, val data: NestedData)

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/columns/DataColumns.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/columns/DataColumns.kt
@@ -50,4 +50,15 @@ class DataColumns {
             values = listOf(dataFrameOf("a")(1), null),
         ).kind() shouldBe ColumnKind.Value
     }
+
+    @Test
+    fun `allow no non-null dataframe value columns`() {
+        // ordinarily this is a type-check only, in DEBUG mode, it's an instance check
+        shouldThrow<IllegalArgumentException> {
+            DataColumn.createValueColumn(
+                name = "",
+                values = listOf(dataFrameOf("a")(1), dataFrameOf("a")(2)),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Disallowing `ValueColumn<AnyFrame>` from being created because FrameColumn should be used instead.

Fixes https://github.com/Kotlin/dataframe/issues/1852
Unblocks https://github.com/Kotlin/dataframe/issues/1854
and may be followed up by https://github.com/Kotlin/dataframe/issues/1855
