### PR TITLE
Inline `AnyFrame`, `AnyRow`, and `AnyBaseCol` type aliases in public API

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/DataRowApi.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyColumnReference
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -30,13 +29,13 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
 @Deprecated(MESSAGE_SHORTCUT, ReplaceWith(IS_EMPTY_REPLACE), DeprecationLevel.WARNING)
-public fun AnyRow.isEmpty(): Boolean = owner.columns().all { it[index] == null }
+public fun DataRow<*>.isEmpty(): Boolean = owner.columns().all { it[index] == null }
 
 @Suppress("DEPRECATION_ERROR")
 @Deprecated(MESSAGE_SHORTCUT, ReplaceWith(IS_NOT_EMPTY_REPLACE), DeprecationLevel.WARNING)
-public fun AnyRow.isNotEmpty(): Boolean = !isEmpty()
+public fun DataRow<*>.isNotEmpty(): Boolean = !isEmpty()
 
-public inline fun <reified R> AnyRow.valuesOf(): List<R> = values().filterIsInstance<R>()
+public inline fun <reified R> DataRow<*>.valuesOf(): List<R> = values().filterIsInstance<R>()
 
 // region DataSchema
 @DataSchema
@@ -62,50 +61,50 @@ public val DataRow<NameValuePair<*>>.value: Any?
 
 // endregion
 
-public inline fun <reified R> AnyRow.namedValuesOf(): List<NameValuePair<R>> =
+public inline fun <reified R> DataRow<*>.namedValuesOf(): List<NameValuePair<R>> =
     values().zip(columnNames()).filter { it.first is R }.map { NameValuePair(it.second, it.first as R) }
 
 @RequiredByIntellijPlugin
-public fun AnyRow.namedValues(): List<NameValuePair<Any?>> =
+public fun DataRow<*>.namedValues(): List<NameValuePair<Any?>> =
     values().zip(columnNames()) { value, name -> NameValuePair(name, value) }
 
 // region getValue
 
-public fun <T> AnyRow.getValue(columnName: String): T = get(columnName) as T
+public fun <T> DataRow<*>.getValue(columnName: String): T = get(columnName) as T
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T> AnyRow.getValue(column: ColumnReference<T>): T = get(column)
+public fun <T> DataRow<*>.getValue(column: ColumnReference<T>): T = get(column)
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T> AnyRow.getValue(column: KProperty<T>): T = get(column)
+public fun <T> DataRow<*>.getValue(column: KProperty<T>): T = get(column)
 
-public fun <T> AnyRow.getValueOrNull(columnName: String): T? = getOrNull(columnName) as T?
+public fun <T> DataRow<*>.getValueOrNull(columnName: String): T? = getOrNull(columnName) as T?
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T> AnyRow.getValueOrNull(column: KProperty<T>): T? = getValueOrNull<T>(column.columnName)
+public fun <T> DataRow<*>.getValueOrNull(column: KProperty<T>): T? = getValueOrNull<T>(column.columnName)
 
 // endregion
 
 // region contains
 
-public fun AnyRow.containsKey(columnName: String): Boolean = owner.containsColumn(columnName)
+public fun DataRow<*>.containsKey(columnName: String): Boolean = owner.containsColumn(columnName)
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun AnyRow.containsKey(column: AnyColumnReference): Boolean = owner.containsColumn(column)
+public fun DataRow<*>.containsKey(column: AnyColumnReference): Boolean = owner.containsColumn(column)
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun AnyRow.containsKey(column: KProperty<*>): Boolean = owner.containsColumn(column)
+public fun DataRow<*>.containsKey(column: KProperty<*>): Boolean = owner.containsColumn(column)
 
-public operator fun AnyRow.contains(column: AnyColumnReference): Boolean = containsKey(column)
+public operator fun DataRow<*>.contains(column: AnyColumnReference): Boolean = containsKey(column)
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public operator fun AnyRow.contains(column: KProperty<*>): Boolean = containsKey(column)
+public operator fun DataRow<*>.contains(column: KProperty<*>): Boolean = containsKey(column)
 
 // endregion
 
@@ -183,11 +182,11 @@ public inline fun <T> DataRow<T>.diffOrNull(expression: RowExpression<T, Float>)
     prev()?.let { p -> expression(this, this) - expression(p, p) }
 
 @RequiredByIntellijPlugin
-public fun AnyRow.columnsCount(): Int = df().ncol
+public fun DataRow<*>.columnsCount(): Int = df().ncol
 
-public fun AnyRow.columnNames(): List<String> = df().columnNames()
+public fun DataRow<*>.columnNames(): List<String> = df().columnNames()
 
-public fun AnyRow.columnTypes(): List<KType> = df().columnTypes()
+public fun DataRow<*>.columnTypes(): List<KType> = df().columnTypes()
 
 @Suppress("DEPRECATION_ERROR")
 @Deprecated(MESSAGE_SHORTCUT, ReplaceWith(GET_ROW_REPLACE), DeprecationLevel.WARNING)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/add.kt
@@ -1,11 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.AnyColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.AnyColumnReference
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -51,7 +48,7 @@ import kotlin.reflect.KProperty
     replaceWith = ReplaceWith(ADD_VARARG_COLUMNS_REPLACE),
     level = DeprecationLevel.WARNING,
 )
-public fun <T> DataFrame<T>.add(vararg columns: AnyBaseCol): DataFrame<T> = addAll(columns.asIterable())
+public fun <T> DataFrame<T>.add(vararg columns: BaseColumn<*>): DataFrame<T> = addAll(columns.asIterable())
 
 /**
  * Adds new [columns] to the end of this [DataFrame] (at the top level).
@@ -65,7 +62,7 @@ public fun <T> DataFrame<T>.add(vararg columns: AnyBaseCol): DataFrame<T> = addA
  * @throws [UnequalColumnSizesException] if columns in an expected result have different sizes.
  * @return new [DataFrame] with added columns.
  */
-public fun <T> DataFrame<T>.addAll(vararg columns: AnyBaseCol): DataFrame<T> = addAll(columns.asIterable())
+public fun <T> DataFrame<T>.addAll(vararg columns: BaseColumn<*>): DataFrame<T> = addAll(columns.asIterable())
 
 /**
  * Adds new [columns] to the end of this [DataFrame] (at the top level).
@@ -79,7 +76,7 @@ public fun <T> DataFrame<T>.addAll(vararg columns: AnyBaseCol): DataFrame<T> = a
  * @throws [UnequalColumnSizesException] if columns in an expected result have different sizes.
  * @return new [DataFrame] with added columns.
  */
-public fun <T> DataFrame<T>.addAll(columns: Iterable<AnyBaseCol>): DataFrame<T> =
+public fun <T> DataFrame<T>.addAll(columns: Iterable<BaseColumn<*>>): DataFrame<T> =
     dataFrameOf(columns() + columns).cast()
 
 /**
@@ -100,7 +97,7 @@ public fun <T> DataFrame<T>.addAll(columns: Iterable<AnyBaseCol>): DataFrame<T> 
     replaceWith = ReplaceWith(ADD_VARARG_FRAMES_REPLACE),
     level = DeprecationLevel.WARNING,
 )
-public fun <T> DataFrame<T>.add(vararg dataFrames: AnyFrame): DataFrame<T> = addAll(dataFrames.asIterable())
+public fun <T> DataFrame<T>.add(vararg dataFrames: DataFrame<*>): DataFrame<T> = addAll(dataFrames.asIterable())
 
 /**
  * Adds all columns from the given [dataFrames] to the end of this [DataFrame] (at the top level).
@@ -117,7 +114,7 @@ public fun <T> DataFrame<T>.add(vararg dataFrames: AnyFrame): DataFrame<T> = add
  */
 @Refine
 @Interpretable("DataFrameAddAll")
-public fun <T> DataFrame<T>.addAll(vararg dataFrames: AnyFrame): DataFrame<T> = addAll(dataFrames.asIterable())
+public fun <T> DataFrame<T>.addAll(vararg dataFrames: DataFrame<*>): DataFrame<T> = addAll(dataFrames.asIterable())
 
 /**
  * Adds all columns from the given [dataFrames] to the end of this [DataFrame] (at the top level).
@@ -133,7 +130,7 @@ public fun <T> DataFrame<T>.addAll(vararg dataFrames: AnyFrame): DataFrame<T> = 
  * @return new [DataFrame] with added columns.
  */
 @JvmName("addAllFrames")
-public fun <T> DataFrame<T>.addAll(dataFrames: Iterable<AnyFrame>): DataFrame<T> =
+public fun <T> DataFrame<T>.addAll(dataFrames: Iterable<DataFrame<*>>): DataFrame<T> =
     addAll(dataFrames.flatMap { it.columns() })
 
 // endregion
@@ -154,7 +151,7 @@ public interface AddDataRow<out T> : DataRow<T> {
      *
      * @throws IndexOutOfBoundsException when called on a successive row that doesn't have new value yet
      */
-    public fun <C> AnyRow.newValue(): C
+    public fun <C> DataRow<*>.newValue(): C
 }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/addId.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/addId.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
@@ -11,7 +10,7 @@ import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
 
 // region DataColumn
 
-public fun AnyCol.addId(columnName: String = "id"): AnyFrame = toDataFrame().addId(columnName)
+public fun AnyCol.addId(columnName: String = "id"): DataFrame<*> = toDataFrame().addId(columnName)
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
@@ -50,7 +50,7 @@ public fun <C> DataColumn<C>.allNulls(): Boolean =
 
 // region DataRow
 
-public fun AnyRow.allNA(): Boolean = owner.columns().all { it[index()].isNA }
+public fun DataRow<*>.allNA(): Boolean = owner.columns().all { it[index()].isNA }
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cast.kt
@@ -3,8 +3,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -23,9 +21,9 @@ import org.jetbrains.kotlinx.dataframe.impl.api.convertToImpl
 import kotlin.reflect.typeOf
 
 @Check
-public fun <T> AnyFrame.cast(): DataFrame<T> = this as DataFrame<T>
+public fun <T> DataFrame<*>.cast(): DataFrame<T> = this as DataFrame<T>
 
-public inline fun <reified T> AnyFrame.cast(verify: Boolean = true): DataFrame<T> =
+public inline fun <reified T> DataFrame<*>.cast(verify: Boolean = true): DataFrame<T> =
     if (verify) {
         convertToImpl(
             typeOf<T>(),
@@ -36,7 +34,7 @@ public inline fun <reified T> AnyFrame.cast(verify: Boolean = true): DataFrame<T
         cast()
     }
 
-public inline fun <reified T> AnyFrame.castTo(
+public inline fun <reified T> DataFrame<*>.castTo(
     @Suppress("UNUSED_PARAMETER") schemaFrom: DataFrame<T>,
     verify: Boolean = true,
 ): DataFrame<T> = cast<T>(verify = verify)
@@ -66,14 +64,14 @@ public inline fun <reified T> AnyFrame.castTo(
  * }
  * ```
  */
-public inline fun <reified T> AnyFrame.castTo(
+public inline fun <reified T> DataFrame<*>.castTo(
     @Suppress("UNUSED_PARAMETER") schemaFrom: Function<DataFrame<T>>,
     verify: Boolean = true,
 ): DataFrame<T> = cast<T>(verify = verify)
 
-public fun <T> AnyRow.cast(): DataRow<T> = this as DataRow<T>
+public fun <T> DataRow<*>.cast(): DataRow<T> = this as DataRow<T>
 
-public inline fun <reified T> AnyRow.cast(verify: Boolean = true): DataRow<T> = df().cast<T>(verify)[0]
+public inline fun <reified T> DataRow<*>.cast(verify: Boolean = true): DataRow<T> = df().cast<T>(verify)[0]
 
 @Interpretable("AnyColCast")
 public fun <T> AnyCol.cast(): DataColumn<T> = this as DataColumn<T>

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colGroups.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.Predicate
@@ -109,7 +108,7 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups0")
-    public fun ColumnSet<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun ColumnSet<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         columnGroupsInternal(filter)
 
     /**
@@ -121,7 +120,7 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]`  {  `[colGroups][ColumnsSelectionDsl.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups1")
-    public fun ColumnsSelectionDsl<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun ColumnsSelectionDsl<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         asSingleColumn().columnGroupsInternal(filter)
 
     /**
@@ -133,7 +132,7 @@ public interface ColGroupsColumnsSelectionDsl {
      * `df.`[select][DataFrame.select]` { myColGroup.`[colGroups][SingleColumn.colGroups]` { it.`[name][ColumnReference.name]`.`[startsWith][String.startsWith]`("my") } }`
      */
     @Interpretable("ColGroups2")
-    public fun SingleColumn<DataRow<*>>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun SingleColumn<DataRow<*>>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         this.ensureIsColumnGroup().columnGroupsInternal(filter)
 
     /**
@@ -144,7 +143,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "myColGroup".`[colGroups][String.colGroups]`() }`
      */
-    public fun String.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun String.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         columnGroup(this).colGroups(filter)
 
     /**
@@ -155,7 +154,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { DataSchemaType::myColGroup.`[colGroups][KProperty.colGroups]`() }`
      */
-    public fun KProperty<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun KProperty<*>.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         columnGroup(this).colGroups(filter)
 
     /**
@@ -164,7 +163,7 @@ public interface ColGroupsColumnsSelectionDsl {
      *
      * `df.`[select][DataFrame.select]` { "pathTo"["myGroupCol"].`[colGroups][ColumnPath.colGroups]`() }`
      */
-    public fun ColumnPath.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<AnyRow> =
+    public fun ColumnPath.colGroups(filter: Predicate<ColumnGroup<*>> = { true }): ColumnSet<DataRow<*>> =
         columnGroup(this).colGroups(filter)
 }
 
@@ -177,6 +176,6 @@ public interface ColGroupsColumnsSelectionDsl {
 @Suppress("UNCHECKED_CAST")
 internal inline fun ColumnsResolver<*>.columnGroupsInternal(
     crossinline filter: (ColumnGroup<*>) -> Boolean,
-): ColumnSet<AnyRow> = colsInternal { it.isColumnGroup() && filter(it) }.cast()
+): ColumnSet<DataRow<*>> = colsInternal { it.isColumnGroup() && filter(it) }.cast()
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/colsOf.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.ColumnsResolver
 import org.jetbrains.kotlinx.dataframe.columns.SingleColumn
-import org.jetbrains.kotlinx.dataframe.columns.size
 import org.jetbrains.kotlinx.dataframe.documentation.DslGrammarTemplateColumnsSelectionDsl.DslGrammarTemplate
 import org.jetbrains.kotlinx.dataframe.documentation.Indent
 import org.jetbrains.kotlinx.dataframe.documentation.LineBreak

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/constructors.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnGroupReference
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -12,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -128,17 +126,17 @@ public fun <T> ColumnGroupReference.valueColumn(property: KProperty<T>): ColumnA
 
 // region columnGroup
 
-public fun columnGroup(): ColumnDelegate<AnyRow> = column()
+public fun columnGroup(): ColumnDelegate<DataRow<*>> = column()
 
 @JvmName("columnGroupTyped")
 public fun <T> columnGroup(): ColumnDelegate<DataRow<T>> = column()
 
-public fun columnGroup(name: String): ColumnAccessor<AnyRow> = column(name)
+public fun columnGroup(name: String): ColumnAccessor<DataRow<*>> = column(name)
 
 @JvmName("columnGroupTyped")
 public fun <T> columnGroup(name: String): ColumnAccessor<DataRow<T>> = column(name)
 
-public fun columnGroup(path: ColumnPath): ColumnAccessor<AnyRow> = column(path)
+public fun columnGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> = column(path)
 
 @JvmName("columnGroupTyped")
 public fun <T> columnGroup(path: ColumnPath): ColumnAccessor<DataRow<T>> = column(path)
@@ -152,18 +150,19 @@ public fun <T> columnGroup(property: KProperty<DataRow<T>>): ColumnAccessor<Data
 @AccessApiOverload
 public fun <T> columnGroup(property: KProperty<T>): ColumnAccessor<DataRow<T>> = column(property.name)
 
-public fun ColumnGroupReference.columnGroup(): ColumnDelegate<AnyRow> = ColumnDelegate(this)
+public fun ColumnGroupReference.columnGroup(): ColumnDelegate<DataRow<*>> = ColumnDelegate(this)
 
 @JvmName("columnGroupTyped")
 public fun <T> ColumnGroupReference.columnGroup(): ColumnDelegate<DataRow<T>> = ColumnDelegate(this)
 
-public fun ColumnGroupReference.columnGroup(name: String): ColumnAccessor<AnyRow> = ColumnAccessorImpl(path() + name)
+public fun ColumnGroupReference.columnGroup(name: String): ColumnAccessor<DataRow<*>> =
+    ColumnAccessorImpl(path() + name)
 
 @JvmName("columnGroupTyped")
 public fun <T> ColumnGroupReference.columnGroup(name: String): ColumnAccessor<DataRow<T>> =
     ColumnAccessorImpl(path() + name)
 
-public fun ColumnGroupReference.columnGroup(path: ColumnPath): ColumnAccessor<AnyRow> =
+public fun ColumnGroupReference.columnGroup(path: ColumnPath): ColumnAccessor<DataRow<*>> =
     ColumnAccessorImpl(this.path() + path)
 
 @JvmName("columnGroupTyped")
@@ -185,17 +184,17 @@ public fun <T> ColumnGroupReference.columnGroup(property: KProperty<T>): ColumnA
 
 // region frameColumn
 
-public fun frameColumn(): ColumnDelegate<AnyFrame> = column()
+public fun frameColumn(): ColumnDelegate<DataFrame<*>> = column()
 
 @JvmName("frameColumnTyped")
 public fun <T> frameColumn(): ColumnDelegate<DataFrame<T>> = column()
 
-public fun frameColumn(name: String): ColumnAccessor<AnyFrame> = column(name)
+public fun frameColumn(name: String): ColumnAccessor<DataFrame<*>> = column(name)
 
 @JvmName("frameColumnTyped")
 public fun <T> frameColumn(name: String): ColumnAccessor<DataFrame<T>> = column(name)
 
-public fun frameColumn(path: ColumnPath): ColumnAccessor<AnyFrame> = column(path)
+public fun frameColumn(path: ColumnPath): ColumnAccessor<DataFrame<*>> = column(path)
 
 @JvmName("frameColumnTyped")
 public fun <T> frameColumn(path: ColumnPath): ColumnAccessor<DataFrame<T>> = column(path)
@@ -209,18 +208,19 @@ public fun <T> frameColumn(property: KProperty<DataFrame<T>>): ColumnAccessor<Da
 @AccessApiOverload
 public fun <T> frameColumn(property: KProperty<List<T>>): ColumnAccessor<DataFrame<T>> = column(property.name)
 
-public fun ColumnGroupReference.frameColumn(): ColumnDelegate<AnyFrame> = ColumnDelegate(this)
+public fun ColumnGroupReference.frameColumn(): ColumnDelegate<DataFrame<*>> = ColumnDelegate(this)
 
 @JvmName("frameColumnTyped")
 public fun <T> ColumnGroupReference.frameColumn(): ColumnDelegate<DataFrame<T>> = ColumnDelegate(this)
 
-public fun ColumnGroupReference.frameColumn(name: String): ColumnAccessor<AnyFrame> = ColumnAccessorImpl(path() + name)
+public fun ColumnGroupReference.frameColumn(name: String): ColumnAccessor<DataFrame<*>> =
+    ColumnAccessorImpl(path() + name)
 
 @JvmName("frameColumnTyped")
 public fun <T> ColumnGroupReference.frameColumn(name: String): ColumnAccessor<DataFrame<T>> =
     ColumnAccessorImpl(path() + name)
 
-public fun ColumnGroupReference.frameColumn(path: ColumnPath): ColumnAccessor<AnyFrame> =
+public fun ColumnGroupReference.frameColumn(path: ColumnPath): ColumnAccessor<DataFrame<*>> =
     ColumnAccessorImpl(this.path() + path)
 
 @JvmName("frameColumnTyped")
@@ -259,7 +259,7 @@ public inline fun <reified T> columnOf(vararg values: T): DataColumn<T> =
         allColsMakesColGroup = true,
     ).forceResolve()
 
-public fun columnOf(vararg values: AnyBaseCol): DataColumn<AnyRow> = columnOf(values.asIterable()).forceResolve()
+public fun columnOf(vararg values: BaseColumn<*>): DataColumn<DataRow<*>> = columnOf(values.asIterable()).forceResolve()
 
 /**
  * Example:
@@ -272,7 +272,7 @@ public fun columnOf(vararg values: AnyBaseCol): DataColumn<AnyRow> = columnOf(va
  */
 @Refine
 @Interpretable("ColumnOfPairs")
-public fun columnOf(vararg columns: Pair<String, AnyBaseCol>): ColumnGroup<*> =
+public fun columnOf(vararg columns: Pair<String, BaseColumn<*>>): ColumnGroup<*> =
     dataFrameOf(
         columns.map { (name, col) ->
             col.rename(name)
@@ -281,7 +281,7 @@ public fun columnOf(vararg columns: Pair<String, AnyBaseCol>): ColumnGroup<*> =
 
 public fun <T> columnOf(vararg frames: DataFrame<T>): FrameColumn<T> = columnOf(frames.asIterable()).forceResolve()
 
-public fun columnOf(columns: Iterable<AnyBaseCol>): DataColumn<AnyRow> =
+public fun columnOf(columns: Iterable<BaseColumn<*>>): DataColumn<DataRow<*>> =
     DataColumn.createColumnGroup(
         name = "",
         df = dataFrameOf(columns),
@@ -317,7 +317,7 @@ public inline fun <reified T> column(values: Iterable<T>): DataColumn<T> =
  * @throws [UnequalColumnSizesException] if column size are not equal
  * @param columns columns for [DataFrame]
  */
-public fun dataFrameOf(columns: Iterable<AnyBaseCol>): DataFrame<*> {
+public fun dataFrameOf(columns: Iterable<BaseColumn<*>>): DataFrame<*> {
     val cols = columns.map { it.unbox() }
     val nrow = if (cols.isEmpty()) 0 else cols[0].size
     return DataFrameImpl<Unit>(cols, nrow)
@@ -338,12 +338,12 @@ public fun dataFrameOf(columns: Iterable<AnyBaseCol>): DataFrame<*> {
 @Refine
 @JvmName("dataFrameOfColumns")
 @Interpretable("DataFrameOfPairs")
-public fun dataFrameOf(vararg columns: Pair<String, AnyBaseCol>): DataFrame<*> =
+public fun dataFrameOf(vararg columns: Pair<String, BaseColumn<*>>): DataFrame<*> =
     dataFrameOf(columns.map { (name, col) -> col.rename(name) })
 
 public fun dataFrameOf(vararg header: ColumnReference<*>): DataFrameBuilder = DataFrameBuilder(header.map { it.name() })
 
-public fun dataFrameOf(vararg columns: AnyBaseCol): DataFrame<*> = dataFrameOf(columns.asIterable())
+public fun dataFrameOf(vararg columns: BaseColumn<*>): DataFrame<*> = dataFrameOf(columns.asIterable())
 
 @Interpretable("DataFrameOf0")
 public fun dataFrameOf(vararg header: String): DataFrameBuilder = dataFrameOf(header.toList())
@@ -424,7 +424,7 @@ public class DataFrameBuilder(private val header: List<String>) {
             )
         }
 
-    public fun fill(nrow: Int, dataFrame: AnyFrame): DataFrame<*> =
+    public fun fill(nrow: Int, dataFrame: DataFrame<*>): DataFrame<*> =
         withColumns { name ->
             DataColumn.createFrameColumn(
                 name = name,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -12,9 +12,7 @@ import kotlinx.datetime.format.FormatStringsInDatetimeFormats
 import kotlinx.datetime.format.byUnicodePattern
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.toStdlibInstant
-import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -480,7 +478,7 @@ public fun <T> Convert<T, *>.to(type: KType, parserOptions: ParserOptions? = nul
     asColumn { it.convertToTypeImpl(type, parserOptions) }
 
 @Deprecated(CONVERT_TO, ReplaceWith(CONVERT_TO_REPLACE), DeprecationLevel.ERROR)
-public fun <T, C> Convert<T, C>.to(columnConverter: DataFrame<T>.(DataColumn<C>) -> AnyBaseCol): DataFrame<T> =
+public fun <T, C> Convert<T, C>.to(columnConverter: DataFrame<T>.(DataColumn<C>) -> BaseColumn<*>): DataFrame<T> =
     df.replace(columns).with { columnConverter(df, it) }
 
 /** [Convert per row col][Convert.perRowCol] to provide a new value for every selected cell giving its column. */
@@ -4238,7 +4236,7 @@ public fun <T, C> Convert<T, List<List<C>>>.toDataFrames(containsColumns: Boolea
  *                        Defaults to `false`.
  *  @return A new [DataColumn] with the values converted to [DataFrame].
  */
-public fun <T> DataColumn<List<List<T>>>.toDataFrames(containsColumns: Boolean = false): DataColumn<AnyFrame> =
+public fun <T> DataColumn<List<List<T>>>.toDataFrames(containsColumns: Boolean = false): DataColumn<DataFrame<*>> =
     map { it.toDataFrame(containsColumns = containsColumns) }
 
 // region deprecated

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -159,7 +158,7 @@ public class ConvertType<T>(
  * @throws [TypeConversionException] if type converter failed to convert column values.
  * @return converted [DataFrame].
  */
-public inline fun <reified T : Any> AnyFrame.convertTo(
+public inline fun <reified T : Any> DataFrame<*>.convertTo(
     excessiveColumnsBehavior: ExcessiveColumns = ExcessiveColumns.Keep,
     noinline body: ConvertSchemaDsl<T>.() -> Unit = {},
 ): DataFrame<T> = convertToImpl(typeOf<T>(), true, excessiveColumnsBehavior, body).cast()
@@ -195,7 +194,7 @@ public inline fun <reified T : Any> AnyFrame.convertTo(
  * @throws [TypeConversionException] if type converter failed to convert column values.
  * @return converted [DataFrame].
  */
-public inline fun <reified T : Any> AnyFrame.convertTo(
+public inline fun <reified T : Any> DataFrame<*>.convertTo(
     @Suppress("UNUSED_PARAMETER") schemaFrom: DataFrame<T>,
     excessiveColumnsBehavior: ExcessiveColumns = ExcessiveColumns.Keep,
     noinline body: ConvertSchemaDsl<T>.() -> Unit = {},
@@ -231,10 +230,10 @@ public inline fun <reified T : Any> AnyFrame.convertTo(
  * @throws [TypeConversionException] if type converter failed to convert column values.
  * @return converted [DataFrame].
  */
-public fun AnyFrame.convertTo(
+public fun DataFrame<*>.convertTo(
     schemaType: KType,
     excessiveColumnsBehavior: ExcessiveColumns = ExcessiveColumns.Keep,
     body: ConvertSchemaDsl<Any>.() -> Unit = {},
-): AnyFrame = convertToImpl(schemaType, true, excessiveColumnsBehavior, body)
+): DataFrame<*> = convertToImpl(schemaType, true, excessiveColumnsBehavior, body)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/count.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/count.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -43,7 +42,7 @@ public fun <T> DataColumn<T>.count(predicate: Predicate<T>? = null): Int =
  * @return the number of columns in this row.
  * @see [columnsCount].
  */
-public fun AnyRow.count(): Int = columnsCount()
+public fun DataRow<*>.count(): Int = columnsCount()
 
 /**
  * Counts the number of elements in the current row that satisfy the given [predicate].
@@ -52,7 +51,7 @@ public fun AnyRow.count(): Int = columnsCount()
  * The predicate should return `true` for elements to be counted.
  * @return The number of elements that satisfy the predicate.
  */
-public inline fun AnyRow.count(predicate: Predicate<Any?>): Int = values().count(predicate)
+public inline fun DataRow<*>.count(predicate: Predicate<Any?>): Int = values().count(predicate)
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/countDistinct.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/countDistinct.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyColumnReference
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
@@ -29,7 +28,7 @@ import kotlin.reflect.KProperty
  *
  * @return The number of distinct rows in this [DataFrame].
  */
-public fun AnyFrame.countDistinct(): Int = countDistinct { all() }
+public fun DataFrame<*>.countDistinct(): Int = countDistinct { all() }
 
 /**
  * Returns number of distinct combinations of values in selected [columns\] in this [DataFrame].

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/indices.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/indices.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.RowFilter
 import org.jetbrains.kotlinx.dataframe.indices
 
 // region DataFrame
 
-public fun AnyFrame.indices(): IntRange = 0 until rowsCount()
+public fun DataFrame<*>.indices(): IntRange = 0 until rowsCount()
 
 public inline fun <T> DataFrame<T>.indices(filter: RowFilter<T>): List<Int> =
     indices().filter {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/into.kt
@@ -1,8 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.RowExpression
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
@@ -46,11 +45,11 @@ public fun <T, G> GroupBy<T, G>.into(column: String): DataFrame<T> = toDataFrame
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T> GroupBy<T, *>.into(column: ColumnAccessor<AnyFrame>): DataFrame<T> = toDataFrame(column.name())
+public fun <T> GroupBy<T, *>.into(column: ColumnAccessor<DataFrame<*>>): DataFrame<T> = toDataFrame(column.name())
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T> GroupBy<T, *>.into(column: KProperty<AnyFrame>): DataFrame<T> = toDataFrame(column.columnName)
+public fun <T> GroupBy<T, *>.into(column: KProperty<DataFrame<*>>): DataFrame<T> = toDataFrame(column.columnName)
 
 /**
  * Aggregates this [GroupBy] into a [DataFrame]
@@ -154,10 +153,10 @@ public fun <T, G> ReducedGroupBy<T, G>.into(columnName: String): DataFrame<G> = 
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T, G> ReducedGroupBy<T, G>.into(column: ColumnAccessor<AnyRow>): DataFrame<G> = into(column) { this }
+public fun <T, G> ReducedGroupBy<T, G>.into(column: ColumnAccessor<DataRow<*>>): DataFrame<G> = into(column) { this }
 
 @Deprecated(DEPRECATED_ACCESS_API)
 @AccessApiOverload
-public fun <T, G> ReducedGroupBy<T, G>.into(column: KProperty<AnyRow>): DataFrame<G> = into(column) { this }
+public fun <T, G> ReducedGroupBy<T, G>.into(column: KProperty<DataRow<*>>): DataFrame<G> = into(column) { this }
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
@@ -1,13 +1,13 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 
 // region DataFrame
 
-public fun AnyFrame.isEmpty(): Boolean = ncol == 0 || nrow == 0
+public fun DataFrame<*>.isEmpty(): Boolean = ncol == 0 || nrow == 0
 
-public fun AnyFrame.isNotEmpty(): Boolean = !isEmpty()
+public fun DataFrame<*>.isNotEmpty(): Boolean = !isEmpty()
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/map.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -143,7 +142,7 @@ public fun <T, R> ColumnsContainer<T>.mapToColumn(
 
 @Refine
 @Interpretable("MapToFrame")
-public inline fun <T> DataFrame<T>.mapToFrame(body: AddDsl<T>.() -> Unit): AnyFrame {
+public inline fun <T> DataFrame<T>.mapToFrame(body: AddDsl<T>.() -> Unit): DataFrame<*> {
     val dsl = AddDsl(this)
     body(dsl)
     return dataFrameOf(dsl.columns)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -60,15 +59,15 @@ public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.maxOfOrNul
 // region DataRow
 
 @Deprecated(ROW_MAX_OR_NULL, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMaxOrNull(): Nothing? = error(ROW_MAX_OR_NULL)
+public fun DataRow<*>.rowMaxOrNull(): Nothing? = error(ROW_MAX_OR_NULL)
 
 @Deprecated(ROW_MAX, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMax(): Nothing = error(ROW_MAX)
+public fun DataRow<*>.rowMax(): Nothing = error(ROW_MAX)
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMaxOfOrNull(skipNaN: Boolean = skipNaNDefault): T? =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMaxOfOrNull(skipNaN: Boolean = skipNaNDefault): T? =
     Aggregators.max<T>(skipNaN).aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMaxOf(skipNaN: Boolean = skipNaNDefault): T =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMaxOf(skipNaN: Boolean = skipNaNDefault): T =
     rowMaxOfOrNull<T>(skipNaN).suggestIfNull("rowMaxOf")
 
 // endregion
@@ -489,10 +488,11 @@ public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.maxOfOrNul
     maxOfOrNull(skipNaN = skipNaNDefault, selector = selector)
 
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Comparable<T>> AnyRow.rowMaxOfOrNull(): T? = rowMaxOfOrNull<T>(skipNaN = skipNaNDefault)
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMaxOfOrNull(): T? =
+    rowMaxOfOrNull<T>(skipNaN = skipNaNDefault)
 
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Comparable<T & Any>?> AnyRow.rowMaxOf(): T & Any = rowMaxOf(skipNaN = skipNaNDefault)
+public inline fun <reified T : Comparable<T & Any>?> DataRow<*>.rowMaxOf(): T & Any = rowMaxOf(skipNaN = skipNaNDefault)
 
 @Deprecated(MAX_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.max(): DataRow<T> = max(skipNaN = skipNaNDefault)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -48,10 +47,10 @@ public inline fun <T, reified R : Number?> DataColumn<T>.meanOf(
 
 // region DataRow
 
-public fun AnyRow.rowMean(skipNaN: Boolean = skipNaNDefault): Double =
+public fun DataRow<*>.rowMean(skipNaN: Boolean = skipNaNDefault): Double =
     Aggregators.mean(skipNaN).aggregateOfRow(this, primitiveOrMixedNumberColumns())
 
-public inline fun <reified T : Number> AnyRow.rowMeanOf(skipNaN: Boolean = skipNaNDefault): Double {
+public inline fun <reified T : Number> DataRow<*>.rowMeanOf(skipNaN: Boolean = skipNaNDefault): Double {
     require(typeOf<T>().isPrimitiveOrMixedNumber()) {
         "Type ${T::class.simpleName} is not a primitive number type. Mean only supports primitive number types."
     }
@@ -306,10 +305,10 @@ public inline fun <T, reified R : Number?> DataColumn<T>.meanOf(crossinline expr
     meanOf(skipNaN = skipNaNDefault, expression = expression)
 
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public fun AnyRow.rowMean(): Double = rowMean(skipNaN = skipNaNDefault)
+public fun DataRow<*>.rowMean(): Double = rowMean(skipNaN = skipNaNDefault)
 
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Number> AnyRow.rowMeanOf(): Double = rowMeanOf<T>(skipNaN = skipNaNDefault)
+public inline fun <reified T : Number> DataRow<*>.rowMeanOf(): Double = rowMeanOf<T>(skipNaN = skipNaNDefault)
 
 @Deprecated(MEAN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.mean(): DataRow<T> = mean(skipNaN = skipNaNDefault)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
@@ -2,7 +2,6 @@
 
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -108,24 +107,24 @@ public inline fun <T, reified R> DataColumn<T>.medianOfOrNull(
 // region DataRow
 
 @Deprecated(ROW_MEDIAN_OR_NULL, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMedianOrNull(): Nothing? = error(ROW_MEDIAN_OR_NULL)
+public fun DataRow<*>.rowMedianOrNull(): Nothing? = error(ROW_MEDIAN_OR_NULL)
 
 @Deprecated(ROW_MEDIAN, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMedian(): Nothing = error(ROW_MEDIAN)
+public fun DataRow<*>.rowMedian(): Nothing = error(ROW_MEDIAN)
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMedianOfOrNull(): T? =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMedianOfOrNull(): T? =
     Aggregators.medianComparables<T>().aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMedianOf(): T =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMedianOf(): T =
     rowMedianOfOrNull<T>().suggestIfNull("rowMedianOf")
 
-public inline fun <reified T> AnyRow.rowMedianOfOrNull(
+public inline fun <reified T> DataRow<*>.rowMedianOfOrNull(
     skipNaN: Boolean = skipNaNDefault,
 ): Double?
     where T : Comparable<T>, T : Number =
     Aggregators.medianNumbers<T>(skipNaN).aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T> AnyRow.rowMedianOf(
+public inline fun <reified T> DataRow<*>.rowMedianOf(
     skipNaN: Boolean = skipNaNDefault,
 ): Double
     where T : Comparable<T>, T : Number = rowMedianOfOrNull<T>(skipNaN).suggestIfNull("rowMedianOf")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -60,15 +59,15 @@ public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.minOfOrNul
 // region DataRow
 
 @Deprecated(ROW_MIN_OR_NULL, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMinOrNull(): Nothing? = error(ROW_MIN_OR_NULL)
+public fun DataRow<*>.rowMinOrNull(): Nothing? = error(ROW_MIN_OR_NULL)
 
 @Deprecated(ROW_MIN, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowMin(): Nothing = error(ROW_MIN)
+public fun DataRow<*>.rowMin(): Nothing = error(ROW_MIN)
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMinOfOrNull(skipNaN: Boolean = skipNaNDefault): T? =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMinOfOrNull(skipNaN: Boolean = skipNaNDefault): T? =
     Aggregators.min<T>(skipNaN).aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowMinOf(skipNaN: Boolean = skipNaNDefault): T =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMinOf(skipNaN: Boolean = skipNaNDefault): T =
     rowMinOfOrNull<T>(skipNaN).suggestIfNull("rowMinOf")
 
 // endregion
@@ -489,10 +488,11 @@ public inline fun <T, reified R : Comparable<R & Any>?> DataColumn<T>.minOfOrNul
     minOfOrNull(skipNaN = skipNaNDefault, selector = selector)
 
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Comparable<T>> AnyRow.rowMinOfOrNull(): T? = rowMinOfOrNull<T>(skipNaN = skipNaNDefault)
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowMinOfOrNull(): T? =
+    rowMinOfOrNull<T>(skipNaN = skipNaNDefault)
 
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Comparable<T & Any>?> AnyRow.rowMinOf(): T & Any = rowMinOf(skipNaN = skipNaNDefault)
+public inline fun <reified T : Comparable<T & Any>?> DataRow<*>.rowMinOf(): T & Any = rowMinOf(skipNaN = skipNaNDefault)
 
 @Deprecated(MIN_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.min(): DataRow<T> = min(skipNaN = skipNaNDefault)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -95,5 +94,5 @@ public fun DataColumn<Char?>.parse(options: ParserOptions? = null): DataColumn<*
         .also { if (it.isSubtypeOf<Char?>() || it.isSubtypeOf<String?>()) error("Can't guess column type") }
 
 @JvmName("parseAnyFrameNullable")
-public fun DataColumn<AnyFrame?>.parse(options: ParserOptions? = null): DataColumn<AnyFrame?> =
+public fun DataColumn<DataFrame<*>?>.parse(options: ParserOptions? = null): DataColumn<DataFrame<*>?> =
     map { it?.parse(options) }

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -2,7 +2,6 @@
 
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -119,25 +118,25 @@ public inline fun <T, reified R> DataColumn<T>.percentileOfOrNull(
 // region DataRow
 
 @Deprecated(ROW_PERCENTILE_OR_NULL, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowPercentileOrNull(): Nothing? = error(ROW_PERCENTILE_OR_NULL)
+public fun DataRow<*>.rowPercentileOrNull(): Nothing? = error(ROW_PERCENTILE_OR_NULL)
 
 @Deprecated(ROW_PERCENTILE, level = DeprecationLevel.ERROR)
-public fun AnyRow.rowPercentile(): Nothing = error(ROW_PERCENTILE)
+public fun DataRow<*>.rowPercentile(): Nothing = error(ROW_PERCENTILE)
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowPercentileOfOrNull(percentile: Double): T? =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowPercentileOfOrNull(percentile: Double): T? =
     Aggregators.percentileComparables<T>(percentile).aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T : Comparable<T>> AnyRow.rowPercentileOf(percentile: Double): T =
+public inline fun <reified T : Comparable<T>> DataRow<*>.rowPercentileOf(percentile: Double): T =
     rowPercentileOfOrNull<T>(percentile).suggestIfNull("rowPercentileOf")
 
-public inline fun <reified T> AnyRow.rowPercentileOfOrNull(
+public inline fun <reified T> DataRow<*>.rowPercentileOfOrNull(
     percentile: Double,
     skipNaN: Boolean = skipNaNDefault,
 ): Double?
     where T : Comparable<T>, T : Number =
     Aggregators.percentileNumbers<T>(percentile, skipNaN).aggregateOfRow(this) { colsOf<T?>() }
 
-public inline fun <reified T> AnyRow.rowPercentileOf(
+public inline fun <reified T> DataRow<*>.rowPercentileOf(
     percentile: Double,
     skipNaN: Boolean = skipNaNDefault,
 ): Double

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/replace.kt
@@ -1,12 +1,12 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
 import org.jetbrains.kotlinx.dataframe.ColumnsContainer
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
+import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.get
@@ -60,7 +60,9 @@ public fun <T, C> ReplaceClause<T, C>.with(newColumns: List<AnyCol>): DataFrame<
 /**
  * For an alternative supported in the compiler plugin use [Convert.asColumn]
  */
-public fun <T, C> ReplaceClause<T, C>.with(transform: ColumnsContainer<T>.(DataColumn<C>) -> AnyBaseCol): DataFrame<T> {
+public fun <T, C> ReplaceClause<T, C>.with(
+    transform: ColumnsContainer<T>.(DataColumn<C>) -> BaseColumn<*>,
+): DataFrame<T> {
     val removeResult = df.removeImpl(columns = columns)
     val toInsert = removeResult.removedColumns.map {
         @Suppress("UNCHECKED_CAST")

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -1,8 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.RequiredByIntellijPlugin
 import org.jetbrains.kotlinx.dataframe.impl.api.compileTimeSchemaImpl
 import org.jetbrains.kotlinx.dataframe.impl.owner
@@ -11,14 +10,14 @@ import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
 // region DataRow
 
-public fun AnyRow.schema(): DataFrameSchema = owner.schema()
+public fun DataRow<*>.schema(): DataFrameSchema = owner.schema()
 
 // endregion
 
 // region DataFrame
 
 @RequiredByIntellijPlugin
-public fun AnyFrame.schema(): DataFrameSchema = extractSchema()
+public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
 
 // endregion
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -337,7 +337,7 @@ public fun <T> Split<T, String>.inward(
 
 @Refine
 @Interpretable("SplitAnyFrameIntoColumns")
-public fun <T, C : AnyFrame> Split<T, C>.intoColumns(): DataFrame<T> =
+public fun <T, C : DataFrame<*>> Split<T, C>.intoColumns(): DataFrame<T> =
     df.convert(columns).with {
         when {
             it == null -> null
@@ -360,7 +360,7 @@ public inline fun <T, C : Iterable<R>, reified R> Split<T, C>.intoRows(dropEmpty
 @JvmName("intoRowsFrame")
 @Refine
 @Interpretable("SplitAnyFrameRows")
-public fun <T, C : AnyFrame> Split<T, C>.intoRows(dropEmpty: Boolean = true): DataFrame<T> =
+public fun <T, C : DataFrame<*>> Split<T, C>.intoRows(dropEmpty: Boolean = true): DataFrame<T> =
     by { it.rows() }.intoRows(dropEmpty)
 
 internal inline fun <T, C, R> Convert<T, C?>.splitInplace(
@@ -393,7 +393,7 @@ public fun <T, C, R> SplitWithTransform<T, C, R>.inplace(): DataFrame<T> =
 
 // region DataColumn
 
-public fun DataColumn<Iterable<*>>.splitInto(vararg names: String): AnyFrame =
+public fun DataColumn<Iterable<*>>.splitInto(vararg names: String): DataFrame<*> =
     toDataFrame().split { this@splitInto }.into(*names)
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -49,10 +48,10 @@ public inline fun <T, reified R : Number?> DataColumn<T>.stdOf(
 
 // region DataRow
 
-public fun AnyRow.rowStd(skipNaN: Boolean = skipNaNDefault, ddof: Int = ddofDefault): Double =
+public fun DataRow<*>.rowStd(skipNaN: Boolean = skipNaNDefault, ddof: Int = ddofDefault): Double =
     Aggregators.std(skipNaN, ddof).aggregateOfRow(this, primitiveOrMixedNumberColumns())
 
-public inline fun <reified T : Number?> AnyRow.rowStdOf(
+public inline fun <reified T : Number?> DataRow<*>.rowStdOf(
     skipNaN: Boolean = skipNaNDefault,
     ddof: Int = ddofDefault,
 ): Double {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -3,7 +3,6 @@
 
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
@@ -77,45 +76,45 @@ public inline fun <C, reified V : Number?> DataColumn<C>.sumOf(
 
 // region DataRow
 
-public fun AnyRow.rowSum(skipNaN: Boolean = skipNaNDefault): Number =
+public fun DataRow<*>.rowSum(skipNaN: Boolean = skipNaNDefault): Number =
     Aggregators.sum(skipNaN).aggregateOfRow(this, primitiveOrMixedNumberColumns())
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfShort")
-public inline fun <reified T : Short> AnyRow.rowSumOf(_kClass: KClass<Short> = Short::class): Int =
+public inline fun <reified T : Short> DataRow<*>.rowSumOf(_kClass: KClass<Short> = Short::class): Int =
     rowSumOf(typeOf<T>(), false) as Int
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfByte")
-public inline fun <reified T : Byte> AnyRow.rowSumOf(_kClass: KClass<Byte> = Byte::class): Int =
+public inline fun <reified T : Byte> DataRow<*>.rowSumOf(_kClass: KClass<Byte> = Byte::class): Int =
     rowSumOf(typeOf<T>(), false) as Int
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfInt")
-public inline fun <reified T : Int> AnyRow.rowSumOf(_kClass: KClass<Int> = Int::class): Int =
+public inline fun <reified T : Int> DataRow<*>.rowSumOf(_kClass: KClass<Int> = Int::class): Int =
     rowSumOf(typeOf<T>(), false) as Int
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfLong")
-public inline fun <reified T : Long> AnyRow.rowSumOf(_kClass: KClass<Long> = Long::class): Long =
+public inline fun <reified T : Long> DataRow<*>.rowSumOf(_kClass: KClass<Long> = Long::class): Long =
     rowSumOf(typeOf<T>(), false) as Long
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfFloat")
-public inline fun <reified T : Float> AnyRow.rowSumOf(
+public inline fun <reified T : Float> DataRow<*>.rowSumOf(
     skipNaN: Boolean = skipNaNDefault,
     _kClass: KClass<Float> = Float::class,
 ): Float = rowSumOf(typeOf<T>(), skipNaN) as Float
 
 @Suppress("FINAL_UPPER_BOUND")
 @JvmName("rowSumOfDouble")
-public inline fun <reified T : Double> AnyRow.rowSumOf(
+public inline fun <reified T : Double> DataRow<*>.rowSumOf(
     skipNaN: Boolean = skipNaNDefault,
     _kClass: KClass<Double> = Double::class,
 ): Double = rowSumOf(typeOf<T>(), skipNaN) as Double
 
 // unfortunately, we cannot make a `reified T : Number?` due to clashes
-public fun AnyRow.rowSumOf(type: KType, skipNaN: Boolean = skipNaNDefault): Number {
+public fun DataRow<*>.rowSumOf(type: KType, skipNaN: Boolean = skipNaNDefault): Number {
     require(type.isPrimitiveOrMixedNumber()) {
         "Type $type is not a primitive number type. Mean only supports primitive number types."
     }
@@ -437,20 +436,20 @@ public inline fun <C, reified V : Number?> DataColumn<C>.sumOf(crossinline expre
     sumOf(skipNaN = skipNaNDefault, expression = expression)
 
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public fun AnyRow.rowSum(): Number = rowSum(skipNaN = skipNaNDefault)
+public fun DataRow<*>.rowSum(): Number = rowSum(skipNaN = skipNaNDefault)
 
 @JvmName("rowSumOfFloat")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Float?> AnyRow.rowSumOf(_kClass: KClass<Float> = Float::class): Float =
+public inline fun <reified T : Float?> DataRow<*>.rowSumOf(_kClass: KClass<Float> = Float::class): Float =
     rowSumOf(typeOf<T>(), skipNaN = skipNaNDefault) as Float
 
 @JvmName("rowSumOfDouble")
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public inline fun <reified T : Double?> AnyRow.rowSumOf(_kClass: KClass<Double> = Double::class): Double =
+public inline fun <reified T : Double?> DataRow<*>.rowSumOf(_kClass: KClass<Double> = Double::class): Double =
     rowSumOf(typeOf<T>(), skipNaN = skipNaNDefault) as Double
 
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
-public fun AnyRow.rowSumOf(type: KType): Number = rowSumOf(type, skipNaN = skipNaNDefault)
+public fun DataRow<*>.rowSumOf(type: KType): Number = rowSumOf(type, skipNaN = skipNaNDefault)
 
 @Deprecated(SUM_NO_SKIPNAN, level = DeprecationLevel.HIDDEN)
 public fun <T> DataFrame<T>.sum(): DataRow<T> = sum(skipNaN = skipNaNDefault)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toDataFrame.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.AnyBaseCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -9,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.impl.ColumnNameGenerator
 import org.jetbrains.kotlinx.dataframe.impl.api.createDataFrameImpl
@@ -65,7 +65,7 @@ public fun <T> Iterable<DataRow<T>>.toDataFrame(): DataFrame<T> {
 }
 
 @JvmName("toDataFrameMapStringAnyNullable")
-public fun Iterable<Map<String, Any?>>.toDataFrame(): AnyFrame {
+public fun Iterable<Map<String, Any?>>.toDataFrame(): DataFrame<*> {
     val list = asList()
     if (list.isEmpty()) return DataFrame.empty()
 
@@ -86,10 +86,10 @@ public fun Iterable<Map<String, Any?>>.toDataFrame(): AnyFrame {
 }
 
 @JvmName("toDataFrameAnyColumn")
-public fun Iterable<AnyBaseCol>.toDataFrame(): AnyFrame = dataFrameOf(this)
+public fun Iterable<BaseColumn<*>>.toDataFrame(): DataFrame<*> = dataFrameOf(this)
 
 @JvmName("toDataFramePairColumnPathAnyCol")
-public fun <T> Iterable<Pair<ColumnPath, AnyBaseCol>>.toDataFrameFromPairs(): DataFrame<T> {
+public fun <T> Iterable<Pair<ColumnPath, BaseColumn<*>>>.toDataFrameFromPairs(): DataFrame<T> {
     val nameGenerator = ColumnNameGenerator()
     val columnNames = mutableListOf<String>()
     val columnGroups = mutableListOf<MutableList<Pair<ColumnPath, AnyBaseCol>>?>()
@@ -143,12 +143,12 @@ public fun <T> Iterable<Pair<ColumnPath, AnyBaseCol>>.toDataFrameFromPairs(): Da
 }
 
 @JvmName("toDataFrameColumnPathAnyNullable")
-public fun Iterable<Pair<ColumnPath, Iterable<Any?>>>.toDataFrameFromPairs(): AnyFrame =
+public fun Iterable<Pair<ColumnPath, Iterable<Any?>>>.toDataFrameFromPairs(): DataFrame<*> =
     map {
         it.first to createColumnGuessingType(it.first.last(), it.second.asList())
     }.toDataFrameFromPairs<Unit>()
 
-public fun Iterable<Pair<String, Iterable<Any?>>>.toDataFrameFromPairs(): AnyFrame =
+public fun Iterable<Pair<String, Iterable<Any?>>>.toDataFrameFromPairs(): DataFrame<*> =
     map {
         ColumnPath(it.first) to createColumnGuessingType(it.first, it.second.asList())
     }.toDataFrameFromPairs<Unit>()
@@ -192,13 +192,13 @@ public abstract class CreateDataFrameDsl<T> : TraversePropertiesDsl {
 
     public abstract val source: Iterable<T>
 
-    public abstract fun add(column: AnyBaseCol, path: ColumnPath? = null)
+    public abstract fun add(column: BaseColumn<*>, path: ColumnPath? = null)
 
     @Interpretable("ToDataFrameDslIntoString")
-    public infix fun AnyBaseCol.into(name: String): Unit = add(this, pathOf(name))
+    public infix fun BaseColumn<*>.into(name: String): Unit = add(this, pathOf(name))
 
     @Interpretable("ToDataFrameDslIntoPath")
-    public infix fun AnyBaseCol.into(path: ColumnPath): Unit = add(this, path)
+    public infix fun BaseColumn<*>.into(path: ColumnPath): Unit = add(this, path)
 
     @Interpretable("Properties0")
     public abstract fun properties(
@@ -259,13 +259,13 @@ public interface ValueProperty<T> {
 
 // region Create DataFrame from Map
 
-public fun Map<String, Iterable<Any?>>.toDataFrame(): AnyFrame =
+public fun Map<String, Iterable<Any?>>.toDataFrame(): DataFrame<*> =
     map {
         DataColumn.createByInference(it.key, it.value.asList())
     }.toDataFrame()
 
 @JvmName("toDataFrameColumnPathAnyNullable")
-public fun Map<ColumnPath, Iterable<Any?>>.toDataFrame(): AnyFrame =
+public fun Map<ColumnPath, Iterable<Any?>>.toDataFrame(): DataFrame<*> =
     map {
         it.key to DataColumn.createByInference(
             name = it.key.last(),
@@ -293,7 +293,7 @@ public fun Map<ColumnPath, Iterable<Any?>>.toDataFrame(): AnyFrame =
  */
 @Refine
 @Interpretable("ValuesListsToDataFrame")
-public fun <T> List<List<T>>.toDataFrame(header: List<String>?, containsColumns: Boolean = false): AnyFrame =
+public fun <T> List<List<T>>.toDataFrame(header: List<String>?, containsColumns: Boolean = false): DataFrame<*> =
     when {
         containsColumns -> {
             mapIndexedNotNull { index, list ->

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toList.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toList.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.api.toSequenceImpl
 import kotlin.reflect.typeOf
@@ -9,6 +8,6 @@ import kotlin.reflect.typeOf
 
 public inline fun <reified T> DataFrame<T>.toList(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
 
-public inline fun <reified T> AnyFrame.toListOf(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
+public inline fun <reified T> DataFrame<*>.toListOf(): List<T> = toSequenceImpl(typeOf<T>()).toList() as List<T>
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/toSequence.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.impl.api.toSequenceImpl
 import kotlin.reflect.typeOf
@@ -9,6 +8,6 @@ import kotlin.reflect.typeOf
 
 public inline fun <reified T> DataFrame<T>.toSequence(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
-public inline fun <reified T> AnyFrame.toSequenceOf(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
+public inline fun <reified T> DataFrame<*>.toSequenceOf(): Sequence<T> = toSequenceImpl(typeOf<T>()) as Sequence<T>
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/transpose.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.impl.api.convertTo
 import org.jetbrains.kotlinx.dataframe.impl.columnName
 import org.jetbrains.kotlinx.dataframe.impl.owner
@@ -12,13 +13,13 @@ import kotlin.reflect.typeOf
 
 // region DataRow
 
-public fun AnyRow.transpose(): DataFrame<NameValuePair<*>> {
+public fun DataRow<*>.transpose(): DataFrame<NameValuePair<*>> {
     val valueColumn = DataColumn.createByInference(NameValuePair<*>::value.columnName, values)
     val nameColumn = owner.columnNames().toValueColumn(NameValuePair<*>::name.name)
     return dataFrameOf(nameColumn, valueColumn).cast()
 }
 
-public inline fun <reified T> AnyRow.transposeTo(): DataFrame<NameValuePair<T>> = transposeTo(typeOf<T>())
+public inline fun <reified T> DataRow<*>.transposeTo(): DataFrame<NameValuePair<T>> = transposeTo(typeOf<T>())
 
 @PublishedApi
 internal fun <T> AnyRow.transposeTo(type: KType): DataFrame<NameValuePair<T>> {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/typeConversions.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/typeConversions.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyBaseCol
 import org.jetbrains.kotlinx.dataframe.AnyCol
-import org.jetbrains.kotlinx.dataframe.AnyFrame
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnGroupAccessor
 import org.jetbrains.kotlinx.dataframe.ColumnSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -12,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
@@ -49,9 +47,9 @@ public fun <T> ColumnPath.toColumnOf(): ColumnAccessor<T> = ColumnAccessorImpl(t
 
 public fun ColumnPath.toColumnAccessor(): ColumnAccessor<Any?> = ColumnAccessorImpl(this)
 
-public fun ColumnPath.toColumnGroupAccessor(): ColumnAccessor<AnyRow> = ColumnAccessorImpl(this)
+public fun ColumnPath.toColumnGroupAccessor(): ColumnAccessor<DataRow<*>> = ColumnAccessorImpl(this)
 
-public fun ColumnPath.toFrameColumnAccessor(): ColumnAccessor<AnyFrame> = ColumnAccessorImpl(this)
+public fun ColumnPath.toFrameColumnAccessor(): ColumnAccessor<DataFrame<*>> = ColumnAccessorImpl(this)
 
 // endregion
 
@@ -73,7 +71,7 @@ public fun <T> KProperty<T>.toColumnAccessor(): ColumnAccessor<T> = ColumnAccess
 
 // region DataColumn
 
-public fun AnyBaseCol.toDataFrame(): AnyFrame = dataFrameOf(listOf(this))
+public fun BaseColumn<*>.toDataFrame(): DataFrame<*> = dataFrameOf(listOf(this))
 
 @JvmName("asNumberAnyNullable")
 public fun DataColumn<Any?>.asNumbers(): ValueColumn<Number?> {
@@ -345,18 +343,18 @@ public inline fun <reified T> Iterable<T>.toColumn(property: KProperty<T>): Data
 
 public fun Iterable<String>.toPath(): ColumnPath = ColumnPath(asList())
 
-public fun Iterable<AnyBaseCol>.toColumnGroup(name: String): ColumnGroup<*> = dataFrameOf(this).asColumnGroup(name)
+public fun Iterable<BaseColumn<*>>.toColumnGroup(name: String): ColumnGroup<*> = dataFrameOf(this).asColumnGroup(name)
 
-public fun <T> Iterable<AnyBaseCol>.toColumnGroup(column: ColumnGroupAccessor<T>): ColumnGroup<T> =
+public fun <T> Iterable<BaseColumn<*>>.toColumnGroup(column: ColumnGroupAccessor<T>): ColumnGroup<T> =
     dataFrameOf(this).cast<T>().asColumnGroup(column)
 
-public fun <T> Iterable<AnyBaseCol>.toColumnGroupOf(name: String): ColumnGroup<T> = toColumnGroup(name).cast()
+public fun <T> Iterable<BaseColumn<*>>.toColumnGroupOf(name: String): ColumnGroup<T> = toColumnGroup(name).cast()
 
 // endregion
 
 // region DataFrame
 
-public fun AnyFrame.toMap(): Map<String, List<Any?>> = columns().associateBy({ it.name }, { it.toList() })
+public fun DataFrame<*>.toMap(): Map<String, List<Any?>> = columns().associateBy({ it.name }, { it.toList() })
 
 public fun <T> DataFrame<T>.asColumnGroup(name: String = ""): ColumnGroup<T> =
     when (this) {
@@ -402,7 +400,7 @@ public fun <T, G> DataFrame<T>.asGroupBy(selector: ColumnSelector<T, DataFrame<G
 
 public fun <T> DataRow<T>.toDataFrame(): DataFrame<T> = owner[index..index]
 
-public fun AnyRow.toMap(): Map<String, Any?> = df().columns().associate { it.name() to it[index] }
+public fun DataRow<*>.toMap(): Map<String, Any?> = df().columns().associate { it.name() to it[index] }
 
 public fun Map<String, Any?>.toDataRow(): DataRow<*> {
     val df = mapValues { listOf(it.value) }.toDataFrame()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnExpression
 import org.jetbrains.kotlinx.dataframe.ColumnsSelector
 import org.jetbrains.kotlinx.dataframe.DataColumn
@@ -381,7 +380,7 @@ public fun <T, C> Update<T, C>.perCol(values: Map<String, C>): DataFrame<T> =
  */
 @Refine
 @Interpretable("UpdatePerColRow")
-public fun <T, C> Update<T, C>.perCol(values: AnyRow): DataFrame<T> = perCol(values.toMap() as Map<String, C>)
+public fun <T, C> Update<T, C>.perCol(values: DataRow<*>): DataFrame<T> = perCol(values.toMap() as Map<String, C>)
 
 /**
  * @include [CommonUpdatePerColDoc]


### PR DESCRIPTION
Fixes #906