### PR TITLE
Configure `KorroGenerateTask` to run after test tasks

### DIFF
--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -75,9 +75,9 @@ dependencies {
     testImplementation(libs.hikaricp)
 }
 
-// Tests create
+// Running tests creates korro output lines!
 tasks.withType<KorroGenerateTask>().configureEach {
-    mustRunAfter(tasks.test)
+    dependsOn(tasks.test)
 }
 
 korro {

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.devcrocod.korro.KorroGenerateTask
 import org.gradle.kotlin.dsl.libs
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -72,6 +73,11 @@ dependencies {
     testImplementation(libs.poi)
     testImplementation(libs.arrow.vector)
     testImplementation(libs.hikaricp)
+}
+
+// Tests create
+tasks.withType<KorroGenerateTask>().configureEach {
+    mustRunAfter(tasks.test)
 }
 
 korro {


### PR DESCRIPTION
Korro must run after test, since tests generate korro outputs.
Now generated source should be correct!