### PR TITLE
`dependencyUpdates` for example projects

### DIFF
--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -37,7 +37,12 @@ acting as [Convention Plugins](https://docs.gradle.org/current/userguide/impleme
 
 - `dfbuild.buildExampleProjects`: Generates tasks that sync versions and
     build all example projects in the `/examples/projects` and `/examples/projects/dev` directories.
-    - Only apply this plugin to the root project!
+    - NOTE: Only apply this plugin to the root project!
+    - NOTE: Add every dependency version that needs to be synced to the `libs.versions.toml` file of the example in
+      the `versionsToSync` list!
+    - NOTE: Add every dependency used in each example project to `dependencies { exampleDependencyUpdates() }`
+      so `dependencyUpdates` can detect outdated dependencies in examples.
+
     - Projects inside `/examples/projects` are built using the latest release version of DataFrame.
       They are meant to be downloadable as separate projects by users.
     - Projects inside `/examples/projects/dev` are built using sources of DataFrame.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
     compileOnly("org.gradle.kotlin:gradle-kotlin-dsl-plugins:$expectedKotlinDslPluginsVersion")
 
     // So we can create pretty tables in gradle task outputs, parse json, and rename to camelCase
-    implementation(libs.dataframe.release.core)
-    implementation(libs.dataframe.release.json)
+    implementation(libs.dataframe.core)
+    implementation(libs.dataframe.json)
 
     // We need to declare a dependency for each plugin used in convention plugins below
     implementation(pluginMarker(libs.plugins.ktlint.gradle))

--- a/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
@@ -18,29 +18,54 @@ val buildExampleProjectsGroup = "build example projects"
 // region syncing
 
 val versionsToSync =
-    listOf(
-        "kotlin",
-        "dataframe",
-        "kandy",
-        "ktlint-gradle",
-        "ktlint",
-        "maven-wrapper",
-        "maven-surefire",
-        "maven",
-        "kotlinDatetime",
-        "log4j",
-        "spark3",
-        "kotlin-spark",
-        "spark4",
-        "kotlin-dl",
-        "multik",
-        "exposed",
-        "sqlite",
-        "h2db",
-        "hibernate",
-        "hikari",
-        "sl4j",
-    )
+    with(libs.versions) {
+        listOf(
+            kotlin,
+            dataframe,
+            kandy,
+            ktlint.gradle,
+            ktlint,
+            maven.wrapper,
+            maven.surefire,
+            maven,
+            kotlinDatetime,
+            log4j,
+            spark3,
+            kotlin.spark,
+            spark4,
+            kotlin.dl,
+            multik,
+            exposed,
+            sqlite,
+            h2db,
+            hibernate,
+            hikari,
+            sl4j,
+        )
+    }.map { it.getVersionName() }
+
+// tiny reflection-based solution to retrieve the original version name from the accessor,
+// so we can keep the list of version type-safe
+private fun Any.getVersionName(): String {
+    val klass = this::class.java
+    if (this is Provider<*>) {
+        val valueField = klass.declaredFields
+            .single { it.name == "value" }
+            .also { it.isAccessible = true }
+        val result = valueField.get(this)
+        val lambdaClass = result::class.java
+        val nameField = lambdaClass.declaredFields
+            .single { it.type == String::class.java }
+            .also { it.isAccessible = true }
+        val name = nameField.get(result) as String
+        return name.replace('.', '-')
+    } else {
+        val asProviderFunction = klass.declaredMethods
+            .single { it.name == "asProvider" }
+        val provider = asProviderFunction.invoke(this) as Provider<*>
+        return provider.getVersionName()
+    }
+}
 
 val syncAllExampleFolders by tasks.registering {
     group = buildExampleProjectsGroup

--- a/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
@@ -4,7 +4,10 @@ import dfbuild.buildExampleProjects.generateTestCase
 import dfbuild.buildExampleProjects.isAndroid
 import dfbuild.buildExampleProjects.setupGradleSyncVersionsTask
 import dfbuild.buildExampleProjects.setupMavenSyncVersionsTask
+import dfbuild.getVersionName
+import org.gradle.api.provider.Provider
 import org.gradle.internal.extensions.stdlib.capitalized
+import org.gradle.plugin.use.PluginDependency
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
@@ -17,6 +20,9 @@ val buildExampleProjectsGroup = "build example projects"
 
 // region syncing
 
+/**
+ * Make sure to write a reference to each library version that needs to be synced to the example/projects folder here.
+ */
 val versionsToSync =
     with(libs.versions) {
         listOf(
@@ -41,31 +47,106 @@ val versionsToSync =
             hibernate,
             hikari,
             sl4j,
+            agp,
+            coreKtx,
+            junitVersion,
+            espressoCore,
+            lifecycleRuntimeKtx,
+            activityCompose,
+            composeBom,
+            exec,
         )
     }.map { it.getVersionName() }
 
-// tiny reflection-based solution to retrieve the original version name from the accessor,
-// so we can keep the list of version type-safe
-private fun Any.getVersionName(): String {
-    val klass = this::class.java
-    if (this is Provider<*>) {
-        val valueField = klass.declaredFields
-            .single { it.name == "value" }
-            .also { it.isAccessible = true }
-        val result = valueField.get(this)
-        val lambdaClass = result::class.java
-        val nameField = lambdaClass.declaredFields
-            .single { it.type == String::class.java }
-            .also { it.isAccessible = true }
-        val name = nameField.get(result) as String
-        return name.replace('.', '-')
-    } else {
-        val asProviderFunction = klass.declaredMethods
-            .single { it.name == "asProvider" }
-        val provider = asProviderFunction.invoke(this) as Provider<*>
-        return provider.getVersionName()
-    }
+val exampleDependencyUpdates by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isVisible = false
 }
+
+/**
+ * Every library and plugin used by the projects in /examples/projects (excluding deps already
+ * declared by the root build itself, which `dependencyUpdates` picks up anyway).
+ *
+ * This makes the ben-manes `dependencyUpdates` task aware of example-only dependencies without
+ * having to apply the plugin inside the example projects.
+ */
+dependencies {
+    // android-example
+    exampleDependencyUpdates(libs.androidx.core.ktx)
+    exampleDependencyUpdates(libs.androidx.junit)
+    exampleDependencyUpdates(libs.androidx.espresso.core)
+    exampleDependencyUpdates(libs.androidx.lifecycle.runtime.ktx)
+    exampleDependencyUpdates(libs.androidx.activity.compose)
+    // BOM-managed compose artifacts (versions come from the BOM)
+    exampleDependencyUpdates(platform(libs.androidx.compose.bom))
+    exampleDependencyUpdates(libs.androidx.ui)
+    exampleDependencyUpdates(libs.androidx.ui.graphics)
+    exampleDependencyUpdates(libs.androidx.ui.tooling)
+    exampleDependencyUpdates(libs.androidx.ui.tooling.preview)
+    exampleDependencyUpdates(libs.androidx.ui.test.manifest)
+    exampleDependencyUpdates(libs.androidx.ui.test.junit4)
+    exampleDependencyUpdates(libs.androidx.material3)
+    exampleDependencyUpdates(pluginMarker(libs.plugins.android.application))
+    exampleDependencyUpdates(pluginMarker(libs.plugins.kotlin.android))
+    exampleDependencyUpdates(pluginMarker(libs.plugins.kotlin.compose))
+
+    // exposed
+    exampleDependencyUpdates(libs.sqlite)
+    exampleDependencyUpdates(libs.exposed.core)
+    exampleDependencyUpdates(libs.exposed.kotlin.datetime)
+    exampleDependencyUpdates(libs.exposed.jdbc)
+    exampleDependencyUpdates(libs.exposed.json)
+    exampleDependencyUpdates(libs.exposed.money)
+
+    // hibernate
+    exampleDependencyUpdates(libs.hibernate.core)
+    exampleDependencyUpdates(libs.hibernate.hikaricp)
+    exampleDependencyUpdates(libs.hikaricp)
+    exampleDependencyUpdates(libs.h2db)
+    exampleDependencyUpdates(libs.sl4jsimple)
+
+    // json-openapi
+    exampleDependencyUpdates(libs.dataframe.openapi)
+    exampleDependencyUpdates(libs.dataframe.openapi.generator)
+
+    // kotlin-dataframe-plugin-gradle-example
+    exampleDependencyUpdates(libs.dataframe)
+    exampleDependencyUpdates(libs.kandy)
+
+    // kotlin-dataframe-plugin-maven-example
+    exampleDependencyUpdates(libs.maven.exec.plugin)
+    exampleDependencyUpdates(libs.maven.surefire.plugin)
+
+    // kotlin-spark
+    exampleDependencyUpdates(libs.spark3.sql)
+    exampleDependencyUpdates(libs.kotlin.spark)
+    exampleDependencyUpdates(libs.log4j.core)
+    exampleDependencyUpdates(libs.log4j.api)
+
+    // movies
+    // all already here
+
+    // multik
+    exampleDependencyUpdates(libs.multik.core)
+    exampleDependencyUpdates(libs.multik.default)
+
+    // spark-parquet-dataframe
+    exampleDependencyUpdates(libs.spark4.sql)
+    exampleDependencyUpdates(libs.spark4.mllib)
+
+    // titanic
+    exampleDependencyUpdates(libs.kotlin.dl.api)
+    exampleDependencyUpdates(libs.kotlin.dl.impl)
+    exampleDependencyUpdates(libs.kotlin.dl.tensorflow)
+    exampleDependencyUpdates(libs.kotlin.dl.dataset)
+
+    // youtube
+    exampleDependencyUpdates(libs.kotlin.datetimeJvm)
+}
+
+private fun pluginMarker(provider: Provider<PluginDependency>): Provider<String> =
+    provider.map { "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" }
 
 val syncAllExampleFolders by tasks.registering {
     group = buildExampleProjectsGroup

--- a/build-logic/src/main/kotlin/dfbuild.dependencyUpdates.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.dependencyUpdates.gradle.kts
@@ -35,6 +35,7 @@ val dependencyUpdateExclusions = listOf(
     // need to revise our tests to update
     libs.android.gradle.api.get().group,
     // we have spark3 and spark4 for examples, keep spark3 at 3.3.2
+    libs.spark3.sql.get().name,
 )
 
 // run `./gradlew dependencyUpdates` to check for updates

--- a/build-logic/src/main/kotlin/dfbuild/utils.kt
+++ b/build-logic/src/main/kotlin/dfbuild/utils.kt
@@ -1,6 +1,7 @@
 package dfbuild
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import java.io.File
 
 /**
@@ -16,4 +17,27 @@ fun File.findRootDir(): File {
             ?: error("Could not find parent of '${rootDir.absolutePath}'")
     }
     return rootDir
+}
+
+// tiny reflection-based solution to retrieve the original version name from the accessor,
+// so we can keep the list of version type-safe
+fun Any.getVersionName(): String {
+    val klass = this::class.java
+    if (this is Provider<*>) {
+        val valueField = klass.declaredFields
+            .single { it.name == "value" }
+            .also { it.isAccessible = true }
+        val result = valueField.get(this)
+        val lambdaClass = result::class.java
+        val nameField = lambdaClass.declaredFields
+            .single { it.type == String::class.java }
+            .also { it.isAccessible = true }
+        val name = nameField.get(result) as String
+        return name.replace('.', '-')
+    } else {
+        val asProviderFunction = klass.declaredMethods
+            .single { it.name == "asProvider" }
+        val provider = asProviderFunction.invoke(this) as Provider<*>
+        return provider.getVersionName()
+    }
 }

--- a/build-logic/src/main/kotlin/dfbuild/utils.kt
+++ b/build-logic/src/main/kotlin/dfbuild/utils.kt
@@ -20,24 +20,51 @@ fun File.findRootDir(): File {
 }
 
 // tiny reflection-based solution to retrieve the original version name from the accessor,
-// so we can keep the list of version type-safe
+// so we can keep the list of version type-safe in dfbuild.buildExampleProjects
 fun Any.getVersionName(): String {
     val klass = this::class.java
     if (this is Provider<*>) {
-        val valueField = klass.declaredFields
-            .single { it.name == "value" }
-            .also { it.isAccessible = true }
-        val result = valueField.get(this)
+        val result = try {
+            val valueField = klass.declaredFields
+                .single { it.name == "value" }
+                .also { it.isAccessible = true }
+            valueField.get(this)
+        } catch (e: Throwable) {
+            throw IllegalStateException(
+                "`dfbuild.buildExampleProjects` failed to get a version name from libs.versions.toml because the " +
+                    "`Provider<String>` did not have an (accessible) `value: Callable<String>` field. " +
+                    "`Any.getVersionName()` might need to be fixed. Class: $this",
+                e,
+            )
+        }
         val lambdaClass = result::class.java
-        val nameField = lambdaClass.declaredFields
-            .single { it.type == String::class.java }
-            .also { it.isAccessible = true }
-        val name = nameField.get(result) as String
+        val name = try {
+            val nameField = lambdaClass.declaredFields
+                .single { it.type == String::class.java }
+                .also { it.isAccessible = true }
+            nameField.get(result) as String
+        } catch (e: Throwable) {
+            throw IllegalStateException(
+                "`dfbuild.buildExampleProjects` failed to get a version name from libs.versions.toml because the " +
+                    "`value: Callable<String>` did not have an (accessible) `String` typed field containing the " +
+                    "name of the version. `Any.getVersionName()` might need to be fixed.\nClass: $this",
+                e,
+            )
+        }
         return name.replace('.', '-')
     } else {
-        val asProviderFunction = klass.declaredMethods
-            .single { it.name == "asProvider" }
-        val provider = asProviderFunction.invoke(this) as Provider<*>
+        val provider = try {
+            val asProviderFunction = klass.declaredMethods
+                .single { it.name == "asProvider" }
+            asProviderFunction.invoke(this) as Provider<*>
+        } catch (e: Throwable) {
+            throw IllegalStateException(
+                "`dfbuild.buildExampleProjects` failed to get a version name from libs.versions.toml because a " +
+                    "version group was expected, but the encountered value did not have an (accessible) " +
+                    "`asProvider()` function. `Any.getVersionName()` might need to be fixed.\nClass: $this",
+                e,
+            )
+        }
         return provider.getVersionName()
     }
 }

--- a/build-settings-logic/src/main/kotlin/dfsettings.base.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dfsettings.base.settings.gradle.kts
@@ -12,6 +12,7 @@ dependencyResolutionManagement {
         mavenLocal()
         gradlePluginPortal()
         mavenCentral()
+        google()
         maven("https://redirector.kotlinlang.org/maven/bootstrap")
         jupyterApiTCRepo?.let { jupyterApiTCRepo ->
             if (jupyterApiTCRepo.isNotBlank()) maven(jupyterApiTCRepo)

--- a/examples/projects/dev/kotlin-spark/build.gradle.kts
+++ b/examples/projects/dev/kotlin-spark/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     // (Kotlin) Spark SQL (Spark 3.3.2)
     implementation(libs.kotlin.spark)
-    compileOnly(libs.spark.sql)
+    compileOnly(libs.spark3.sql)
 
     // Logging to keep Spark quiet
     implementation(libs.log4j.core)

--- a/examples/projects/dev/kotlin-spark/gradle/libs.versions.toml
+++ b/examples/projects/dev/kotlin-spark/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ dataframe = { module = "org.jetbrains.kotlinx:dataframe", version.ref = "datafra
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 kotlin-spark = { group = "org.jetbrains.kotlinx.spark", name = "kotlin-spark-api_3.3.2_2.13", version.ref = "kotlin-spark" }
-spark-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
+spark3-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/examples/projects/kotlin-spark/build.gradle.kts
+++ b/examples/projects/kotlin-spark/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     // (Kotlin) Spark SQL (Spark 3.3.2)
     implementation(libs.kotlin.spark)
-    compileOnly(libs.spark.sql)
+    compileOnly(libs.spark3.sql)
 
     // Logging to keep Spark quiet
     implementation(libs.log4j.core)

--- a/examples/projects/kotlin-spark/gradle/libs.versions.toml
+++ b/examples/projects/kotlin-spark/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ dataframe = { module = "org.jetbrains.kotlinx:dataframe", version.ref = "datafra
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 kotlin-spark = { group = "org.jetbrains.kotlinx.spark", name = "kotlin-spark-api_3.3.2_2.13", version.ref = "kotlin-spark" }
-spark-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
+spark3-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,18 @@ spark4 = "4.0.0"
 
 multik = "0.3.1"
 
+# Used by the Android example project; keys mirror examples/projects/android-example/gradle/libs.versions.toml
+agp = "9.0.0"
+coreKtx = "1.10.1"
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
+lifecycleRuntimeKtx = "2.6.1"
+activityCompose = "1.8.0"
+composeBom = "2024.09.00"
+
+# Maven exec
+exec = "3.5.0"
+
 [libraries]
 jupyter-api = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-kernel", version.ref = "kotlinJupyter" }
 
@@ -176,9 +188,6 @@ kotlin-script-runtime = { group = "org.jetbrains.kotlin", name = "kotlin-script-
 kotlin-annotations-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-annotations-jvm", version.ref = "kotlin" }
 kotlin-jupyter-test-kit = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-test-kit", version.ref = "kotlinJupyter" }
 kotlinx-benchmark-runtime = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "benchmark" }
-dataframe-symbol-processor = { group = "org.jetbrains.kotlinx.dataframe", name = "symbol-processor-all" }
-dataframe-release-core = { group = "org.jetbrains.kotlinx", name = "dataframe-core", version.ref = "dataframe" }
-dataframe-release-json = { group = "org.jetbrains.kotlinx", name = "dataframe-json", version.ref = "dataframe" }
 
 hikari = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikari" }
 duckdb-jdbc = { group = "org.duckdb", name = "duckdb_jdbc", version.ref = "duckdb" }
@@ -194,12 +203,53 @@ hibernate-hikaricp = { group = "org.hibernate.orm", name = "hibernate-hikaricp",
 hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikari" }
 
 kotlin-spark = { group = "org.jetbrains.kotlinx.spark", name = "kotlin-spark-api_3.3.2_2.13", version.ref = "kotlin-spark" }
-spark = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
+spark3-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark3" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 
 multik-core = { group = "org.jetbrains.kotlinx", name = "multik-core", version.ref = "multik" }
 multik-default = { group = "org.jetbrains.kotlinx", name = "multik-default", version.ref = "multik" }
+
+# Released DataFrame artifacts used by example projects.
+# `dataframe-release-core`/`dataframe-release-json` above are the same artifacts (kept under their
+# existing alias for build-logic use); the entries below mirror the aliases used by the examples.
+dataframe = { group = "org.jetbrains.kotlinx", name = "dataframe", version.ref = "dataframe" }
+dataframe-core = { group = "org.jetbrains.kotlinx", name = "dataframe-core", version.ref = "dataframe" }
+dataframe-csv = { group = "org.jetbrains.kotlinx", name = "dataframe-csv", version.ref = "dataframe" }
+dataframe-json = { group = "org.jetbrains.kotlinx", name = "dataframe-json", version.ref = "dataframe" }
+dataframe-openapi = { group = "org.jetbrains.kotlinx", name = "dataframe-openapi", version.ref = "dataframe" }
+dataframe-openapi-generator = { group = "org.jetbrains.kotlinx", name = "dataframe-openapi-generator", version.ref = "dataframe" }
+
+# Kotlin-DL example (titanic)
+kotlin-dl-api = { group = "org.jetbrains.kotlinx", name = "kotlin-deeplearning-api", version.ref = "kotlin-dl" }
+kotlin-dl-impl = { group = "org.jetbrains.kotlinx", name = "kotlin-deeplearning-impl", version.ref = "kotlin-dl" }
+kotlin-dl-tensorflow = { group = "org.jetbrains.kotlinx", name = "kotlin-deeplearning-tensorflow", version.ref = "kotlin-dl" }
+kotlin-dl-dataset = { group = "org.jetbrains.kotlinx", name = "kotlin-deeplearning-dataset", version.ref = "kotlin-dl" }
+
+# Spark 4 example (spark-parquet-dataframe); the `spark` entry above is the spark3 variant.
+spark4-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark4" }
+spark4-mllib = { group = "org.apache.spark", name = "spark-mllib_2.13", version.ref = "spark4" }
+
+# Maven exec plugin (kotlin-dataframe-plugin-maven-example)
+maven-exec-plugin = { group = "org.codehaus.mojo", name = "exec-maven-plugin", version.ref = "exec" }
+# Maven surefire/failsafe plugins (kotlin-dataframe-plugin-maven-example); both share the
+# `maven-surefire` version, so tracking surefire covers failsafe too.
+maven-surefire-plugin = { group = "org.apache.maven.plugins", name = "maven-surefire-plugin", version.ref = "maven-surefire" }
+
+# Android example
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
 [plugins]
 jupyter-api = { id = "org.jetbrains.kotlin.jupyter.api", version.ref = "kotlinJupyter" }
@@ -222,3 +272,8 @@ kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "ben
 dataframe-compiler-plugin = { id = "org.jetbrains.kotlin.plugin.dataframe", version.ref = "kotlin" }
 gradlePlugin-gradle-foojayToolchains = { id = "org.gradle.toolchains:foojay-resolver-convention", version.ref = "gradlePlugin-gradle-foojayToolchains" }
 typesafe-conventions = { id = "dev.panuszewski:typesafe-conventions", version.ref = "typesafe-conventions" }
+
+# Android example
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Helps #1661 

Adapts `dfbuild.dependencyUpdates` convention plugin:
- Makes `versionsToSync` type safe
  - (Note, we always need to format versions with `-`, but we already do this)
- Added every missing dependency from our examples in the main gradle/libs.versions.toml
- Created `exampleDependencyUpdates` configuration that consumes every dependency from our examples, so the `dependencyUpdate` task is aware of them.
  - (I would have liked this to be automatic, but I cannot find a way to do that in a transparent manner, unfortunately...)
  - (If you know a better way, or if I missed a dependency, please let me know!)

As you can see, running `dependencyUpdates` now also detects out-of-date android dependencies :D
<img width="2494" height="844" alt="image" src="https://github.com/user-attachments/assets/9b594ae5-a225-4f3d-8234-a474f250f10f" />
