### PR TITLE
 Preserve resolved path from ColumnsSelector in moveToImpl so that it can be correctly used from compiler plugin

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/move.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/move.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlinx.dataframe.api.getColumn
 import org.jetbrains.kotlinx.dataframe.api.getColumnGroup
 import org.jetbrains.kotlinx.dataframe.api.getColumnWithPath
 import org.jetbrains.kotlinx.dataframe.api.getColumns
+import org.jetbrains.kotlinx.dataframe.api.getColumnsWithPaths
 import org.jetbrains.kotlinx.dataframe.api.move
 import org.jetbrains.kotlinx.dataframe.api.replace
 import org.jetbrains.kotlinx.dataframe.api.to
@@ -137,7 +138,7 @@ internal fun <T, C> MoveClause<T, C>.moveToImpl(columnIndex: Int, insideGroup: B
         return moveTo(columnIndex)
     }
 
-    val columnsToMove = df.getColumns(columns)
+    val columnsToMove = df.getColumnsWithPaths(columns)
 
     // check if columns to move have the same parent
     val columnsToMoveParents = columnsToMove.map { it.path.dropLast() }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
@@ -3,6 +3,9 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
+import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
+import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.junit.Test
 
@@ -318,5 +321,24 @@ class MoveTests {
         shouldThrow<IllegalArgumentException> {
             grouped.move { "a"["b"] and "b"["c"] }.to(0, true)
         }.message shouldBe "Cannot move columns to an index remaining inside group if they have different parent"
+    }
+
+    @Test
+    fun `custom compiler plugin-like columns resolver`() {
+        // main diff:
+        // runtime selector { a.b } => ColumnWithPath(DataColumnWithParent, pathOf)
+        // compile time ResolvedDataColumn => just normal ColumnWithPath(DataColumn, pathOf)
+        val ref = object : ColumnSet<Any?> {
+            override fun resolve(context: ColumnResolutionContext): List<ColumnWithPath<Any?>> =
+                listOf(
+                    ColumnWithPath(
+                        columnOf<Any?>(values = arrayOf()) named "b",
+                        pathOf("a", "b"),
+                    ),
+                )
+        }
+        // should resolve column by provided path
+        val res = grouped.move { ref }.toEnd(insideGroup = true)
+        res.getColumnGroup("a").columnNames() shouldBe listOf("c", "b")
     }
 }


### PR DESCRIPTION
fixes #1894