### PR TITLE
Re-enabled incremental compilation

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild/buildExampleProjects/gradleTasks.kt
+++ b/build-logic/src/main/kotlin/dfbuild/buildExampleProjects/gradleTasks.kt
@@ -56,16 +56,6 @@ internal fun Project.setupGradleSyncVersionsTask(
                 gradlePropertiesContent.removeAll { it.startsWith("kotlin.code.style=") }
                 gradlePropertiesContent.add("kotlin.code.style=official")
             }
-            if ("kotlin.incremental=false" !in gradlePropertiesContent) {
-                gradlePropertiesContent.removeAll { it.startsWith("kotlin.incremental=") }
-                gradlePropertiesContent.add(
-                    """
-                    # Disabling incremental compilation will no longer be necessary
-                    # when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-                    kotlin.incremental=false
-                    """.trimIndent(),
-                )
-            }
 
             gradleProperties.writeText(gradlePropertiesContent.joinToString("\n"))
 

--- a/docs/StardustDocs/topics/Compiler-Plugin.md
+++ b/docs/StardustDocs/topics/Compiler-Plugin.md
@@ -55,14 +55,16 @@ Setup library dependency:
 implementation("org.jetbrains.kotlinx:dataframe:%dataFrameVersion%")
 ```
 
-Due to the [known issue](https://youtrack.jetbrains.com/issue/KT-66735), incremental compilation must be disabled for now.
+If you're using a version older than Kotlin 2.4.0,
+incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735),
+
 Add the following line to your `gradle.properties` file:
 
 ```properties
 kotlin.incremental=false
 ```
 
-Sync the project.
+Sync the project. This is not needed anymore from Kotlin 2.4.0+.
 
 </tab>
 

--- a/docs/StardustDocs/topics/setup/Modules.md
+++ b/docs/StardustDocs/topics/setup/Modules.md
@@ -529,7 +529,8 @@ plugins {
 </tab>
 </tabs>
 
-Due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735), incremental compilation must be disabled for now.
+If you're using a version older than Kotlin 2.4.0,
+incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735).
 Add the following line to your `gradle.properties` file:
 
 ```properties

--- a/docs/StardustDocs/topics/setup/SetupAndroid.md
+++ b/docs/StardustDocs/topics/setup/SetupAndroid.md
@@ -126,7 +126,9 @@ plugins {
 </tab>
 </tabs>
 
-Due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735), incremental compilation must be disabled for now. 
+If you're using a version older than Kotlin 2.4.0,
+incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735),
+
 Add the following line to your `gradle.properties` file:
 
 ```properties

--- a/docs/StardustDocs/topics/setup/SetupGradle.md
+++ b/docs/StardustDocs/topics/setup/SetupGradle.md
@@ -121,7 +121,9 @@ plugins {
 </tab>
 </tabs>
 
-Due to the [known issue](https://youtrack.jetbrains.com/issue/KT-66735), incremental compilation must be disabled for now.
+If you're using a version older than Kotlin 2.4.0,
+incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735),
+
 Add the following line to your `gradle.properties` file:
 
 ```properties

--- a/examples/projects/android-example/gradle.properties
+++ b/examples/projects/android-example/gradle.properties
@@ -21,6 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/android-example/gradle.properties
+++ b/examples/projects/dev/android-example/gradle.properties
@@ -21,6 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/exposed/gradle.properties
+++ b/examples/projects/dev/exposed/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/hibernate/gradle.properties
+++ b/examples/projects/dev/hibernate/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/json-openapi/gradle.properties
+++ b/examples/projects/dev/json-openapi/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/kotlin-dataframe-plugin-gradle-example/gradle.properties
+++ b/examples/projects/dev/kotlin-dataframe-plugin-gradle-example/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/kotlin-spark/gradle.properties
+++ b/examples/projects/dev/kotlin-spark/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/movies/gradle.properties
+++ b/examples/projects/dev/movies/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/multik/gradle.properties
+++ b/examples/projects/dev/multik/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/spark-parquet-dataframe/gradle.properties
+++ b/examples/projects/dev/spark-parquet-dataframe/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/titanic/gradle.properties
+++ b/examples/projects/dev/titanic/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/dev/youtube/gradle.properties
+++ b/examples/projects/dev/youtube/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/exposed/gradle.properties
+++ b/examples/projects/exposed/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/hibernate/gradle.properties
+++ b/examples/projects/hibernate/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/json-openapi/gradle.properties
+++ b/examples/projects/json-openapi/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/kotlin-dataframe-plugin-gradle-example/gradle.properties
+++ b/examples/projects/kotlin-dataframe-plugin-gradle-example/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/kotlin-spark/gradle.properties
+++ b/examples/projects/kotlin-spark/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/movies/gradle.properties
+++ b/examples/projects/movies/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/multik/gradle.properties
+++ b/examples/projects/multik/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/spark-parquet-dataframe/gradle.properties
+++ b/examples/projects/spark-parquet-dataframe/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/titanic/gradle.properties
+++ b/examples/projects/titanic/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/examples/projects/youtube/gradle.properties
+++ b/examples/projects/youtube/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 kotlin.code.style=official
-# Disabling incremental compilation will no longer be necessary
-# when https://youtrack.jetbrains.com/issue/KT-66735 is resolved.
-kotlin.incremental=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,6 @@ org.gradle.jvmargs=-Xmx5G -XX:MaxMetaspaceSize=1G -Duser.language=en -Duser.coun
 # It can also be turned on from the command line with `-Pkotlin.dataframe.debug=true`
 kotlin.dataframe.debug=false
 
-kotlin.incremental=false
-
 # Can speed up build time but stops KDocs from being preprocessed.
 # It can also be turned on from the command line with `-PskipKodex`
 # skipKodex=true


### PR DESCRIPTION
Removed `kotlin.incremental=false` since KT-66735 is resolved in Kotlin 2.4

Mentioned https://github.com/Kotlin/dataframe/issues/1885#issuecomment-4631176581