### PR TITLE
Clarify that schema of property with `DataFrame<T>?` type is not a FrameColumn

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MarkersExtractor.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.typeOf
 internal fun KType.getFieldKind(): FieldKind =
     FieldKind.of(
         this,
-        isDataFrame = { jvmErasure == DataFrame::class },
+        isDataFrame = { jvmErasure == DataFrame::class && !isMarkedNullable },
         isListToFrame = {
             jvmErasure == List::class && (arguments[0].type?.jvmErasure?.hasAnnotation<DataSchema>() == true)
         },

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/convertTo.kt
@@ -193,7 +193,14 @@ internal fun AnyFrame.convertToImpl(
 
                         when (targetSchema.kind) {
                             ColumnKind.Value ->
-                                convertedColumn ?: originalColumn.convertTo(to)
+                                when {
+                                    convertedColumn != null -> convertedColumn
+
+                                    originalColumn.kind == ColumnKind.Frame && to.jvmErasure == DataFrame::class ->
+                                        originalColumn
+
+                                    else -> originalColumn.convertTo(to)
+                                }
 
                             ColumnKind.Group -> {
                                 val column = when {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/toDataFrame.kt
@@ -320,18 +320,27 @@ internal fun convertToDataFrame(
         val kClass = returnType.classifier as KClass<*>
         val fieldKind = returnType.getFieldKind()
 
-        val keepSubtree =
-            maxDepth <= 0 && !fieldKind.shouldBeConvertedToFrameColumn && !fieldKind.shouldBeConvertedToColumnGroup
-        val shouldCreateValueCol = keepSubtree ||
-            kClass in preserveClasses ||
-            property in preserveProperties ||
-            (
-                !kClass.canBeUnfolded &&
-                    !fieldKind.shouldBeConvertedToFrameColumn &&
-                    !fieldKind.shouldBeConvertedToColumnGroup
-            )
-
+        // property type might not be of FrameColumn kind if `AnyFrame?`, but we still have to narrow it to FrameCol
+        // when no actual nulls are met
         val shouldCreateFrameCol = kClass == DataFrame::class && !nullable
+
+        val keepSubtree =
+            maxDepth <= 0 &&
+                !fieldKind.shouldBeConvertedToFrameColumn &&
+                !fieldKind.shouldBeConvertedToColumnGroup &&
+                !shouldCreateFrameCol
+
+        val shouldCreateValueCol =
+            keepSubtree ||
+                kClass in preserveClasses ||
+                property in preserveProperties ||
+                (
+                    !kClass.canBeUnfolded &&
+                        !fieldKind.shouldBeConvertedToFrameColumn &&
+                        !fieldKind.shouldBeConvertedToColumnGroup &&
+                        !shouldCreateFrameCol
+                )
+
         val shouldCreateColumnGroup = kClass == DataRow::class
 
         if (shouldCreateFrameCol && shouldCreateValueCol) {
@@ -358,7 +367,7 @@ internal fun convertToDataFrame(
             shouldCreateColumnGroup ->
                 DataColumn.createColumnGroup(
                     name = it.columnName,
-                    df = (values as List<AnyRow>).concat(),
+                    df = (values as List<AnyRow?>).concat(),
                 )
 
             kClass.isSubclassOf(Iterable::class) ->

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/convertTo.kt
@@ -184,6 +184,21 @@ class ConvertToTests {
     @DataSchema
     data class DataSchemaWithAnyFrame(val dfs: AnyFrame?)
 
+    private fun locationsFrame(): DataFrame<Location?> =
+        listOf(
+            Location("Home", Gps(0.0, 0.0)),
+            Location("Away", null),
+            null,
+        ).toDataFrame()
+            .alsoDebug("locations:")
+
+    private fun gpsFrame(): DataFrame<Gps?> =
+        listOf(
+            Gps(0.0, 0.0),
+            null,
+        ).toDataFrame()
+            .alsoDebug("gps:")
+
     @Test
     fun test() {
         val df1 = dataFrameOf("a")(1, 2, 3)
@@ -202,67 +217,70 @@ class ConvertToTests {
     }
 
     @Test
-    fun `convert df with AnyFrame to itself`() {
-        val locationsList = listOf(
-            Location("Home", Gps(0.0, 0.0)),
-            Location("Away", null),
-            null,
-        )
-        val locations = locationsList
-            .toDataFrame()
-            .alsoDebug("locations:")
+    fun `convert df with AnyFrame containing locations to itself`() {
+        val locations = locationsFrame()
 
-        val gpsList = listOf(
-            Gps(0.0, 0.0),
-            null,
-        )
-        val gps = gpsList
+        listOf(DataSchemaWithAnyFrame(locations))
             .toDataFrame()
-            .alsoDebug("gps:")
-
-        val df1 = listOf(
-            DataSchemaWithAnyFrame(locations),
-        ).toDataFrame()
             .alsoDebug("df1:")
+            .convertTo<DataSchemaWithAnyFrame>()
+    }
 
-        df1.convertTo<DataSchemaWithAnyFrame>()
+    @Test
+    fun `convert df with AnyFrame containing gps to itself`() {
+        val gps = gpsFrame()
 
-        val df2 = listOf(
-            DataSchemaWithAnyFrame(gps),
-        ).toDataFrame()
+        listOf(DataSchemaWithAnyFrame(gps))
+            .toDataFrame()
             .alsoDebug("df2:")
+            .convertTo<DataSchemaWithAnyFrame>()
+    }
 
-        df2.convertTo<DataSchemaWithAnyFrame>()
+    @Test
+    fun `convert df with preserved AnyFrame containing null and gps to itself`() {
+        val gps = gpsFrame()
 
-        val df3 = listOf(
+        listOf(
             DataSchemaWithAnyFrame(null),
             DataSchemaWithAnyFrame(gps),
         ).toDataFrame { properties { preserve(DataFrame::class) } }
             .alsoDebug("df3 before convert:")
+            .convertTo<DataSchemaWithAnyFrame>()
+    }
 
-        df3.convertTo<DataSchemaWithAnyFrame>()
-
-        val df4 = listOf(
+    @Test
+    fun `convert df with preserved null AnyFrame to itself`() {
+        listOf(
             DataSchemaWithAnyFrame(null),
         ).toDataFrame { properties { preserve(DataFrame::class) } }
             .alsoDebug("df4 before convert:")
+            .convertTo<DataSchemaWithAnyFrame>()
+    }
 
-        df4.convertTo<DataSchemaWithAnyFrame>()
+    @Test
+    fun `convert raw df with AnyFrame column to itself`() {
+        val locations = locationsFrame()
+        val gps = gpsFrame()
 
-        val df5a: DataFrame<*> = dataFrameOf(
+        val df: DataFrame<*> = dataFrameOf(
             columnOf(locations, gps, null).named("dfs"),
         ).alsoDebug("df5a:")
 
-        df5a.convertTo<DataSchemaWithAnyFrame>()
+        df.convertTo<DataSchemaWithAnyFrame>()
+    }
 
-        val df5 = listOf(
+    @Test
+    fun `convert df with preserved mixed AnyFrame values to itself repeatedly`() {
+        val locations = locationsFrame()
+        val gps = gpsFrame()
+
+        listOf(
             DataSchemaWithAnyFrame(null),
             DataSchemaWithAnyFrame(locations),
             DataSchemaWithAnyFrame(gps),
         ).toDataFrame { properties { preserve(DataFrame::class) } }
             .alsoDebug("df5 before convert:")
-
-        df5.convertTo<DataSchemaWithAnyFrame>()
+            .convertTo<DataSchemaWithAnyFrame>()
             .alsoDebug("df5 after convert:")
             .convertTo<DataSchemaWithAnyFrame>()
             .alsoDebug("df5 after second convert:")

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/CodeGenerationTests.kt
@@ -4,7 +4,9 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.ColumnsScope
 import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.default
@@ -16,6 +18,7 @@ import org.jetbrains.kotlinx.dataframe.api.groupBy
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.move
 import org.jetbrains.kotlinx.dataframe.api.pathOf
+import org.jetbrains.kotlinx.dataframe.api.print
 import org.jetbrains.kotlinx.dataframe.api.schema
 import org.jetbrains.kotlinx.dataframe.api.toCodeString
 import org.jetbrains.kotlinx.dataframe.api.under
@@ -23,9 +26,11 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGenerator
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGeneratorImpl
 import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
+import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
 import org.jetbrains.kotlinx.dataframe.testSets.person.BaseTest
 import org.jetbrains.kotlinx.dataframe.testSets.person.Person
 import org.junit.Test
+import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 
 class CodeGenerationTests : BaseTest() {
@@ -568,6 +573,18 @@ class CodeGenerationTests : BaseTest() {
             )
             """.trimIndent()
         assertEquals(expected, df.generateDataClasses().value)
+    }
+
+    @DataSchema
+    class C(val i: Int)
+
+    @DataSchema
+    class Schema(val df: DataFrame<C>?)
+
+    @Test
+    fun extractNullableDataFrameSchema() {
+        val schema = MarkersExtractor.get<Schema>().schema
+        schema.columns["df"] shouldBe ColumnSchema.Value(typeOf<DataFrame<C>?>())
     }
 
     // region Tests for generateX functions


### PR DESCRIPTION
This makes extracted schema represent runtime more accurately
With compiler plugin enabled, check this:
```kt
val df = dataFrameOf("a" to columnOf(List(4) {
    dataFrameOf(
        "c" to columnOf(2)
    )
}))
    .addId()

val res = df
    .convert { a }.with { it.takeIf { index() % 2 == 0 } }
    .add("f1") { a }

println(res.compileTimeSchema())
```

Reproduced by `extractNullableDataFrameSchema` test

Before, schema would lie to us that `a` and `f1` are FrameColumns (and has no nulls):

```
id: Int
a: *
    c: Int?
f1: *
    c: Int?
```
    


After:

```
id: Int
a: DataFrame<`FieldkindKt$main$df$2$A_651`>?
f1: DataFrame<`FieldkindKt$main$df$2$A_651`>?
```

Result is arguably not much better, because now suddenly we have not expanded structural dataframe type in the schema. In this case it is also anonymous and cannot be "materialized" by either generateCode or recent compiler warnings utilities. 
Resolving this usability problem will be our next step. We can either, idk, re-define operations in a way that nulls automatically replaced with empty frames, or fix codegen/schema/model to reflect possible DataFrame values better

Regarding changes made in this PR:
1. toDataFrame is expected to behave exactly as before, but it requires additional condition
2. convertTo used to be able to convert `FrameColumn<Schema>` to a `ValueColumn<DataFrame<Schema>?>` (which is valid operation) due to MarkersExtractor.get wrongly interpreting `DataFrame<Schema>?` as FrameColumn. I added branch that explicitly allows such pre-existing convertTo 

fixes #1498 


