### PR TITLE
Fixes slicing `ValueColumn<AnyFrame?> -> FrameColumn`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5304,12 +5304,10 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/columns/ValueCol
 	public synthetic fun distinct ()Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public synthetic fun distinct ()Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;
 	public abstract fun distinct ()Lorg/jetbrains/kotlinx/dataframe/columns/ValueColumn;
-	public synthetic fun get (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public abstract fun get (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public synthetic fun get (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;
-	public abstract fun get (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/columns/ValueColumn;
-	public synthetic fun get (Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
+	public abstract fun get (Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public synthetic fun get (Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;
-	public abstract fun get (Lkotlin/ranges/IntRange;)Lorg/jetbrains/kotlinx/dataframe/columns/ValueColumn;
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/DataColumn;
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/BaseColumn;
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnReference;

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
+import org.jetbrains.kotlinx.dataframe.impl.columns.asValueColumn
 import org.jetbrains.kotlinx.dataframe.indices
 
 public fun <T> DataFrame<T>.reverse(): DataFrame<T> = get(indices.reversed())
@@ -15,4 +16,4 @@ public fun <T> ColumnGroup<T>.reverse(): ColumnGroup<T> = get(indices.reversed()
 
 public fun <T> FrameColumn<T>.reverse(): FrameColumn<T> = get(indices.reversed())
 
-public fun <T> ValueColumn<T>.reverse(): ValueColumn<T> = get(indices.reversed())
+public fun <T> ValueColumn<T>.reverse(): ValueColumn<T> = get(indices.reversed()).asValueColumn()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ValueColumn.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/columns/ValueColumn.kt
@@ -17,14 +17,14 @@ public interface ValueColumn<out T> : DataColumn<T> {
 
     override fun distinct(): ValueColumn<T>
 
-    override fun get(indices: Iterable<Int>): ValueColumn<T>
+    override fun get(indices: Iterable<Int>): DataColumn<T>
 
     override fun rename(newName: String): ValueColumn<T>
 
     override operator fun getValue(thisRef: Any?, property: KProperty<*>): ValueColumn<T> =
         super.getValue(thisRef, property) as ValueColumn<T>
 
-    public override operator fun get(range: IntRange): ValueColumn<T>
+    public override operator fun get(range: IntRange): DataColumn<T>
 
     /**
      * Changes column [type][BaseColumn.type].

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ValueColumnImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/columns/ValueColumnImpl.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlinx.dataframe.impl.columns
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
@@ -78,12 +79,17 @@ internal open class ValueColumnImpl<T>(
 
     override fun addParent(parent: ColumnGroup<*>): DataColumn<T> = ValueColumnWithParent(parent, this)
 
-    override fun createWithValues(values: List<T>, hasNulls: Boolean?): ValueColumn<T> {
+    override fun createWithValues(values: List<T>, hasNulls: Boolean?): DataColumn<T> {
         val nulls = hasNulls ?: values.any { it == null }
+
+        // If this value column was of type `AnyFrame?` and all nulls are filtered out, return a frame column instead
+        if (!nulls && type.isSubtypeOf(typeOf<AnyFrame?>())) {
+            return DataColumn.createFrameColumn(name, values as List<AnyFrame>).cast()
+        }
         return DataColumn.createValueColumn(name, values, type.withNullability(nulls))
     }
 
-    override fun get(indices: Iterable<Int>): ValueColumn<T> {
+    override fun get(indices: Iterable<Int>): DataColumn<T> {
         var nullable = false
         val newValues = indices.map {
             val value = values[it]
@@ -96,7 +102,7 @@ internal open class ValueColumnImpl<T>(
     override fun get(columnName: String) =
         throw UnsupportedOperationException("Can not get nested column '$columnName' from ValueColumn '$name'")
 
-    override operator fun get(range: IntRange): ValueColumn<T> = super<DataColumnImpl>.get(range) as ValueColumn<T>
+    override operator fun get(range: IntRange): DataColumn<T> = super<DataColumnImpl>.get(range) as DataColumn<T>
 
     override fun defaultValue() = defaultValue
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
@@ -1,11 +1,48 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
 import org.junit.Test
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.typeOf
 
 class DropTests : ColumnsSelectionDslTests() {
+
+    // Issue #1926
+    @Test
+    fun `removing nulls from ValueCol of DF should turn into FrameCol`() {
+        val df = dataFrameOf(
+            DataColumn.createValueColumn("col", listOf(df, null)),
+        )
+        df["col"].let {
+            it.kind() shouldBe ColumnKind.Value
+            it.type() shouldBe typeOf<DataFrame<Person>?>()
+        }
+        val updatedDf = df.update("col").where { it == null }.with { emptyDataFrame<Person>() }
+        updatedDf["col"].let {
+            // correct
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
+        }
+
+        df["col"].dropNulls() // should work correctly
+        val droppedDf = df.dropNulls("col")
+        droppedDf["col"].let {
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
+        }
+
+        val takenDf = droppedDf.take(1)
+        takenDf["col"].let {
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
+        }
+    }
 
     @Test
     fun `drop and dropLast`() {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/drop.kt
@@ -1,48 +1,11 @@
 package org.jetbrains.kotlinx.dataframe.api
 
-import io.kotest.matchers.shouldBe
-import org.jetbrains.kotlinx.dataframe.DataColumn
-import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.samples.api.firstName
 import org.jetbrains.kotlinx.dataframe.samples.api.lastName
 import org.jetbrains.kotlinx.dataframe.samples.api.name
 import org.junit.Test
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.typeOf
 
 class DropTests : ColumnsSelectionDslTests() {
-
-    // Issue #1926
-    @Test
-    fun `removing nulls from ValueCol of DF should turn into FrameCol`() {
-        val df = dataFrameOf(
-            DataColumn.createValueColumn("col", listOf(df, null)),
-        )
-        df["col"].let {
-            it.kind() shouldBe ColumnKind.Value
-            it.type() shouldBe typeOf<DataFrame<Person>?>()
-        }
-        val updatedDf = df.update("col").where { it == null }.with { emptyDataFrame<Person>() }
-        updatedDf["col"].let {
-            // correct
-            it.kind() shouldBe ColumnKind.Frame
-            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
-        }
-
-        df["col"].dropNulls() // should work correctly
-        val droppedDf = df.dropNulls("col")
-        droppedDf["col"].let {
-            it.kind() shouldBe ColumnKind.Frame
-            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
-        }
-
-        val takenDf = droppedDf.take(1)
-        takenDf["col"].let {
-            it.kind() shouldBe ColumnKind.Frame
-            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
-        }
-    }
 
     @Test
     fun `drop and dropLast`() {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/columns/DataColumns.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/columns/DataColumns.kt
@@ -1,17 +1,29 @@
 package org.jetbrains.kotlinx.dataframe.columns
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.dropNulls
+import org.jetbrains.kotlinx.dataframe.api.emptyDataFrame
+import org.jetbrains.kotlinx.dataframe.api.take
 import org.jetbrains.kotlinx.dataframe.api.toColumn
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.api.update
+import org.jetbrains.kotlinx.dataframe.api.where
+import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.core.BuildConfig
+import org.jetbrains.kotlinx.dataframe.samples.api.TestBase.Person
+import org.jetbrains.kotlinx.dataframe.testSets.person.BaseTest
 import org.junit.Test
 import java.net.URI
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.typeOf
 
-class DataColumns {
+class DataColumns : BaseTest() {
     @Test
     fun `create column with platform type from Api`() {
         val df1 = listOf(1, 2, 3).toDataFrame {
@@ -59,6 +71,53 @@ class DataColumns {
                 name = "",
                 values = listOf(dataFrameOf("a")(1), dataFrameOf("a")(2)),
             )
+        }
+    }
+
+    // Tests for issue #1926
+    val nullableDfValueColumnDf = dataFrameOf(
+        DataColumn.createValueColumn("col", listOf(df, null)),
+    )
+
+    @Test
+    fun `checking nullableDfValueColumnDf creation`() {
+        nullableDfValueColumnDf["col"].let {
+            it.kind() shouldBe ColumnKind.Value
+            it.type().isSubtypeOf(typeOf<DataFrame<*>?>()) shouldBe true
+        }
+    }
+
+    @Test
+    fun `test removing nulls update from nullable DF ValueCol should turn into FrameCol`() {
+        val updatedDf = nullableDfValueColumnDf
+            .update("col").where { it == null }.with { emptyDataFrame<Person>() }
+        updatedDf["col"].let {
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
+        }
+    }
+
+    @Test
+    fun `test dropNulls from nullable DF ValueCol should turn into FrameCol`() {
+        shouldNotThrowAny {
+            nullableDfValueColumnDf["col"].dropNulls()
+        }
+        val droppedDf = nullableDfValueColumnDf.dropNulls("col")
+        droppedDf["col"].let {
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
+        }
+    }
+
+    @Test
+    fun `test take from nullable DF ValueCol should turn into FrameCol`() {
+        shouldNotThrowAny {
+            nullableDfValueColumnDf["col"].take(1)
+        }
+        val takenDf = nullableDfValueColumnDf.take(1)
+        takenDf["col"].let {
+            it.kind() shouldBe ColumnKind.Frame
+            it.type().isSubtypeOf(typeOf<DataFrame<*>>()) shouldBe true
         }
     }
 }


### PR DESCRIPTION
Fixes #1926 by letting slicing operations on ValueColumn potentially return a FrameColumn.

Like #1925 this points at a deeper issue with the way we handle dataframes inside columns, but at least does this make it consistent with `update`, `convert`, `replace` etc.