### PR TITLE
Bumped KoDEx to 0.5.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"
 arrow = "19.0.0"
-kodex = "0.5.4"
+kodex = "0.5.5"
 simpleGit = "2.3.1"
 dependencyVersions = "0.54.0"
 plugin-publish = "2.1.1"


### PR DESCRIPTION
Bumping KoDEx to 0.5.5 to prevent clash with @ExportAsHtml from contextual sources

Feel free to merge before the next release if needed, else it can be merged afterwards