### PR TITLE
Replaced binary compatibility validator with KGP validator

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(conventions.plugins.dfbuild.base)
     // enables the linter for every Kotlin module in the project
@@ -9,6 +11,19 @@ plugins {
 kotlin {
     explicitApi()
     jvmToolchain(libs.versions.gradle.jdk.get().toInt())
+
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation()
+}
+
+// Aliases akin to the old binary compatibility validator plugin
+val apiCheck by tasks.registering {
+    group = "verification"
+    dependsOn("checkKotlinAbi")
+}
+val apiDump by tasks.registering {
+    group = "verification"
+    dependsOn("updateKotlinAbi")
 }
 
 // Adds the instrumentedJars configuration/artifact to all Kotlin sub-projects.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,3 +113,6 @@ kotlinPublications {
         }
     }
 }
+
+tasks.checkKotlinAbi { onlyIf { false } }
+tasks.updateKotlinAbi { onlyIf { false } }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -192,7 +192,6 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/aggregation/Colu
 
 public final class org/jetbrains/kotlinx/dataframe/aggregation/NamedValue {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/aggregation/NamedValue$Companion;
-	public synthetic fun <init> (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/Object;Lkotlin/reflect/KType;Ljava/lang/Object;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;
 	public final fun component2 ()Ljava/lang/Object;
 	public final fun component3 ()Lkotlin/reflect/KType;
@@ -1939,7 +1938,6 @@ public abstract class org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions 
 
 public class org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Java : org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Java$Companion;
-	public synthetic fun <init> (Ljava/util/Locale;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun copy ()Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Java;
 	public synthetic fun copy ()Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions;
 	public final fun copy (Ljava/util/Locale;Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Java;
@@ -1968,7 +1966,6 @@ public final class org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Jav
 
 public class org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Kotlin : org/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Kotlin$Companion;
-	public synthetic fun <init> (Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun copy ()Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Kotlin;
 	public synthetic fun copy ()Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions;
 	public final fun copy (Ljava/lang/Iterable;)Lorg/jetbrains/kotlinx/dataframe/api/DateTimeParserOptions$Kotlin;
@@ -4998,7 +4995,6 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/codeGen/TypeCast
 
 public final class org/jetbrains/kotlinx/dataframe/codeGen/TypeCastGenerator$DataFrameApi : org/jetbrains/kotlinx/dataframe/codeGen/TypeCastGenerator {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/codeGen/TypeCastGenerator$DataFrameApi$Companion;
-	public synthetic fun <init> ([Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addCastTo (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getTypes ()[Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -5016,7 +5012,6 @@ public final class org/jetbrains/kotlinx/dataframe/codeGen/TypeCastGenerator$Emp
 
 public final class org/jetbrains/kotlinx/dataframe/codeGen/ValidFieldName {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/codeGen/ValidFieldName$Companion;
-	public synthetic fun <init> (Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getNeedsQuote ()Z
 	public final fun getQuotedIfNeeded ()Ljava/lang/String;
 	public final fun getUnquoted ()Ljava/lang/String;
@@ -5089,7 +5084,6 @@ public class org/jetbrains/kotlinx/dataframe/columns/ColumnKind : java/lang/Enum
 	public static final field Frame Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;
 	public static final field Group Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;
 	public static final field Value Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;
 	public static fun values ()[Lorg/jetbrains/kotlinx/dataframe/columns/ColumnKind;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
         alias(publisher)
         alias(serialization)
         alias(korro)
-        alias(binary.compatibility.validator)
         alias(kotlinx.benchmark)
     }
 }

--- a/dataframe-arrow/build.gradle.kts
+++ b/dataframe-arrow/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     }
     with(libs.plugins) {
         alias(publisher)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-csv/build.gradle.kts
+++ b/dataframe-csv/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     with(libs.plugins) {
         alias(publisher)
         alias(serialization)
-        alias(binary.compatibility.validator)
         alias(kotlinx.benchmark)
     }
 }

--- a/dataframe-excel/build.gradle.kts
+++ b/dataframe-excel/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     }
     with(libs.plugins) {
         alias(publisher)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-jdbc/build.gradle.kts
+++ b/dataframe-jdbc/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     }
     with(libs.plugins) {
         alias(publisher)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-json/build.gradle.kts
+++ b/dataframe-json/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     with(libs.plugins) {
         alias(publisher)
         alias(serialization)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-jupyter/build.gradle.kts
+++ b/dataframe-jupyter/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     with(libs.plugins) {
         alias(publisher)
         alias(jupyter.api)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-openapi-generator/build.gradle.kts
+++ b/dataframe-openapi-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     with(libs.plugins) {
         alias(publisher)
         alias(serialization)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/dataframe-openapi/build.gradle.kts
+++ b/dataframe-openapi/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     }
     with(libs.plugins) {
         alias(publisher)
-        alias(binary.compatibility.validator)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ maven-invoker = "3.3.0"
 maven-wrapper = "3.3.4"
 maven = "3.9.11"
 maven-surefire = "3.5.6"
-binaryCompatibilityValidator = "0.18.1"
 deephavenCsv = "0.19.0"
 fastDoubleParser = "2.0.1"
 commonsCsv = "1.14.1"
@@ -253,7 +252,6 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 
 [plugins]
 jupyter-api = { id = "org.jetbrains.kotlin.jupyter.api", version.ref = "kotlinJupyter" }
-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 publisher = { id = "org.jetbrains.kotlin.libs.publisher", version.ref = "libsPublisher" }


### PR DESCRIPTION
Fixes #1491 

Replaces binary compatibility validator with experimental KGP validator https://kotlinlang.org/docs/gradle-binary-compatibility-validation.html

It seems the behavior is identical to the old plugin; we might as well use it :)