### PR TITLE
Hide TODO page

### DIFF
--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -97,7 +97,7 @@
                 <toc-element topic="columns.md"/>
                 <toc-element topic="getColumn.md"/>
             </toc-element>
-            <toc-element topic="getValues.md">
+            <toc-element toc-title="Get values">
                 <toc-element topic="values.md"/>
             </toc-element>
         </toc-element>


### PR DESCRIPTION
No idea what content to put there. All other root pages seem to have additional content about mix of operations, but for values we only have.. values? Would be strange to have Get values (some info about values()) and then values (some other info about values())
<img width="670" height="414" alt="image" src="https://github.com/user-attachments/assets/42b8ef0b-acf1-4ebe-bd58-bf8d53fd84bf" />
