### PR TITLE
Updated documentation about removed plugins

### DIFF
--- a/docs/StardustDocs/topics/FAQ.md
+++ b/docs/StardustDocs/topics/FAQ.md
@@ -170,40 +170,6 @@ including support for reading and writing GeoJSON and Shapefile formats, as well
 See the [GeoDataFrame Guide](https://kotlin.github.io/kandy/geo-plotting-guide.html) for details 
 and examples with beautiful [Kandy](https://kotlin.github.io/kandy) geo visualizations.
 
-## What is the difference between Compiler Plugin, Gradle Plugin, and KSP Plugin?
-
-> The current Gradle plugin is **under consideration for deprecation** and may be officially marked as deprecated 
-> in future releases.
->
-> The KSP plugin is **not compatible with [KSP2](https://github.com/google/ksp?tab=readme-ov-file#ksp2-is-here)**
-> and may **not work properly with Kotlin 2.1 or newer**.
->
-> At the moment, **[data schema generation is handled via dedicated methods](DataSchemaGenerationMethods.md)** instead 
-> of relying on the plugins. 
-> See [](Migration-From-Plugins.md).
-{style="warning"}
-
-All these plugins relate to working with [dataframe schemas](schemas.md), but they serve different purposes:
-
-- **[Gradle Plugin](Gradle-Plugin.md)** and **[KSP Plugin](https://github.com/Kotlin/dataframe/tree/master/plugins/symbol-processor)** 
- are used to **generate data schemas** from external sources as part of the Gradle build process.
-
-    - **Gradle Plugin**: You declare the data source in your `build.gradle.kts` file  
-      using the `dataframes { ... }` block.
-
-    - **KSP Plugin**: You annotate your Kotlin file with `@ImportDataSchema` file annotation,  
-      and the schema will be generated via Kotlin Symbol Processing.
-
-  See [Data Schemas in Gradle Projects](https://kotlin.github.io/dataframe/schemasgradle.html) for more.
-
-- **[Compiler Plugin](Compiler-Plugin.md)** provides **on-the-fly generation** of 
-[extension properties](extensionPropertiesApi.md)
-based on an existing schema **during compilation**, and updates the [`DataFrame`](DataFrame.md)
-schema seamlessly after operations.
-However, when reading data from files or external sources (like SQL),
-the initial `DataFrame` schema cannot be inferred automatically —
-you need to specify it manually or generate it using the [`generate..()` methods](DataSchemaGenerationMethods.md).
-
 ## How do I contribute or report an issue?
 
 We’re always happy to receive contributions!

--- a/docs/StardustDocs/topics/schemas/Migration-From-Plugins.md
+++ b/docs/StardustDocs/topics/schemas/Migration-From-Plugins.md
@@ -14,6 +14,14 @@ Our plans for the next iteration of schema generation from source feature can be
 > and has a different plugin ID.  
 > {style="note"}
 
+Latest available release of the deprecated plugin:
+
+```kotlin
+plugins {
+    id("org.jetbrains.kotlinx.dataframe") version "1.0.0-Beta4"
+}
+```
+
 1. **Generation of [data schemas](schemas.md)** from data sources  
    (files, databases, or external URLs).
     - You could copy already generated schemas from `build/generate` into your project sources.
@@ -27,6 +35,14 @@ Our plans for the next iteration of schema generation from source feature can be
 
 
 ## KSP Plugin
+
+Latest available release of the deprecated processor:
+
+```kotlin
+dependencies {
+    ksp("org.jetbrains.kotlinx.dataframe:symbol-processor-all:1.0.0-Beta4")
+}
+```
 
 - **Generation of [data schemas](schemas.md)** from data sources  
   (files, databases, or external URLs).

--- a/docs/StardustDocs/topics/setup/Modules.md
+++ b/docs/StardustDocs/topics/setup/Modules.md
@@ -64,14 +64,6 @@ that significantly enhance the development experience
       <td>Kotlin compiler plugin. Provides compile-time <a href="extensionPropertiesApi.md">extension properties</a> generation.
 </td>
     </tr>
-    <tr>
-      <td><code><a href="#kotlinx.dataframe">kotlinx.dataframe</a></code></td>
-      <td>Gradle plugin. Provides <a href="schemas.md">schemas generation</a> using Gradle.</td>
-    </tr>
-    <tr>
-      <td><code><a href="#ksp-plugin">kotlinx.dataframe:symbol-processor-all</a></code></td>
-      <td>KSP plugin. Provides <a href="schemas.md">schemas generation</a> using KSP.</td>
-    </tr>
   </tbody>
 </table>
 
@@ -539,77 +531,3 @@ kotlin.incremental=false
 
 Published as a Kotlin official plugin.
 [Source code is available in the Kotlin repository](https://github.com/JetBrains/kotlin/tree/master/plugins/kotlin-dataframe).
-
-#### `kotlinx.dataframe` – Gradle Plugin {id="kotlinx.dataframe"}
-
-> The current Gradle plugin is **under consideration for deprecation** 
-> and may be officially marked as deprecated in future releases.
->
-> At the moment, **[data schema generation is handled via dedicated methods](DataSchemaGenerationMethods.md)** instead of relying on the plugin.
-{style="warning"}
-
-The Gradle plugin allows generating [data schemas](schemas.md) from samples of data
-(of supported formats) like JSON, CSV, Excel files, or URLs, as well as from data fetched from SQL databases  
-using Gradle.
-
-See the [Gradle Plugin Reference](Gradle-Plugin.md) for installation
-and usage instructions in Gradle projects.
-
-> By default, the Gradle plugin also applies the [KSP plugin](#ksp-plugin).
-
-
-<tabs>
-<tab title="Kotlin DSL">
-
-```kotlin
-plugins {
-    id("org.jetbrains.kotlinx.dataframe") version "%dataFrameVersion%"
-}
-```
-</tab> 
-
-<tab title="Groovy DSL">
-
-```groovy
-plugins {
-    id 'org.jetbrains.kotlinx.dataframe' version '%dataFrameVersion%'
-}
-```
-</tab>
-</tabs> 
-
-
-#### `kotlinx.dataframe:symbol-processor-all` – KSP Plugin {id="ksp-plugin"}
-
-> The KSP plugin is **not compatible with [KSP2](https://github.com/google/ksp?tab=readme-ov-file#ksp2-is-here)**
-> and may **not work properly with Kotlin 2.1 or newer**.
-> 
-> At the moment, **[data schema generation is handled via dedicated methods](DataSchemaGenerationMethods.md)** instead of relying on the plugin.
-{style="warning"}
-
-The Gradle plugin allows generating [data schemas](schemas.md) from samples of data
-(of supported formats) like JSON, CSV, Excel files, or URLs, as well as from data fetched from SQL databases
-using Kotlin Symbol Processing (KSP).
-This is useful for projects where you prefer or require schema generation at the source level.
-
-See [Data Schemas in Gradle Projects](schemasGradle.md) for usage details.
-
-<tabs>
-<tab title="Kotlin DSL">
-
-```kotlin
-dependencies {
-    ksp("org.jetbrains.kotlinx.dataframe:symbol-processor-all:%dataFrameVersion%")
-}
-```
-</tab> 
-
-<tab title="Groovy DSL">
-
-```groovy
-dependencies {
-    ksp 'org.jetbrains.kotlinx.dataframe:symbol-processor-all:%dataFrameVersion%'
-}
-```
-</tab>
-</tabs> 


### PR DESCRIPTION
I think at this point it's best to align documentation with the fact that plugins are no longer published even.
We'll keep information in migration guide, and for now in DataSchemas section of the docs