### PR TITLE
Restructured setup guides to have compiler plugin closer to library dependency setup

### DIFF
--- a/docs/StardustDocs/topics/Compiler-Plugin.md
+++ b/docs/StardustDocs/topics/Compiler-Plugin.md
@@ -73,7 +73,7 @@ Sync the project. This is not needed anymore from Kotlin 2.4.0+.
 
 The DataFrame compiler plugin can be used in Maven projects starting from IntelliJ IDEA 2025.3, available now as EAP builds
 
-Setup plugin in pom.xml:
+Update the `<kotlin-maven-plugin>` in the `<plugin>` section of your `pom.xml`:
 
 ```xml
 <plugin>
@@ -82,11 +82,13 @@ Setup plugin in pom.xml:
     <version>%compilerPluginKotlinVersion%</version>
 
     <configuration>
+        <!-- Specify the Kotlin-dataframe plugin -->
         <compilerPlugins>
             <plugin>kotlin-dataframe</plugin>
         </compilerPlugins>
     </configuration>
 
+    <!-- Add the Kotlin-dataframe plugin dependency -->
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/docs/StardustDocs/topics/setup/SetupAndroid.md
+++ b/docs/StardustDocs/topics/setup/SetupAndroid.md
@@ -31,23 +31,6 @@ dependencies {
     // You can add any additional IO modules you like, except for 'dataframe-arrow'.
     // Apache Arrow is not supported well on Android.
 }
-
-android {
-    defaultConfig {
-        minSdk = 21
-    }
-    // Requires Java 8 or higher
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> { 
-    kotlinOptions.jvmTarget = "1.8" 
-}
 ```
 
 </tab>
@@ -64,23 +47,6 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:dataframe-csv:%dataFrameVersion%'
     // You can add any additional IO modules you like, except for 'dataframe-arrow'.
     // Apache Arrow is not supported well on Android.
-}
-
-android {
-    defaultConfig {
-        minSdk 21
-    }
-    // Requires Java 8 or higher
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { 
-    kotlinOptions.jvmTarget = "1.8"
 }
 ```
 

--- a/docs/StardustDocs/topics/setup/SetupAndroid.md
+++ b/docs/StardustDocs/topics/setup/SetupAndroid.md
@@ -14,59 +14,15 @@ How to use Kotlin DataFrame in your Android project with Gradle setup and compil
 
 > See an [Android project example](https://github.com/Kotlin/dataframe/tree/master/examples/projects/android-example).
 
-Kotlin DataFrame doesn't provide a dedicated Android artifact yet, 
-but you can add the Kotlin DataFrame JVM dependency to your Android project with minimal configuration:
 
-<tabs>
-<tab title="Kotlin DSL">
+### 1. Add the plugin
 
-```kotlin
-dependencies {
-    // Core Kotlin DataFrame API, CSV and JSON IO.
-    // See custom Gradle setup:
-    // https://kotlin.github.io/dataframe/setupcustomgradle.html
-    implementation("org.jetbrains.kotlinx:dataframe-core:%dataFrameVersion%")
-    implementation("org.jetbrains.kotlinx:dataframe-json:%dataFrameVersion%")
-    implementation("org.jetbrains.kotlinx:dataframe-csv:%dataFrameVersion%")
-    // You can add any additional IO modules you like, except for 'dataframe-arrow'.
-    // Apache Arrow is not supported well on Android.
-}
-```
-
-</tab>
-
-<tab title="Groovy DSL">
-
-```groovy
-dependencies {
-    // Core Kotlin DataFrame API, CSV and JSON IO.
-    // See custom Gradle setup:
-    // https://kotlin.github.io/dataframe/setupcustomgradle.html
-    implementation 'org.jetbrains.kotlinx:dataframe-core:%dataFrameVersion%'
-    implementation 'org.jetbrains.kotlinx:dataframe-json:%dataFrameVersion%'
-    implementation 'org.jetbrains.kotlinx:dataframe-csv:%dataFrameVersion%'
-    // You can add any additional IO modules you like, except for 'dataframe-arrow'.
-    // Apache Arrow is not supported well on Android.
-}
-```
-
-</tab>
-</tabs>
-
-This setup adds the [Kotlin DataFrame core](Modules.md#dataframe-core) 
-as well as a subset of the [IO modules](Modules.md#io-modules) 
-(excluding [experimental ones](Modules.md#experimental-modules)).
-For flexible configuration, see [Custom configuration](SetupCustomGradle.md).
-
-## Kotlin DataFrame Compiler Plugin
-
-[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation 
-of [extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md) 
-on-the-fly in Android projects, making development with Kotlin DataFrame 
+[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation
+of [extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md)
+on-the-fly in Android projects, making development with Kotlin DataFrame
 faster, more convenient, and fully type- and name-safe.
 
-> Requires Kotlin 2.2.20-Beta1 or higher.  
-> { style = "note" }
+> Requires Kotlin 2.2.20-Beta1 or higher.
 
 To enable the plugin in your Gradle project, add it to the `plugins` section:
 
@@ -92,14 +48,52 @@ plugins {
 </tab>
 </tabs>
 
-If you're using a version older than Kotlin 2.4.0,
-incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735),
-
-Add the following line to your `gradle.properties` file:
+In versions older than Kotlin 2.4.0 add following line to your `gradle.properties`:
 
 ```properties
 kotlin.incremental=false
 ```
+
+### 2. Add the library
+
+Kotlin DataFrame doesn't provide a dedicated Android artifact yet, 
+but you can add the Kotlin DataFrame JVM dependency to your Android project with minimal configuration:
+
+<tabs>
+<tab title="Kotlin DSL">
+
+```kotlin
+dependencies {
+    // Core Kotlin DataFrame API, CSV and JSON IO.
+    // See custom Gradle setup:
+    // https://kotlin.github.io/dataframe/setupcustomgradle.html
+    implementation("org.jetbrains.kotlinx:dataframe-core:%dataFrameVersion%")
+    implementation("org.jetbrains.kotlinx:dataframe-json:%dataFrameVersion%")
+    implementation("org.jetbrains.kotlinx:dataframe-csv:%dataFrameVersion%")
+    // You can add any additional IO modules you like, except for 'dataframe-arrow'.
+    // Apache Arrow is not well supported on Android.
+}
+```
+
+</tab>
+
+<tab title="Groovy DSL">
+
+```groovy
+dependencies {
+    // Core Kotlin DataFrame API, CSV and JSON IO.
+    // See custom Gradle setup:
+    // https://kotlin.github.io/dataframe/setupcustomgradle.html
+    implementation 'org.jetbrains.kotlinx:dataframe-core:%dataFrameVersion%'
+    implementation 'org.jetbrains.kotlinx:dataframe-json:%dataFrameVersion%'
+    implementation 'org.jetbrains.kotlinx:dataframe-csv:%dataFrameVersion%'
+    // You can add any additional IO modules you like, except for 'dataframe-arrow'.
+    // Apache Arrow is not well supported on Android.
+}
+```
+
+</tab>
+</tabs>
 
 ## Next Steps
 

--- a/docs/StardustDocs/topics/setup/SetupGradle.md
+++ b/docs/StardustDocs/topics/setup/SetupGradle.md
@@ -38,8 +38,45 @@ that you want to use in your project. The minimum supported version is JDK 8.
 
 You have successfully created a project with Gradle.
 
-## Add Kotlin DataFrame Gradle dependency
+## Setup Kotlin DataFrame
 
+### 1. Add the plugin
+[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation of
+[extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md)
+on-the-fly in Gradle projects, making development with Kotlin DataFrame faster,
+more convenient, and fully type- and name-safe.
+
+> Requires Kotlin 2.2.20-Beta1 or higher
+
+To enable the plugin in your Gradle project, add it to the `plugins` section:
+
+<tabs>
+<tab title="Kotlin DSL">
+
+```kotlin
+plugins {
+    kotlin("plugin.dataframe") version "%compilerPluginKotlinVersion%"
+}
+```
+</tab>
+<tab title="Groovy DSL">
+
+```groovy
+plugins {
+    id 'org.jetbrains.kotlin.plugin.dataframe' version '%compilerPluginKotlinVersion%'
+}
+```
+
+</tab>
+</tabs>
+
+In versions older than Kotlin 2.4.0 add following line to your `gradle.properties`:
+
+```properties
+kotlin.incremental=false
+```
+
+### 2. Add the library dependency
 In your Gradle build file (`build.gradle` or `build.gradle.kts`), add the Kotlin DataFrame library as a dependency:
 
 <tabs>
@@ -85,49 +122,6 @@ fun main() {
 
     df.print()
 }
-```
-
-## Kotlin DataFrame Compiler Plugin
-
-[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation of
-[extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md)
-on-the-fly in Gradle projects, making development with Kotlin DataFrame faster,
-more convenient, and fully type- and name-safe.
-
-> Requires Kotlin 2.2.20-Beta1 or higher.  
-> { style = "note" }
-
-To enable the plugin in your Gradle project, add it to the `plugins` section:
-
-<tabs>
-<tab title="Kotlin DSL">
-
-```kotlin
-plugins {
-    kotlin("plugin.dataframe") version "%compilerPluginKotlinVersion%"
-}
-```
-
-</tab>
-
-<tab title="Groovy DSL">
-
-```groovy
-plugins {
-    id 'org.jetbrains.kotlin.plugin.dataframe' version '%compilerPluginKotlinVersion%'
-}
-```
-
-</tab>
-</tabs>
-
-If you're using a version older than Kotlin 2.4.0,
-incremental compilation must be disabled due to [this issue](https://youtrack.jetbrains.com/issue/KT-66735),
-
-Add the following line to your `gradle.properties` file:
-
-```properties
-kotlin.incremental=false
 ```
 
 ## Project Example

--- a/docs/StardustDocs/topics/setup/SetupMaven.md
+++ b/docs/StardustDocs/topics/setup/SetupMaven.md
@@ -36,7 +36,45 @@ that you want to use in your project. The minimum supported version is JDK 8.
 
 You have successfully created a project with Maven.
 
-## Add Kotlin DataFrame Maven dependency
+## Setup Kotlin DataFrame
+
+### 1. Add the plugin
+
+[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation of
+[extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md)
+on-the-fly in Maven projects, making development with Kotlin DataFrame faster,
+more convenient, and fully type- and name-safe.
+
+> Requires Kotlin 2.2.20-Beta1 or higher and IntelliJ IDEA 2025.3 or higher.  
+> { style = "note" }
+
+To enable the plugin in your Maven project, update the `<kotlin-maven-plugin>` in the `<plugin>` section of your `pom.xml`:
+
+```xml
+<plugin>
+    <artifactId>kotlin-maven-plugin</artifactId>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <version>%compilerPluginKotlinVersion%</version>
+
+    <configuration>
+        <!-- Specify the Kotlin-dataframe plugin -->
+        <compilerPlugins>
+            <plugin>kotlin-dataframe</plugin>
+        </compilerPlugins>
+    </configuration>
+
+    <!-- Add the Kotlin-dataframe plugin dependency -->
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-dataframe</artifactId>
+            <version>%compilerPluginKotlinVersion%</version>
+        </dependency>
+    </dependencies>
+</plugin>
+```
+
+### 2. Add the library dependency
 
 In your Maven build file (`pom.xml`), add the Kotlin DataFrame library as a dependency:
 
@@ -73,39 +111,6 @@ fun main() {
 }
 ```
 
-## Kotlin DataFrame Compiler Plugin
-
-[Kotlin DataFrame Compiler Plugin](Compiler-Plugin.md) enables automatic generation of
-[extension properties](extensionPropertiesApi.md) and updates [data schemas](schemas.md)
-on-the-fly in Maven projects, making development with Kotlin DataFrame faster,
-more convenient, and fully type- and name-safe.
-
-> Requires Kotlin 2.2.20-Beta1 or higher and IntelliJ IDEA 2025.3 or higher.  
-> { style = "note" }
-
-To enable the plugin in your Maven project, add it to the `plugins` section:
-
-```xml
-<plugin>
-    <artifactId>kotlin-maven-plugin</artifactId>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <version>%compilerPluginKotlinVersion%</version>
-
-    <configuration>
-        <compilerPlugins>
-            <plugin>kotlin-dataframe</plugin>
-        </compilerPlugins>
-    </configuration>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-maven-dataframe</artifactId>
-            <version>%compilerPluginKotlinVersion%</version>
-        </dependency>
-    </dependencies>
-</plugin>
-```
 
 ## Project Example
 

--- a/examples/projects/android-example/app/build.gradle.kts
+++ b/examples/projects/android-example/app/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     // https://kotlin.github.io/dataframe/setupcustomgradle.html
     //
     // You can add any additional IO modules you like, except for 'dataframe-arrow'.
-    // Apache Arrow is not supported well on Android.
+    // Apache Arrow is not well supported on Android.
     //
     // Either use:
     implementation(libs.dataframe.core)

--- a/examples/projects/dev/android-example/app/build.gradle.kts
+++ b/examples/projects/dev/android-example/app/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     // https://kotlin.github.io/dataframe/setupcustomgradle.html
     //
     // You can add any additional IO modules you like, except for 'dataframe-arrow'.
-    // Apache Arrow is not supported well on Android.
+    // Apache Arrow is not well supported on Android.
     //
     // Either use:
     implementation(libs.dataframe.core)


### PR DESCRIPTION
1. Joined compiler plugin setup with library dependency setup as we discussed
2. Updated maven setup, took inspiration from https://kotlinlang.org/docs/power-assert.html#maven
3. Compacted Android setup. I believe all these JDK/minSdk were there only because we used to have a lot of extras for Apache Arrow setup. Turns out it doesn't work at all on Android. Our library doesn't impose any additional restrictions on JDK, i believe. Showing setup of 1.8 everywhere seems redundant. Maaybe we should leave minSdk? Let me know what you think.