### PR TITLE
Enabled KoDEx cross module caches

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
@@ -30,53 +30,74 @@ interface KodexConventionExtension {
      * This can be useful if you want to use `@sample` or `@includeFile`.
      *
      * By default, this contains all `api`/`implementation`/`compileOnly` project source sets this project depends on.
+     *
+     * [inputCacheFiles] will be used to stop KoDEx from processing contextual sources multiple times.
      */
     val contextualSourcesDirectories: SetProperty<List<File>>
 
+    /**
+     * The name of the generated sources folder. "generated-sources" by default.
+     */
     val generatedSourcesFolderName: Property<String>
+
+    /**
+     * Used in conjunction with [contextualSourcesDirectories].
+     * By default, it contains the combined `outputCacheFile`s of the contextual sources.
+     */
+    val inputCacheFiles: ConfigurableFileCollection
 }
 
 val extension = project.extensions.create<KodexConventionExtension>("kodexConvention")
-    .apply {
-        generatedSourcesFolderName.convention("generated-sources")
 
-        // this is set in afterEvaluate to any modifications to the main/test sourceSets are present
-        afterEvaluate {
-            kotlinMainSourcesDirectories.convention(
-                kotlin.sourceSets.main.get()
-                    .kotlin
-                    .sourceDirectories
-                    // important! This clones the collection
-                    .toSet(),
-            )
+extension.generatedSourcesFolderName.convention("generated-sources")
 
-            val dependentProjects =
-                sequenceOf(
-                    configurations.api,
-                    configurations.implementation,
-                    configurations.compileOnly,
-                ).flatMap { it.get().dependencies }
-                    .filterIsInstance<ProjectDependency>()
-                    .distinctBy { it.path }
-                    .map { project(it.path) }
+// this is set in afterEvaluate to any modifications to the main/test sourceSets are present
+afterEvaluate {
+    extension.kotlinMainSourcesDirectories.convention(
+        kotlin.sourceSets.main.get()
+            .kotlin
+            .sourceDirectories
+            // important! This clones the collection
+            .toSet(),
+    )
 
-            tasks["processKDocsMain"].dependsOn(
-                dependentProjects.map { it.path + ":assemble" }.toList(),
-            )
-            val projectSources = dependentProjects.map {
-                it.extensions
-                    .findByName("sourceSets")?.let { it as SourceSetContainer }
-                    ?.findByName("main")
-                    ?.extensions
-                    ?.findByName("kotlin")?.let { it as SourceDirectorySet }
-                    ?.sourceDirectories
-                    ?.toList()
-                    ?: emptyList()
-            }.toSet()
+    // use `project()` dependencies for connecting contextual KoDEx sources and -caches
+    val contextualProjects =
+        sequenceOf(
+            configurations.api,
+            configurations.implementation,
+            configurations.compileOnly,
+        ).flatMap { it.get().dependencies }
+            .filterIsInstance<ProjectDependency>()
+            .distinctBy { it.path }
+            .map { project(it.path) }
 
-            contextualSourcesDirectories.convention(projectSources)
+    val processKDocsMain = tasks["processKDocsMain"]
+
+    // connect contextual outputCaches -> inputCache and dependsOn relations
+    extension.inputCacheFiles.convention(emptyList<Any>())
+    contextualProjects.forEach {
+        it.tasks.withType<RunKodexTask>().configureEach {
+            logger.lifecycle("${processKDocsMain.path} now dependsOn ${this.path}, contextual cache is transferred.")
+            processKDocsMain.dependsOn(this)
+            extension.inputCacheFiles.from(this.outputCacheFile)
         }
     }
+
+    // collect contextual source dirs
+    val contextualProjectsSources = contextualProjects.map {
+        it.extensions
+            .findByName("sourceSets")?.let { it as SourceSetContainer }
+            ?.findByName("main")
+            ?.extensions
+            ?.findByName("kotlin")?.let { it as SourceDirectorySet }
+            ?.sourceDirectories
+            ?.toList()
+            ?: emptyList()
+    }.toSet()
+
+    extension.contextualSourcesDirectories.convention(contextualProjectsSources)
+}
 
 fun pathOf(vararg parts: String) = parts.joinToString(File.separator)
 
@@ -104,7 +125,9 @@ val processKDocsMain = tasks.register<RunKodexTask>("processKDocsMain") {
         }
     contextualSources = extension.contextualSourcesDirectories
 
-    group = "KDocs"
+    inputCacheFiles = extension.inputCacheFiles
+
+    group = "KoDEx"
     target = file(extension.generatedSourcesFolderName)
 
     // false, so `ktlintGeneratedMainSourcesSourceSetFormat` can format the output
@@ -121,7 +144,7 @@ val processKDocsMain = tasks.register<RunKodexTask>("processKDocsMain") {
 
 // Alias for processKDocsMain
 val kodex = tasks.register("kodex") {
-    group = "KDocs"
+    group = "KoDEx"
     dependsOn(processKDocsMain)
 }
 

--- a/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
@@ -79,7 +79,6 @@ afterEvaluate {
     contextualProjects.forEach {
         it.tasks.withType<RunKodexTask>().configureEach {
             logger.lifecycle("${processKDocsMain.path} now dependsOn ${this.path}, contextual cache is transferred.")
-            processKDocsMain.dependsOn(this)
             extension.inputCacheFiles.from(this.outputCacheFile)
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
         alias(publisher)
         alias(serialization) apply false
         alias(dokka)
-        alias(kodex)
 
         alias(simpleGit) apply false
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
         alias(publisher)
         alias(serialization) apply false
         alias(dokka)
+        alias(kodex)
 
         alias(simpleGit) apply false
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"
 arrow = "19.0.0"
-kodex = "0.5.5"
+kodex = "0.6.0"
 simpleGit = "2.3.1"
 caupain = "1.9.1"
 plugin-publish = "2.1.1"


### PR DESCRIPTION
Bumped to [KoDEx 0.6.0](https://github.com/Jolanrensen/KoDEx/releases/tag/v0.6.0), connected the new caches, and refactored the convention plugin a bit. (Should look better when we finally do #985)

~Enabled KoDEx project wide for `preprocessAllWithKodex` task.~

The build should now be faster, as the sources of `:core` and `:json` don't need to be reprocessed every time another module is built that has either module in its dependencies. 