### PR TITLE
Migrated delegated property usages in build files for Gradle 10

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.buildConfig.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.buildConfig.gradle.kts
@@ -19,7 +19,7 @@ buildConfig {
 }
 
 // combining buildconfig with ktlint
-val buildConfigSources by kotlin.sourceSets.creating {
+val buildConfigSources = kotlin.sourceSets.create("buildConfigSources") {
     kotlin.srcDir("build/generated/sources/buildConfig/main")
 }
 tasks.generateBuildConfigClasses {

--- a/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.buildExampleProjects.gradle.kts
@@ -56,7 +56,7 @@ val versionsToSync =
         )
     }.map { it.getVersionName() }
 
-val syncAllExampleFolders by tasks.registering {
+val syncAllExampleFolders = tasks.register("syncAllExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Sync the versions in the nested projects in /examples/projects"
 }
@@ -108,7 +108,7 @@ private fun setupExampleProjectFolderSyncTask(folder: File, isDev: Boolean) {
 
 // region promoting
 
-val promoteDevExamples by tasks.registering {
+val promoteDevExamples = tasks.register("promoteDevExamples") {
     group = buildExampleProjectsGroup
     description = "Promotes the /examples/projects/dev example projects to /examples/projects"
 
@@ -134,7 +134,7 @@ val promoteDevExamples by tasks.registering {
 
 // region testing/building examples
 
-val generateAllExampleFoldersTests by tasks.registering {
+val generateAllExampleFoldersTests = tasks.register("generateAllExampleFoldersTests") {
     group = buildExampleProjectsGroup
     description = "Generates test classes for each example in /examples/projects"
 
@@ -148,7 +148,7 @@ val generateAllExampleFoldersTests by tasks.registering {
     }
 }
 
-val runBuildAllExampleFolders by tasks.registering(Test::class) {
+val runBuildAllExampleFolders = tasks.register<Test>("runBuildAllExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds all the nested builds in /examples/projects to verify they compile correctly."
 }
@@ -159,27 +159,27 @@ tasks.named("test") {
     }
 }
 
-val runBuildReleaseExampleFolders by tasks.registering(Test::class) {
+val runBuildReleaseExampleFolders = tasks.register<Test>("runBuildReleaseExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested release builds in /examples/projects to verify they compile correctly."
 }
-val runBuildDevExampleFolders by tasks.registering(Test::class) {
+val runBuildDevExampleFolders = tasks.register<Test>("runBuildDevExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested dev builds in /examples/projects to verify they compile correctly."
 }
-val runBuildMavenExampleFolders by tasks.registering(Test::class) {
+val runBuildMavenExampleFolders = tasks.register<Test>("runBuildMavenExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested Maven builds in /examples/projects to verify they compile correctly."
 }
-val runBuildGradleExampleFolders by tasks.registering(Test::class) {
+val runBuildGradleExampleFolders = tasks.register<Test>("runBuildGradleExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested Gradle builds in /examples/projects to verify they compile correctly."
 }
-val runBuildAndroidExampleFolders by tasks.registering(Test::class) {
+val runBuildAndroidExampleFolders = tasks.register<Test>("runBuildAndroidExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested Android builds in /examples/projects to verify they compile correctly."
 }
-val runBuildNonAndroidExampleFolders by tasks.registering(Test::class) {
+val runBuildNonAndroidExampleFolders = tasks.register<Test>("runBuildNonAndroidExampleFolders") {
     group = buildExampleProjectsGroup
     description = "Builds the nested non-Android builds in /examples/projects to verify they compile correctly."
 }
@@ -267,7 +267,7 @@ private fun setupGenerateAndRunTestTasks(folder: File, isDev: Boolean) {
     }
 }
 
-val testBuildingExamples: SourceSet by sourceSets.creating {
+val testBuildingExamples: SourceSet = sourceSets.create("testBuildingExamples") {
     kotlin.setSrcDirs(
         listOf(
             // base class
@@ -296,10 +296,10 @@ tasks.named<JavaCompile>("compile${testBuildingExamples.name.capitalized()}Java"
     options.release.set(javaVersion.majorVersion.toInt())
 }
 
-val testBuildingExamplesImplementation: Configuration by configurations.getting {
+val testBuildingExamplesImplementation: Configuration = configurations.getByName("testBuildingExamplesImplementation") {
     extendsFrom(configurations.implementation.get())
 }
-val testBuildingExamplesRuntimeOnly: Configuration by configurations.getting {
+val testBuildingExamplesRuntimeOnly: Configuration = configurations.getByName("testBuildingExamplesRuntimeOnly") {
     extendsFrom(configurations.runtimeOnly.get())
 }
 

--- a/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
@@ -82,7 +82,7 @@ fun pathOf(vararg parts: String) = parts.joinToString(File.separator)
 
 // main sourceset of the generated sources as a result of `processKDocsMain`, this will create linter tasks
 // This also makes sure the contextual sources are not in the final jar
-val generatedMainSources by kotlin.sourceSets.creating {
+val generatedMainSources = kotlin.sourceSets.create("generatedMainSources") {
     kotlin {
         afterEvaluate {
             this@kotlin.setSrcDirs(
@@ -97,7 +97,7 @@ val generatedMainSources by kotlin.sourceSets.creating {
 }
 
 // Task to generate the processed documentation
-val processKDocsMain by tasks.registering(RunKodexTask::class) {
+val processKDocsMain = tasks.register<RunKodexTask>("processKDocsMain") {
     sources = extension.kotlinMainSourcesDirectories.get()
         .also {
             logger.info("$name: Preprocessing sources with KoDEx: ${it.toList()}")
@@ -120,7 +120,7 @@ val processKDocsMain by tasks.registering(RunKodexTask::class) {
 }
 
 // Alias for processKDocsMain
-val kodex by tasks.registering {
+val kodex = tasks.register("kodex") {
     group = "KDocs"
     dependsOn(processKDocsMain)
 }
@@ -144,7 +144,7 @@ idea {
 // If `changeJarTask` is run, modify all Jar tasks such that before running the Kotlin sources are set to
 // the target of `processKdocMain`, and they are returned to normal afterward.
 // This is usually only done when publishing
-val changeJarTask by tasks.registering {
+val changeJarTask = tasks.register("changeJarTask") {
     outputs.upToDateWhen { project.hasProperty("skipKodex") }
     doFirst {
         tasks.withType<Jar> {

--- a/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
 // Adds the instrumentedJars configuration/artifact to all Kotlin sub-projects.
 // This allows other modules to depend on the output of this task, aka the compiled jar of that module
 // Used in :plugins:dataframe-gradle-plugin integration tests and in :samples for compiler plugin support
-val instrumentedJars: Configuration by configurations.creating {
+val instrumentedJars: Configuration = configurations.create("instrumentedJars") {
     isCanBeConsumed = true
     isCanBeResolved = false
 }

--- a/build-settings-logic/src/main/kotlin/dfsettings.base.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/dfsettings.base.settings.gradle.kts
@@ -1,6 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
-val jupyterApiTCRepo: String? by settings
+val jupyterApiTCRepo: String? = providers.gradleProperty("jupyterApiTCRepo").orNull
 
 dependencyResolutionManagement {
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     }
 }
 
-val projectName: String by project
+val projectName: String = providers.gradleProperty("projectName").get()
 
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get())
@@ -55,7 +55,7 @@ fun detectVersion(): String {
     }
 }
 
-val detectVersionForTC by tasks.registering {
+val detectVersionForTC = tasks.register("detectVersionForTC") {
     doLast {
         println("##teamcity[buildNumber '$version']")
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,7 +41,7 @@ sourceSets {
 }
 
 // Separate source set for Java 16+ language-specific tests (e.g., Java Records)
-val testJava16 by sourceSets.creating {
+val testJava16 = sourceSets.create("testJava16") {
     java.srcDir("src/testJava16/java")
     kotlin.srcDir("src/testJava16/kotlin")
     compileClasspath += sourceSets.main.get().output + configurations.testCompileClasspath.get()
@@ -49,7 +49,7 @@ val testJava16 by sourceSets.creating {
 }
 
 dependencies {
-    val kotlinCompilerPluginClasspathSamples by configurations.getting
+    val kotlinCompilerPluginClasspathSamples = configurations.getByName("kotlinCompilerPluginClasspathSamples")
 
     api(libs.kotlin.reflect)
     implementation(libs.kotlin.stdlib)
@@ -89,10 +89,10 @@ dependencies {
 
 // Configure testJava16 dependencies to extend from test
 configurations {
-    val testJava16Implementation by getting {
+    getByName("testJava16Implementation") {
         extendsFrom(configurations.testImplementation.get())
     }
-    val testJava16RuntimeOnly by getting {
+    getByName("testJava16RuntimeOnly") {
         extendsFrom(configurations.testRuntimeOnly.get())
     }
 }
@@ -126,7 +126,7 @@ benchmark {
 // All korro/samples related tasks should be removed
 // after migration all test sample to :samples module
 
-val samplesImplementation by configurations.getting {
+configurations.getByName("samplesImplementation") {
     extendsFrom(configurations.testImplementation.get())
 }
 
@@ -149,10 +149,10 @@ val compileSamplesKotlin = tasks.named<KotlinCompile>("compileSamplesKotlin") {
     destinationDirectory = layout.buildDirectory.dir("classes/testWithOutputs/kotlin")
 }
 
-val clearTestResults by tasks.registering(Delete::class, fun Delete.() {
+val clearTestResults = tasks.register<Delete>("clearTestResults") {
     delete(layout.buildDirectory.dir("dataframes"))
     delete(layout.buildDirectory.dir("korroOutputLines"))
-})
+}
 
 val samplesTest = tasks.register<Test>("samplesTest") {
     group = "Verification"
@@ -177,7 +177,7 @@ val samplesTest = tasks.register<Test>("samplesTest") {
         sourceSets["main"].runtimeClasspath
 }
 
-val clearSamplesOutputs by tasks.registering {
+val clearSamplesOutputs = tasks.register("clearSamplesOutputs") {
     group = "documentation"
 
     doFirst {
@@ -257,7 +257,7 @@ korro {
 // generateLibrariesJson makes sure a META-INF/kotlin-jupyter-libraries/libraries.json file is generated
 // This file allows loading dataframe-jupyter when dataframe-core is present on its own in a Kotlin Notebook.
 val generatedJupyterResourcesDir = layout.buildDirectory.dir("generated/jupyter")
-val generateLibrariesJson by tasks.registering {
+val generateLibrariesJson = tasks.register("generateLibrariesJson") {
     val outDir = generatedJupyterResourcesDir.get().asFile.resolve("META-INF/kotlin-jupyter-libraries")
     val outFile = outDir.resolve("libraries.json")
     outputs.file(outFile)

--- a/plugins/dataframe-gradle-plugin/build.gradle.kts
+++ b/plugins/dataframe-gradle-plugin/build.gradle.kts
@@ -91,8 +91,8 @@ gradlePlugin {
 }
 
 sourceSets {
-    val main by getting
-    val test by getting
+    val main = getByName("main")
+    val test = getByName("test")
     val testRuntimeClasspath by configurations
     create("integrationTest") {
         kotlin.srcDir("src/integrationTest/kotlin")
@@ -101,7 +101,7 @@ sourceSets {
     }
 }
 
-val integrationTestConfiguration by configurations.creating {
+val integrationTestConfiguration = configurations.create("integrationTestConfiguration") {
     extendsFrom(configurations.testImplementation.get())
 }
 

--- a/plugins/kotlin-dataframe/build.gradle.kts
+++ b/plugins/kotlin-dataframe/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 group = "org.jetbrains.kotlinx.dataframe"
 
-val kotlinVersion: String by project.properties
+val kotlinVersion: String = providers.gradleProperty("kotlinVersion").get()
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Suddenly it all became deprecated. Will be error in Gradle 10, apparently. 

registering:
[DEPRECATION] 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. 
See the Gradle 9.6 upgrading guide

getting:
[DEPRECATION] 'fun provideDelegate(thisRef: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<Configuration>' is deprecated. Use 'val element = getByName(name)' instead. See the Gradle 9.6 upgrading guide

creating:
[DEPRECATION] 'fun provideDelegate(thisRef: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<KotlinSourceSet>' is deprecated. Use 'val element = create(name)' instead. See the Gradle 9.6 upgrading guide.