### PR TITLE
Use testImplementation for dataframe-jupyter in openapi-generator

### DIFF
--- a/dataframe-openapi-generator/build.gradle.kts
+++ b/dataframe-openapi-generator/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
         exclude("jakarta.validation")
     }
 
-    testApi(projects.dataframeJupyter)
+    testImplementation(projects.dataframeJupyter)
     testImplementation(libs.junit)
     testImplementation(libs.kotestAssertions) {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")


### PR DESCRIPTION
Kotlin now warns that API dependencies in test source sets are deprecated, since test source sets are not consumable. Switch testApi to testImplementation.