### PR TITLE
Migrate NamedValue .copy visibility according to future Kotlin 2.5 requirement

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -192,14 +192,11 @@ public abstract interface class org/jetbrains/kotlinx/dataframe/aggregation/Colu
 
 public final class org/jetbrains/kotlinx/dataframe/aggregation/NamedValue {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/aggregation/NamedValue$Companion;
-	public synthetic fun <init> (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/Object;Lkotlin/reflect/KType;Ljava/lang/Object;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;
 	public final fun component2 ()Ljava/lang/Object;
 	public final fun component3 ()Lkotlin/reflect/KType;
 	public final fun component4 ()Ljava/lang/Object;
 	public final fun component5 ()Z
-	public final fun copy (Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/Object;Lkotlin/reflect/KType;Ljava/lang/Object;Z)Lorg/jetbrains/kotlinx/dataframe/aggregation/NamedValue;
-	public static synthetic fun copy$default (Lorg/jetbrains/kotlinx/dataframe/aggregation/NamedValue;Lorg/jetbrains/kotlinx/dataframe/columns/ColumnPath;Ljava/lang/Object;Lkotlin/reflect/KType;Ljava/lang/Object;ZILjava/lang/Object;)Lorg/jetbrains/kotlinx/dataframe/aggregation/NamedValue;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/Object;
 	public final fun getGuessType ()Z

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/NamedValue.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/aggregation/NamedValue.kt
@@ -5,8 +5,8 @@ import org.jetbrains.kotlinx.dataframe.impl.aggregation.ValueWithDefault
 import org.jetbrains.kotlinx.dataframe.impl.emptyPath
 import kotlin.reflect.KType
 
-@Suppress("DataClassPrivateConstructor")
-public data class NamedValue private constructor(
+@ConsistentCopyVisibility
+public data class NamedValue internal constructor(
     val path: ColumnPath,
     val value: Any?,
     val type: KType?,


### PR DESCRIPTION
As things now: private constructor with implicitly public constructor, this code will become error in 2.5 release. 
Looks like we deed to decide what ABI we want for it
I propose changing visibility to internal for constructor and for .copy because we use it in implementation, but it doesn't make much sense to have it in public API