### PR TITLE
Fixed flaky KoDEx build error

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kodex.gradle.kts
@@ -1,4 +1,5 @@
 import dfbuild.findRootDir
+import nl.jolanrensen.kodex.gradle.KodexIsolationMode
 import nl.jolanrensen.kodex.gradle.RunKodexTask
 
 plugins {
@@ -123,11 +124,15 @@ val processKDocsMain = tasks.register<RunKodexTask>("processKDocsMain") {
             logger.info("$name: Preprocessing sources with KoDEx: ${it.toList()}")
         }
     contextualSources = extension.contextualSourcesDirectories
-
     inputCacheFiles = extension.inputCacheFiles
 
     group = "KoDEx"
     target = file(extension.generatedSourcesFolderName)
+
+    workerIsolation {
+        mode = KodexIsolationMode.PROCESS
+        maxHeapSize = "512m"
+    }
 
     // false, so `ktlintGeneratedMainSourcesSourceSetFormat` can format the output
     outputReadOnly = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"
 arrow = "19.0.0"
-kodex = "0.6.0"
+kodex = "0.6.1"
 caupain = "1.9.1"
 plugin-publish = "2.1.1"
 shadow = "9.5.1"


### PR DESCRIPTION
Bumped KoDEx to 0.6.1 and enabled process-based worker isolation to prevent the build exception regarding `/META-INF/analysis-api/analysis-api-fir.xml` (https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_DataScience_DataFrame_Build?branch=%3Cdefault%3E&buildTypeTab=overview&logFilter=debug&logView=flowAware&showLog=1020099706_3595_1356.3607#1020098712)