### PR TITLE
bumped kodex to 0.6.2 fixing global Gradle repositories being overridden

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"
 arrow = "19.0.0"
-kodex = "0.6.1"
+kodex = "0.6.2"
 caupain = "1.9.1"
 plugin-publish = "2.1.1"
 shadow = "9.5.1"


### PR DESCRIPTION
bumped kodex to 0.6.2 fixing https://github.com/Jolanrensen/KoDEx/issues/107