### PR TITLE
Fixed dataframe schemas equality check + added tests and docs

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlinx.dataframe.schema.plus
 public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>) : DataFrameSchema {
 
     override fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode): CompareResult {
-
         require(other is DataFrameSchemaImpl)
         if (this === other) return Matches
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
@@ -11,8 +11,14 @@ import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT_FOR_NESTED_SCHEMAS
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
+import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchemaDoc
 import org.jetbrains.kotlinx.dataframe.schema.plus
 
+/**
+ * [DataFrameSchema] implementation.
+ *
+ * @include [DataFrameSchemaDoc]
+ */
 public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>) : DataFrameSchema {
 
     override fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode): CompareResult {
@@ -56,18 +62,20 @@ public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>
 
     /**
      * Returns `true` if, and only if,
-     * [this schema][this] has the same columns **in the same order** as the [other schema][other].
+     * this schema has the same columns **in the same order** as the [other schema][other].
      * The types must also match exactly.
      *
      * Each column is compared by [ColumnSchema.equals], so nested schemas of
-     * [ColumnSchema.Group] and [ColumnSchema.Frame] columns are compared by these same rules, recursively.
+     * [column group schemas][ColumnSchema.Group] and [frame column schemas][ColumnSchema.Frame]
+     * are compared by these same rules, recursively.
      *
-     * Note that this is deliberately independent of [compare][DataFrameSchema.compare]:
-     * [compare][DataFrameSchema.compare] is the API for lenient/semantic matching (and neglects column order),
-     * while [equals] is exact equality.
+     * Note that [equals] and [compare][DataFrameSchema.compare] behave differently:
+     * [equals] requires schemas to match exactly, including column order,
+     * while [compare][DataFrameSchema.compare] ignores column order and provides additional comparison options
+     * (see [ComparisonMode]).
      *
-     * Use [compare][DataFrameSchema.compare] if the order does not matter and
-     * for other comparison options.
+     * Use [compare][DataFrameSchema.compare] when column order does not matter or
+     * when you need additional [comparison options][ComparisonMode].
      *
      * @see [DataFrameSchema.compare]
      * @see [CompareResult.matches]
@@ -77,15 +85,12 @@ public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>
         if (other !is DataFrameSchema) return false
         if (columns.size != other.columns.size) return false
 
-        // compare both schemas' columns pairwise, in order, delegating to ColumnSchema.equals
-        val otherColumns = other.columns.entries.iterator()
-        for ((name, columnSchema) in columns) {
-            val (otherName, otherColumnSchema) = otherColumns.next()
-            if (name != otherName) return false
-            if (columnSchema != otherColumnSchema) return false
-        }
+        val otherColumnsIterator = other.columns.entries.iterator()
 
-        return true
+        return columns.all { (name, schema) ->
+            val (otherName, otherSchema) = otherColumnsIterator.next()
+            name == otherName && schema == otherSchema
+        }
     }
 
     override fun toString(): String = render()

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/schema/DataFrameSchemaImpl.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dataframe.schema.plus
 public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>) : DataFrameSchema {
 
     override fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode): CompareResult {
+
         require(other is DataFrameSchemaImpl)
         if (this === other) return Matches
 
@@ -58,7 +59,14 @@ public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>
      * [this schema][this] has the same columns **in the same order** as the [other schema][other].
      * The types must also match exactly.
      *
-     * Use [compare][DataFrameSchema.compare] it the order does not matter and
+     * Each column is compared by [ColumnSchema.equals], so nested schemas of
+     * [ColumnSchema.Group] and [ColumnSchema.Frame] columns are compared by these same rules, recursively.
+     *
+     * Note that this is deliberately independent of [compare][DataFrameSchema.compare]:
+     * [compare][DataFrameSchema.compare] is the API for lenient/semantic matching (and neglects column order),
+     * while [equals] is exact equality.
+     *
+     * Use [compare][DataFrameSchema.compare] if the order does not matter and
      * for other comparison options.
      *
      * @see [DataFrameSchema.compare]
@@ -67,25 +75,14 @@ public class DataFrameSchemaImpl(override val columns: Map<String, ColumnSchema>
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DataFrameSchema) return false
-        if (this.compare(other) != Matches) return false
-        if (columns.keys.toList() != other.columns.keys.toList()) return false
+        if (columns.size != other.columns.size) return false
 
-        for ((name, col) in columns) {
-            val other = other.columns[name]!!
-            when (col) {
-                is ColumnSchema.Group -> {
-                    other as ColumnSchema.Group // safe to cast because of compare
-                    if (col.schema != other.schema) return false
-                }
-
-                is ColumnSchema.Frame -> {
-                    other as ColumnSchema.Frame // safe to cast because of compare
-                    if (col.schema != other.schema) return false
-                }
-
-                // already checked by compare
-                is ColumnSchema.Value -> Unit
-            }
+        // compare both schemas' columns pairwise, in order, delegating to ColumnSchema.equals
+        val otherColumns = other.columns.entries.iterator()
+        for ((name, columnSchema) in columns) {
+            val (otherName, otherColumnSchema) = otherColumns.next()
+            if (name != otherName) return false
+            if (columnSchema != otherColumnSchema) return false
         }
 
         return true

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ComparisonMode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ComparisonMode.kt
@@ -1,5 +1,18 @@
 package org.jetbrains.kotlinx.dataframe.schema
 
+import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
+import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.LENIENT
+import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT
+import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT_FOR_NESTED_SCHEMAS
+
+/**
+ * Defines how [ColumnSchema] or [DataFrameSchema] are compared.
+ *
+ * Defines how differences between schemas are interpreted; affects the [result][CompareResult]
+ * returned by [ColumnSchema.compare] and [DataFrameSchema.compare].
+ *
+ * @include [ComparisonModeOptionsSnippet]
+ */
 public enum class ComparisonMode {
     /**
      * In this mode, all [CompareResults][CompareResult] can occur.
@@ -18,3 +31,14 @@ public enum class ComparisonMode {
     /** Works like [LENIENT] at the top-level, but turns to [STRICT] for nested schemas. */
     STRICT_FOR_NESTED_SCHEMAS,
 }
+
+/**
+ * - [LENIENT]: Schemas may have different sets of columns. Missing or additional columns
+ *   are reported as [CompareResult.IsDerived] or [CompareResult.IsSuper].
+ * - [STRICT]: Schemas must have the same columns with the same names and types.
+ *   Otherwise, the result is [CompareResult.None].
+ * - [STRICT_FOR_NESTED_SCHEMAS]: Uses [LENIENT] comparison for the top-level schema
+ *   and [STRICT] comparison for nested schemas.
+ */
+@ExcludeFromSources
+internal typealias ComparisonModeOptionsSnippet = Nothing

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
@@ -1,12 +1,35 @@
 package org.jetbrains.kotlinx.dataframe.schema
 
+import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
+
+/**
+ * @include [DataFrameSchemaDoc]
+ */
 public interface DataFrameSchema {
     public companion object;
 
+    /**
+     * A map that defines the schema of the columns within a [DataFrameSchema].
+     *
+     * The key represents the name of the column, while the value is a [ColumnSchema] describing
+     * the structure, type, and properties of the column.
+     *
+     * The value can be one of the following:
+     * - [ColumnSchema.Value]: Represents a value column, including its type and nullability.
+     * - [ColumnSchema.Group]: Represents a group of columns, containing their schemas as a nested [DataFrameSchema].
+     * - [ColumnSchema.Frame]: Represents a frame column (column of dataframes) containing their [DataFrameSchema].
+     *
+     * This map provides an ordered representation of the schema that accurately describes the names and
+     * corresponding structure of all columns in a dataframe.
+     */
     public val columns: Map<String, ColumnSchema>
 
     /**
      * Compares this schema with [other] schema.
+     *
+     * Returns one of possible [CompareResult] based on the specified [comparisonMode]:
+     *
+     * @include [ComparisonModeOptionsSnippet]
      *
      * @param comparisonMode The [mode][ComparisonMode] to compare the schema's by.
      *   By default, generated markers for leafs aren't used as supertypes: `@DataSchema(isOpen = false)`
@@ -19,3 +42,23 @@ public interface DataFrameSchema {
      */
     public fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode = ComparisonMode.LENIENT): CompareResult
 }
+
+/**
+ * Represents the schema of a dataframe,
+ * i.e., an ordered map of column names to their types.
+ *
+ * Column types are represented by [ColumnSchema]:
+ *
+ * - For value columns, it contains the [type][kotlin.reflect.KType] of the column.
+ * - For column groups, it contains the [DataFrameSchema] of the nested columns.
+ * - For frame columns, it contains the [DataFrameSchema] of the contained dataframes.
+ *
+ * Use [compare][org.jetbrains.kotlinx.dataframe.impl.schema.DataFrameSchemaImpl.compare]
+ * to compare this schema with another schema using different [comparison modes][ComparisonMode].
+ * The comparison ignores column order and can report how the schemas are related.
+ *
+ * Use [equals][org.jetbrains.kotlinx.dataframe.impl.schema.DataFrameSchemaImpl.equals]
+ * to check whether two schemas are exactly equal, including column order.
+ */
+@ExcludeFromSources
+internal typealias DataFrameSchemaDoc = Nothing

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
@@ -127,7 +127,6 @@ class MatchSchemeTests {
 
     @Test
     fun `simple data schema comparison`() {
-
         val scheme1 = dataFrameOf(
             "a" to columnOf(1, 2, 3, null),
             "b" to columnOf(1.0, 2.0, 3.0, 4.0),

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
@@ -11,9 +11,10 @@ import org.jetbrains.kotlinx.dataframe.api.after
 import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.columnOf
 import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
-import org.jetbrains.kotlinx.dataframe.api.generateCode
+import org.jetbrains.kotlinx.dataframe.api.generateInterfaces
 import org.jetbrains.kotlinx.dataframe.api.move
 import org.jetbrains.kotlinx.dataframe.api.schema
+import org.jetbrains.kotlinx.dataframe.api.sumOf
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGenerator
@@ -120,12 +121,13 @@ class MatchSchemeTests {
 
     @Test
     fun printSchema() {
-        val res = df.generateCode(false, true)
+        val res = df.generateInterfaces(extensionProperties = true)
         println(res)
     }
 
     @Test
     fun `simple data schema comparison`() {
+
         val scheme1 = dataFrameOf(
             "a" to columnOf(1, 2, 3, null),
             "b" to columnOf(1.0, 2.0, 3.0, 4.0),
@@ -383,5 +385,6 @@ class MatchSchemeTests {
 
         (scheme == reordered) shouldBe false
         scheme.compare(reordered, LENIENT) shouldBe Matches
+        same.hashCode() shouldNotBe reordered.hashCode()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.dataframe.codeGen
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldBeEmpty
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
@@ -16,15 +17,21 @@ import org.jetbrains.kotlinx.dataframe.api.schema
 import org.jetbrains.kotlinx.dataframe.api.update
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.jetbrains.kotlinx.dataframe.impl.codeGen.ReplCodeGenerator
+import org.jetbrains.kotlinx.dataframe.impl.schema.DataFrameSchemaImpl
 import org.jetbrains.kotlinx.dataframe.io.readJsonStr
+import org.jetbrains.kotlinx.dataframe.schema.ColumnSchema
+import org.jetbrains.kotlinx.dataframe.schema.CompareResult
 import org.jetbrains.kotlinx.dataframe.schema.CompareResult.IsDerived
 import org.jetbrains.kotlinx.dataframe.schema.CompareResult.IsSuper
 import org.jetbrains.kotlinx.dataframe.schema.CompareResult.Matches
 import org.jetbrains.kotlinx.dataframe.schema.CompareResult.None
+import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.LENIENT
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT_FOR_NESTED_SCHEMAS
+import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 import org.junit.Test
+import kotlin.reflect.typeOf
 
 class MatchSchemeTests {
 
@@ -246,5 +253,135 @@ class MatchSchemeTests {
 
         typed.schema().compare(movedInFrameAndGroup.schema()).matches() shouldBe true
         (typed.schema() == movedInFrameAndGroup.schema()) shouldBe false
+    }
+
+    @Test
+    fun `column order inside a column group affects equality but not compare`() {
+        val scheme1 = dataFrameOf(
+            "group" to columnOf(
+                "a" to columnOf(1),
+                "b" to columnOf(2),
+            ),
+        ).schema()
+
+        val scheme2 = dataFrameOf(
+            "group" to columnOf(
+                "b" to columnOf(2),
+                "a" to columnOf(1),
+            ),
+        ).schema()
+
+        scheme1.compare(scheme2).matches() shouldBe true
+
+        (scheme1 == scheme2) shouldBe false
+
+        scheme1.hashCode() shouldNotBe scheme2.hashCode()
+    }
+
+    @Test
+    fun `equals is exact where compare is lenient`() {
+        val nullableScheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3, null),
+        ).schema()
+
+        val notNullScheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3, 4),
+        ).schema()
+
+        // compare is lenient about nullability, equals is not
+        nullableScheme.compare(notNullScheme, LENIENT) shouldBe IsSuper
+        notNullScheme.compare(nullableScheme, LENIENT) shouldBe IsDerived
+        (nullableScheme == notNullScheme) shouldBe false
+        (notNullScheme == nullableScheme) shouldBe false
+
+        // and a superset is never equal either
+        val superScheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3, 4),
+            "b" to columnOf(1.0, 2.0, 3.0, 4.0),
+        ).schema()
+
+        notNullScheme.compare(superScheme, LENIENT) shouldBe IsSuper
+        (notNullScheme == superScheme) shouldBe false
+        (superScheme == notNullScheme) shouldBe false
+    }
+
+    @Test
+    fun `equals of frame columns takes nullability into account`() {
+        val nestedScheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3),
+        ).schema()
+
+        val notNullScheme = DataFrameSchemaImpl(
+            mapOf("frame" to ColumnSchema.Frame(nestedScheme, nullable = false, contentType = null)),
+        )
+
+        val nullableScheme = DataFrameSchemaImpl(
+            mapOf("frame" to ColumnSchema.Frame(nestedScheme, nullable = true, contentType = null)),
+        )
+
+        (notNullScheme == nullableScheme) shouldBe false
+        (nullableScheme == notNullScheme) shouldBe false
+
+        notNullScheme.compare(nullableScheme, LENIENT) shouldBe IsDerived
+        nullableScheme.compare(notNullScheme, LENIENT) shouldBe IsSuper
+    }
+
+    @Test
+    fun `equals delegates to ColumnSchema equals`() {
+        val nestedScheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3),
+        ).schema()
+
+        val otherNestedScheme = dataFrameOf(
+            "b" to columnOf(1, 2, 3),
+        ).schema()
+
+        // for each column kind, equality of a single-column schema must follow equality of that ColumnSchema
+        val pairs = listOf(
+            ColumnSchema.Value(typeOf<Int>()) to ColumnSchema.Value(typeOf<Int?>()),
+            ColumnSchema.Group(nestedScheme, contentType = null) to
+                ColumnSchema.Group(otherNestedScheme, contentType = null),
+            ColumnSchema.Frame(nestedScheme, nullable = false, contentType = null) to
+                ColumnSchema.Frame(otherNestedScheme, nullable = false, contentType = null),
+        )
+
+        for ((col, otherCol) in pairs) {
+            (col == otherCol) shouldBe false
+            val schema = DataFrameSchemaImpl(mapOf("x" to col))
+            (schema == DataFrameSchemaImpl(mapOf("x" to col))) shouldBe true
+            (schema == DataFrameSchemaImpl(mapOf("x" to otherCol))) shouldBe false
+        }
+    }
+
+    @Test
+    fun `equals does not throw for other DataFrameSchema implementations`() {
+        val scheme = dataFrameOf(
+            "a" to columnOf(1, 2, 3),
+        ).schema()
+
+        fun foreignSchemaOf(columns: Map<String, ColumnSchema>) =
+            object : DataFrameSchema {
+                override val columns: Map<String, ColumnSchema> = columns
+
+                override fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode): CompareResult =
+                    throw UnsupportedOperationException("should not be called by equals")
+            }
+
+        (scheme == foreignSchemaOf(scheme.columns)) shouldBe true
+        (scheme == foreignSchemaOf(emptyMap())) shouldBe false
+    }
+
+    @Test
+    fun `equal schemas have equal hash codes`() {
+        val scheme = typed.schema()
+        val same = typed.schema()
+
+        (scheme == same) shouldBe true
+        scheme.hashCode() shouldBe same.hashCode()
+
+        val reordered = typed.move { pageInfo.resultsPerPage }.after { pageInfo.snippets }.schema()
+
+        (scheme == reordered) shouldBe false
+        scheme.compare(reordered, LENIENT) shouldBe Matches
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
@@ -257,7 +257,7 @@ class MatchSchemeTests {
     }
 
     @Test
-    fun `column order inside a column group affects equality but not compare`() {
+    fun `column order inside a column group affects equality but not compare matches`() {
         val scheme1 = dataFrameOf(
             "group" to columnOf(
                 "a" to columnOf(1),
@@ -330,5 +330,11 @@ class MatchSchemeTests {
         (scheme == reordered) shouldBe false
         scheme.compare(reordered, LENIENT) shouldBe Matches
         same.hashCode() shouldNotBe reordered.hashCode()
+
+        val reorderedSame = typed.move { pageInfo.resultsPerPage }.after { pageInfo.snippets }.schema()
+
+        (reorderedSame == reordered) shouldBe true
+        reorderedSame.compare(reordered, LENIENT) shouldBe Matches
+        reorderedSame.hashCode() shouldBe reordered.hashCode()
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/codeGen/MatchSchemeTests.kt
@@ -280,7 +280,7 @@ class MatchSchemeTests {
     }
 
     @Test
-    fun `equals is exact where compare is lenient`() {
+    fun `compare is lenient about nullability where equals is exact`() {
         val nullableScheme = dataFrameOf(
             "a" to columnOf(1, 2, 3, null),
         ).schema()
@@ -294,16 +294,6 @@ class MatchSchemeTests {
         notNullScheme.compare(nullableScheme, LENIENT) shouldBe IsDerived
         (nullableScheme == notNullScheme) shouldBe false
         (notNullScheme == nullableScheme) shouldBe false
-
-        // and a superset is never equal either
-        val superScheme = dataFrameOf(
-            "a" to columnOf(1, 2, 3, 4),
-            "b" to columnOf(1.0, 2.0, 3.0, 4.0),
-        ).schema()
-
-        notNullScheme.compare(superScheme, LENIENT) shouldBe IsSuper
-        (notNullScheme == superScheme) shouldBe false
-        (superScheme == notNullScheme) shouldBe false
     }
 
     @Test
@@ -325,51 +315,6 @@ class MatchSchemeTests {
 
         notNullScheme.compare(nullableScheme, LENIENT) shouldBe IsDerived
         nullableScheme.compare(notNullScheme, LENIENT) shouldBe IsSuper
-    }
-
-    @Test
-    fun `equals delegates to ColumnSchema equals`() {
-        val nestedScheme = dataFrameOf(
-            "a" to columnOf(1, 2, 3),
-        ).schema()
-
-        val otherNestedScheme = dataFrameOf(
-            "b" to columnOf(1, 2, 3),
-        ).schema()
-
-        // for each column kind, equality of a single-column schema must follow equality of that ColumnSchema
-        val pairs = listOf(
-            ColumnSchema.Value(typeOf<Int>()) to ColumnSchema.Value(typeOf<Int?>()),
-            ColumnSchema.Group(nestedScheme, contentType = null) to
-                ColumnSchema.Group(otherNestedScheme, contentType = null),
-            ColumnSchema.Frame(nestedScheme, nullable = false, contentType = null) to
-                ColumnSchema.Frame(otherNestedScheme, nullable = false, contentType = null),
-        )
-
-        for ((col, otherCol) in pairs) {
-            (col == otherCol) shouldBe false
-            val schema = DataFrameSchemaImpl(mapOf("x" to col))
-            (schema == DataFrameSchemaImpl(mapOf("x" to col))) shouldBe true
-            (schema == DataFrameSchemaImpl(mapOf("x" to otherCol))) shouldBe false
-        }
-    }
-
-    @Test
-    fun `equals does not throw for other DataFrameSchema implementations`() {
-        val scheme = dataFrameOf(
-            "a" to columnOf(1, 2, 3),
-        ).schema()
-
-        fun foreignSchemaOf(columns: Map<String, ColumnSchema>) =
-            object : DataFrameSchema {
-                override val columns: Map<String, ColumnSchema> = columns
-
-                override fun compare(other: DataFrameSchema, comparisonMode: ComparisonMode): CompareResult =
-                    throw UnsupportedOperationException("should not be called by equals")
-            }
-
-        (scheme == foreignSchemaOf(scheme.columns)) shouldBe true
-        (scheme == foreignSchemaOf(emptyMap())) shouldBe false
     }
 
     @Test


### PR DESCRIPTION
Now `DataFrameSchemaImpl.equals` is checked using `ColumnSchema.equals`.

Fixes #1717