### PR TITLE
Bumped KoDEx to 0.6.3 to include codespan aliases for Dokka

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"
 arrow = "19.0.0"
-kodex = "0.6.2"
+kodex = "0.6.3"
 caupain = "1.9.1"
 plugin-publish = "2.1.1"
 shadow = "9.5.1"


### PR DESCRIPTION
Fixes #2023 

by https://github.com/Jolanrensen/KoDEx/releases/tag/v0.6.3

See "[Generated sources will change, merging this PR](https://github.com/Kotlin/dataframe/commit/3485f2cfc006a50aa70d7acc3d55f5d0728ccf17)" below for a preview of the changes
