### PR TITLE
Add KDocs for public `reverse` APIs

### DIFF
--- a/KDOC_GUIDELINES.md
+++ b/KDOC_GUIDELINES.md
@@ -574,11 +574,6 @@ When using `@set` and `@get` / `$`, it's a good practice to use a reference as t
 This makes the KDoc more refactor-safe, and it makes it easier to understand which arguments
 need to be provided for a certain template.
 
-A `@set` value may span several lines, but the indentation of the continuation lines is kept
-verbatim in the processed KDoc. Keep continuation lines at the same indentation as the first line:
-a hanging indent of four or more spaces is read by Markdown as a code block, so the whole
-paragraph would silently render as monospace.
-
 A good example of this concept can be found in the
 [`AllColumnsSelectionDsl.CommonAllSubsetDocs` documentation interface](./core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt).
 This interface provides a template for all overloads of `allBefore`,

--- a/KDOC_GUIDELINES.md
+++ b/KDOC_GUIDELINES.md
@@ -498,6 +498,15 @@ private typealias Common~OperationName~Docs = Nothing
 public fun <T, C> DataFrame<T>.operation(columns: ColumnsSelector<T, C>)
 ```
 
+Keep in mind that `@param` and `@return` have to stay at the end of a KDoc.
+So when a template already ends with them, you cannot `@include` it and then append
+overload-specific text after the include — that text would land inside the template's `@return`.
+Everything that differs between the overloads has to be passed *into* the template as a `@set`
+argument instead. That is why a template shared by several sibling overloads usually has one
+argument per varying part (receiver type, "See also" section, type parameter description, and so on),
+like
+[`CommonTakeAndDropDocs`](./core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/CommonTakeAndDropDocs.kt).
+
 ### Grammar
 
 DSL Grammar (helpers usually are called simply `Grammar` and place inside the
@@ -564,6 +573,11 @@ internal interface CommonDoc {
 When using `@set` and `@get` / `$`, it's a good practice to use a reference as the key name.
 This makes the KDoc more refactor-safe, and it makes it easier to understand which arguments
 need to be provided for a certain template.
+
+A `@set` value may span several lines, but the indentation of the continuation lines is kept
+verbatim in the processed KDoc. Keep continuation lines at the same indentation as the first line:
+a hanging indent of four or more spaces is read by Markdown as a code block, so the whole
+paragraph would silently render as monospace.
 
 A good example of this concept can be found in the
 [`AllColumnsSelectionDsl.CommonAllSubsetDocs` documentation interface](./core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt).

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
@@ -48,13 +48,13 @@ internal interface CommonReverseDocs {
 
 /**
  * @include [CommonReverseDocs]
- * {@set [CommonReverseDocs.RECEIVER] [DataFrame]}
- * {@set [CommonReverseDocs.UNIT] row}
- * {@set [CommonReverseDocs.DETAILS] Only the order of the rows changes:
- * the columns, their names and types, and thus the schema of the dataframe stay the same.}
- * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle], which reorders rows randomly,
- * and [sortBy][DataFrame.sortBy], which orders rows by the values of the selected columns.}
- * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [DataFrame].}
+ * @set [CommonReverseDocs.RECEIVER] [DataFrame]
+ * @set [CommonReverseDocs.UNIT] row
+ * @set [CommonReverseDocs.DETAILS] Only the order of the rows changes:
+ * the columns, their names and types, and thus the schema of the dataframe stay the same.
+ * @set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle], which reorders rows randomly,
+ * and [sortBy][DataFrame.sortBy], which orders rows by the values of the selected columns.
+ * @set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [DataFrame].
  */
 public fun <T> DataFrame<T>.reverse(): DataFrame<T> = get(indices.reversed())
 
@@ -64,53 +64,53 @@ public fun <T> DataFrame<T>.reverse(): DataFrame<T> = get(indices.reversed())
 
 /**
  * @include [CommonReverseDocs]
- * {@set [CommonReverseDocs.RECEIVER] [DataColumn]}
- * {@set [CommonReverseDocs.UNIT] value}
- * {@set [CommonReverseDocs.DETAILS] The column keeps its name, type and [kind][ColumnKind]:
+ * @set [CommonReverseDocs.RECEIVER] [DataColumn]
+ * @set [CommonReverseDocs.UNIT] value
+ * @set [CommonReverseDocs.DETAILS] The column keeps its name, type, and [kind][ColumnKind]:
  * a value column stays a value column, a column group stays a column group,
  * and a frame column stays a frame column.
  * The result is typed as [DataColumn] though, so for a column group use
- * [asColumnGroup][DataColumn.asColumnGroup] to get [ColumnGroup] back.}
- * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
- * which reorders values randomly.}
- * {@set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [DataColumn].}
+ * [asColumnGroup][DataColumn.asColumnGroup] to get [ColumnGroup] back.
+ * @set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
+ * which reorders values randomly.
+ * @set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [DataColumn].
  */
 public fun <T> DataColumn<T>.reverse(): DataColumn<T> = get(indices.reversed())
 
 /**
  * @include [CommonReverseDocs]
- * {@set [CommonReverseDocs.RECEIVER] [ColumnGroup]}
- * {@set [CommonReverseDocs.UNIT] row}
- * {@set [CommonReverseDocs.DETAILS] The group keeps its name and its nested column structure.
+ * @set [CommonReverseDocs.RECEIVER] [ColumnGroup]
+ * @set [CommonReverseDocs.UNIT] row
+ * @set [CommonReverseDocs.DETAILS] The group keeps its name and its nested column structure.
  * Reversing is applied to the group as a whole, so the values in all nested columns
- * stay aligned row-wise.}
- * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle],
- * which reorders rows randomly.}
- * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [ColumnGroup].}
+ * stay aligned row-wise.
+ * @set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle],
+ * which reorders rows randomly.
+ * @set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [ColumnGroup].
  */
 public fun <T> ColumnGroup<T>.reverse(): ColumnGroup<T> = get(indices.reversed())
 
 /**
  * @include [CommonReverseDocs]
- * {@set [CommonReverseDocs.RECEIVER] [FrameColumn]}
- * {@set [CommonReverseDocs.UNIT] dataframe}
- * {@set [CommonReverseDocs.DETAILS] The column keeps its name and type.
+ * @set [CommonReverseDocs.RECEIVER] [FrameColumn]
+ * @set [CommonReverseDocs.UNIT] dataframe
+ * @set [CommonReverseDocs.DETAILS] The column keeps its name and type.
  * Only the order of the dataframes in it changes;
- * the rows inside each of them keep their original order.}
- * {@set [CommonReverseDocs.SEE_ALSO] See also [reverse][DataFrame.reverse],
- * which reverses the rows inside a single dataframe.}
- * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of the dataframes in this [FrameColumn].}
+ * the rows inside each of them keep their original order.
+ * @set [CommonReverseDocs.SEE_ALSO] See also [reverse][DataFrame.reverse],
+ * which reverses the rows inside a single dataframe.
+ * @set [CommonReverseDocs.TYPE_PARAM] The schema marker type of the dataframes in this [FrameColumn].
  */
 public fun <T> FrameColumn<T>.reverse(): FrameColumn<T> = get(indices.reversed())
 
 /**
  * @include [CommonReverseDocs]
- * {@set [CommonReverseDocs.RECEIVER] [ValueColumn]}
- * {@set [CommonReverseDocs.UNIT] value}
- * {@set [CommonReverseDocs.DETAILS] The column keeps its name and type.}
- * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
- * which reorders values randomly.}
- * {@set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [ValueColumn].}
+ * @set [CommonReverseDocs.RECEIVER] [ValueColumn]
+ * @set [CommonReverseDocs.UNIT] value
+ * @set [CommonReverseDocs.DETAILS] The column keeps its name and type.
+ * @set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
+ * which reorders values randomly.
+ * @set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [ValueColumn].
  */
 public fun <T> ValueColumn<T>.reverse(): ValueColumn<T> = get(indices.reversed()).asValueColumn()
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
@@ -3,17 +3,115 @@ package org.jetbrains.kotlinx.dataframe.api
 import org.jetbrains.kotlinx.dataframe.DataColumn
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
+import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
+import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
 import org.jetbrains.kotlinx.dataframe.impl.columns.asValueColumn
 import org.jetbrains.kotlinx.dataframe.indices
 
+/**
+ * {@comment Shared KDoc template for all `reverse` overloads. KDoc-snippet.}
+ * Returns a new {@get [RECEIVER]} with the same {@get [UNIT]}s in reversed order,
+ * so the last {@get [UNIT]} becomes the first one.
+ *
+ * {@get [DETAILS]}
+ *
+ * For more information: {@include [DocumentationUrls.Reverse]}
+ *
+ * {@get [SEE_ALSO]}
+ *
+ * @param [T\] {@get [TYPE_PARAM]}
+ * @return A new {@get [RECEIVER]} with the {@get [UNIT]}s in reversed order.
+ */
+@ExcludeFromSources
+internal interface CommonReverseDocs {
+
+    // Receiver type link, like "[DataFrame]"
+    typealias RECEIVER = Nothing
+
+    // The reordered unit, like "row" or "value"
+    typealias UNIT = Nothing
+
+    // Overload-specific paragraph about what exactly is (not) affected
+    typealias DETAILS = Nothing
+
+    // Overload-specific "See also" paragraph
+    typealias SEE_ALSO = Nothing
+
+    // Description of the [T] type parameter
+    typealias TYPE_PARAM = Nothing
+}
+
+// region DataFrame
+
+/**
+ * @include [CommonReverseDocs]
+ * {@set [CommonReverseDocs.RECEIVER] [DataFrame]}
+ * {@set [CommonReverseDocs.UNIT] row}
+ * {@set [CommonReverseDocs.DETAILS] Only the order of the rows changes:
+ * the columns, their names and types, and thus the schema of the dataframe stay the same.}
+ * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle], which reorders rows randomly,
+ * and [sortBy][DataFrame.sortBy], which orders rows by the values of the selected columns.}
+ * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [DataFrame].}
+ */
 public fun <T> DataFrame<T>.reverse(): DataFrame<T> = get(indices.reversed())
 
+// endregion
+
+// region DataColumn
+
+/**
+ * @include [CommonReverseDocs]
+ * {@set [CommonReverseDocs.RECEIVER] [DataColumn]}
+ * {@set [CommonReverseDocs.UNIT] value}
+ * {@set [CommonReverseDocs.DETAILS] The column keeps its name, type and [kind][ColumnKind]:
+ * a value column stays a value column, a column group stays a column group,
+ * and a frame column stays a frame column.
+ * The result is typed as [DataColumn] though, so for a column group use
+ * [asColumnGroup][DataColumn.asColumnGroup] to get [ColumnGroup] back.}
+ * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
+ * which reorders values randomly.}
+ * {@set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [DataColumn].}
+ */
 public fun <T> DataColumn<T>.reverse(): DataColumn<T> = get(indices.reversed())
 
+/**
+ * @include [CommonReverseDocs]
+ * {@set [CommonReverseDocs.RECEIVER] [ColumnGroup]}
+ * {@set [CommonReverseDocs.UNIT] row}
+ * {@set [CommonReverseDocs.DETAILS] The group keeps its name and its nested column structure.
+ * Reversing is applied to the group as a whole, so the values in all nested columns
+ * stay aligned row-wise.}
+ * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataFrame.shuffle],
+ * which reorders rows randomly.}
+ * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of this [ColumnGroup].}
+ */
 public fun <T> ColumnGroup<T>.reverse(): ColumnGroup<T> = get(indices.reversed())
 
+/**
+ * @include [CommonReverseDocs]
+ * {@set [CommonReverseDocs.RECEIVER] [FrameColumn]}
+ * {@set [CommonReverseDocs.UNIT] dataframe}
+ * {@set [CommonReverseDocs.DETAILS] The column keeps its name and type.
+ * Only the order of the dataframes in it changes;
+ * the rows inside each of them keep their original order.}
+ * {@set [CommonReverseDocs.SEE_ALSO] See also [reverse][DataFrame.reverse],
+ * which reverses the rows inside a single dataframe.}
+ * {@set [CommonReverseDocs.TYPE_PARAM] The schema marker type of the dataframes in this [FrameColumn].}
+ */
 public fun <T> FrameColumn<T>.reverse(): FrameColumn<T> = get(indices.reversed())
 
+/**
+ * @include [CommonReverseDocs]
+ * {@set [CommonReverseDocs.RECEIVER] [ValueColumn]}
+ * {@set [CommonReverseDocs.UNIT] value}
+ * {@set [CommonReverseDocs.DETAILS] The column keeps its name and type.}
+ * {@set [CommonReverseDocs.SEE_ALSO] See also [shuffle][DataColumn.shuffle],
+ * which reorders values randomly.}
+ * {@set [CommonReverseDocs.TYPE_PARAM] The type of the values in this [ValueColumn].}
+ */
 public fun <T> ValueColumn<T>.reverse(): ValueColumn<T> = get(indices.reversed()).asValueColumn()
+
+// endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
@@ -487,6 +487,9 @@ public interface DocumentationUrls {
     /** [See `shuffle` on the documentation website.]({@include [Url]}/shuffle.html) */
     public typealias Shuffle = Nothing
 
+    /** [See `reverse` on the documentation website.]({@include [Url]}/reverse.html) */
+    public typealias Reverse = Nothing
+
     /** [See `sortWith` on the documentation website.]({@include [Url]}/sortby.html#sortwith) */
     public typealias SortWith = Nothing
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/reverse.kt
@@ -1,7 +1,14 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
 import org.junit.Test
+import kotlin.reflect.typeOf
 
 class ReverseTests {
 
@@ -11,10 +18,64 @@ class ReverseTests {
         df.reverse() shouldBe dataFrameOf("a", "b")(3, 4, 1, 2)
     }
 
+    /** `reverse` on a [DataFrame] only changes the row order; the schema stays the same. */
+    @Test
+    fun `dataframe keeps schema and size`() {
+        val df = dataFrameOf("a", "b")(1, "x", 2, "y", 3, "z")
+        val reversed = df.reverse()
+
+        reversed.schema() shouldBe df.schema()
+        reversed.rowsCount() shouldBe df.rowsCount()
+    }
+
     @Test
     fun column() {
         val col by columnOf(1, 2, 3)
         col.reverse() shouldBe listOf(3, 2, 1).toColumn("col")
+    }
+
+    /** `reverse` on a [DataColumn] keeps the name and type of the column. */
+    @Test
+    fun `column keeps name and type`() {
+        val col by columnOf(1, 2, 3)
+        val reversed = col.reverse()
+
+        reversed.name() shouldBe col.name()
+        reversed.type() shouldBe col.type()
+        reversed.size() shouldBe col.size()
+    }
+
+    /**
+     * A column reversed through the [DataColumn] overload stays the same [ColumnKind] as before,
+     * even though the overload is typed to return a plain [DataColumn].
+     */
+    @Test
+    fun `column overload keeps the column kind`() {
+        val a by columnOf(1, 2)
+        // the DataColumn<*> types are load-bearing: they make the calls below resolve to the
+        // DataColumn overload instead of the ColumnGroup / FrameColumn / ValueColumn ones
+        val group: DataColumn<*> = columnOf(a).named("group")
+        val frame: DataColumn<*> = columnOf(dataFrameOf("a")(1), dataFrameOf("a")(2)).named("frame")
+        val value: DataColumn<*> = columnOf(1, 2).named("value")
+
+        group.reverse().kind() shouldBe ColumnKind.Group
+        frame.reverse().kind() shouldBe ColumnKind.Frame
+        value.reverse().kind() shouldBe ColumnKind.Value
+    }
+
+    /**
+     * A [ColumnGroup] is not a [DataColumn] subtype, so getting the group type back after the
+     * [DataColumn] overload requires [asColumnGroup].
+     */
+    @Test
+    fun `column group type can be restored after the column overload`() {
+        val a by columnOf(1, 2, 3)
+        val group: DataColumn<*> = columnOf(a).named("group")
+
+        val reversed: ColumnGroup<*> = group.reverse().asColumnGroup()
+
+        reversed.name() shouldBe "group"
+        reversed["a"].toList() shouldBe listOf(3, 2, 1)
     }
 
     @Test
@@ -23,5 +84,60 @@ class ReverseTests {
         val b by columnOf(3, 4)
         val col by columnOf(a, b)
         col.reverse() shouldBe columnOf(a.reverse(), b.reverse()).named("col")
+    }
+
+    /**
+     * `reverse` on a [ColumnGroup] reverses the group as a whole: the nested structure is unchanged
+     * and values in all nested columns stay aligned row-wise.
+     *
+     * Note that `columnOf(a, b)` is statically a [DataColumn], so a group has to be built explicitly
+     * for the [ColumnGroup] overload to be the one under test.
+     */
+    @Test
+    fun `column group reverses rows as a whole`() {
+        val group: ColumnGroup<*> =
+            DataColumn.createColumnGroup("group", dataFrameOf("a", "b")(1, "x", 2, "y", 3, "z"))
+        val reversed: ColumnGroup<*> = group.reverse()
+
+        // name and nested structure are unchanged
+        reversed.name() shouldBe group.name()
+        reversed.schema() shouldBe group.schema()
+
+        // values stay aligned row-wise: whole rows are reversed, not each column independently
+        // (a per-column shift would pair 3 with "x" instead of "z")
+        reversed.rows().map { it["a"] to it["b"] } shouldBe listOf(3 to "z", 2 to "y", 1 to "x")
+
+        // a ColumnGroup is a DataFrame, so this is the same row reversal as DataFrame.reverse
+        reversed shouldBe group.asDataFrame().reverse()
+    }
+
+    /**
+     * `reverse` on a [FrameColumn] only reverses the order of the frames;
+     * rows inside each frame keep their original order.
+     */
+    @Test
+    fun frameColumn() {
+        val df1 = dataFrameOf("a")(1, 2)
+        val df2 = dataFrameOf("a")(3, 4)
+        val col by columnOf(df1, df2)
+        val reversed = col.reverse()
+
+        // the frames swap places, but rows inside them are untouched:
+        // had they been reversed too, the frames would hold (4, 3) and (2, 1)
+        reversed shouldBe columnOf(df2, df1).named("col")
+    }
+
+    /** `reverse` on a [ValueColumn] returns a [ValueColumn], not a plain [DataColumn]. */
+    @Test
+    fun valueColumn() {
+        // columnOf() is statically a DataColumn, so the ValueColumn has to be built explicitly;
+        // the ValueColumn<Int> type below is the actual assertion — it is checked by the compiler
+        val col: ValueColumn<Int> = DataColumn.createValueColumn("col", listOf(1, 2, 3), typeOf<Int>())
+        val reversed: ValueColumn<Int> = col.reverse()
+
+        reversed.toList() shouldBe listOf(3, 2, 1)
+        reversed.kind() shouldBe ColumnKind.Value
+        reversed.name() shouldBe "col"
+        reversed.type() shouldBe col.type()
     }
 }


### PR DESCRIPTION
# Add KDocs for public `reverse` APIs

Closes #1980. All five public `reverse` overloads now have KDocs. No behavior changes.

## KDoc

- Added a shared KoDEx template `CommonReverseDocs` in `api/reverse.kt`. It holds the first
  line, the website link, `@param [T]` and `@return`. Each overload only sets its own parts
  (`RECEIVER`, `UNIT`, `DETAILS`, `SEE_ALSO`, `TYPE_PARAM`). Same pattern as `CommonTakeAndDropDocs`.
- Added `DocumentationUrls.Reverse` for the `reverse.html` link.
- The text describes the contract only — what you get back, not how it is done.

What each overload now states:

| Overload | Documented contract |
|---|---|
| `DataFrame` | Only row order changes. Columns, types and schema stay the same. |
| `DataColumn` | Name, type and kind stay the same. The result is typed as `DataColumn`, so for a column group you need `asColumnGroup()`. |
| `ColumnGroup` | Name and nested structure stay. Values in all nested columns stay aligned row-wise. |
| `FrameColumn` | Only the order of the dataframes changes. Rows inside each dataframe keep their order. |
| `ValueColumn` | Name and type stay the same. |

## Tests

3 tests -> 10. Every statement in the KDocs now has a test. The three old tests are unchanged.

**The old tests did not call the overloads one may expect.** `columnOf(a, b)` returns
`DataColumn<DataRow<*>>`, not `ColumnGroup`. `columnOf(1, 2, 3)` returns `DataColumn<Int>`, not
`ValueColumn`. So `ColumnGroup.reverse()` and `ValueColumn.reverse()` were never called by any
test. The new tests build these columns explicitly with `DataColumn.createColumnGroup()` and
`DataColumn.createValueColumn()`.

New tests:

- `dataframe keeps schema and size` — schema and row count.
- `column keeps name and type`.
- `column overload keeps the column kind` — a group stays `Group`, a frame stays `Frame`, a value
  stays `Value`. The `DataColumn<*>` types in this test are required: without them the calls go to
  the other overloads and the test would check something else.
- `column group type can be restored after the column overload` — `asColumnGroup()` round-trip.
  `ColumnGroup` is not a subtype of `DataColumn` (it extends `BaseColumn` and `DataFrame`), so this
  cast is the only way to get the group type back.
- `column group reverses rows as a whole` — real `ColumnGroup` receiver. It checks the name, the
  schema and the row pairs. It compares against explicit expected pairs and not against
  `DataFrame.reverse()`: comparing two implementations can pass while both are wrong.
- `frameColumn` — the frames swap places, rows inside them keep their order.
- `valueColumn` — the `ValueColumn<Int>` type of the result is the assertion here. The compiler
  checks it.

Note on assertions: column equality (`impl/columns/Utils.kt`) compares name, type and values. One
`shouldBe` on a whole column therefore already covers name and type. Separate `name()` / `type()`
asserts are used only where there is no whole-column comparison.

## KDoc guidelines

Two notes added to `KDOC_GUIDELINES.md`, both found while writing the template:

- A multi-line `@set` value keeps the indent of its continuation lines. An indent of 4+ spaces
  becomes a code block in Markdown, so the paragraph renders as monospace.
- `@param` and `@return` must stay at the end of a KDoc. Text cannot be added after `@include`, so
  all parts that differ between overloads must be passed in as `@set` arguments.
