### PR TITLE
Exposed GeoDataFrame geometry and CRS types to consumers

### DIFF
--- a/dataframe-geo-jupyter/build.gradle.kts
+++ b/dataframe-geo-jupyter/build.gradle.kts
@@ -19,15 +19,11 @@ repositories {
     mavenLocal()
 }
 
-// https://stackoverflow.com/questions/26993105/i-get-an-error-downloading-javax-media-jai-core1-1-3-from-maven-central
-// jai core dependency should be excluded from geotools dependencies and added separately
-fun ExternalModuleDependency.excludeJaiCore() = exclude("javax.media", "jai_core")
-
 dependencies {
+    // deliberately declares no GeoTools/JTS of its own: it resolves `GeoDataFrame.crs` purely through
+    // dataframe-geo's `api` scope, so this module fails to compile if those scopes are ever narrowed again (#1920)
     implementation(projects.dataframeGeo)
     implementation(projects.dataframeJupyter)
-
-    implementation(libs.geotools.referencing) { excludeJaiCore() }
 
     // logger, need it for geotools
     implementation(libs.log4j.core)

--- a/dataframe-geo/build.gradle.kts
+++ b/dataframe-geo/build.gradle.kts
@@ -33,17 +33,17 @@ dependencies {
     api(projects.core)
 
     // Geotools
-    implementation(libs.geotools.main) { excludeJaiCore() }
+    api(libs.geotools.main) { excludeJaiCore() }
     implementation(libs.geotools.shapefile) { excludeJaiCore() }
     implementation(libs.geotools.geojson) { excludeJaiCore() }
-    implementation(libs.geotools.referencing) { excludeJaiCore() }
+    api(libs.geotools.referencing) { excludeJaiCore() }
     implementation(libs.geotools.epsg.hsql) { excludeJaiCore() }
 
     // JAI
     implementation(libs.jai.core)
 
     // JTS
-    implementation(libs.jts.core)
+    api(libs.jts.core)
     implementation(libs.jts.io.common)
 
     // Ktor

--- a/dataframe-geo/build.gradle.kts
+++ b/dataframe-geo/build.gradle.kts
@@ -33,16 +33,24 @@ dependencies {
     api(projects.core)
 
     // Geotools
+    // `api` scope for everything whose types appear in our public API, so that consumers can use it
+    // without declaring GeoTools themselves (#1920):
+    //  - gt-api holds `CoordinateReferenceSystem` (GeoDataFrame.crs, applyCrs, DEFAULT_CRS, AnyFrame.toGeo)
+    //  - gt-main holds `ReferencedEnvelope` (bounds) and `SimpleFeatureCollection` (to/from SimpleFeatureCollection)
+    //  - gt-referencing holds `CRS`, which is not in our signatures but which consumers need to build a CRS at all
+    api(libs.geotools.api) { excludeJaiCore() }
     api(libs.geotools.main) { excludeJaiCore() }
+    api(libs.geotools.referencing) { excludeJaiCore() }
+    // used internally only; `implementation` still puts them on the consumer's runtime classpath
     implementation(libs.geotools.shapefile) { excludeJaiCore() }
     implementation(libs.geotools.geojson) { excludeJaiCore() }
-    api(libs.geotools.referencing) { excludeJaiCore() }
     implementation(libs.geotools.epsg.hsql) { excludeJaiCore() }
 
     // JAI
     implementation(libs.jai.core)
 
     // JTS
+    // `Geometry` and friends are the geometry model of WithGeometry and the jts/ helpers
     api(libs.jts.core)
     implementation(libs.jts.io.common)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,6 +167,7 @@ arrow-memory = { group = "org.apache.arrow", name = "arrow-memory-unsafe", versi
 arrow-c-data = { group = "org.apache.arrow", name = "arrow-c-data", version.ref = "arrow" }
 arrow-dataset = { group = "org.apache.arrow", name = "arrow-dataset", version.ref = "arrow" }
 
+geotools-api = { module = "org.geotools:gt-api", version.ref = "geotools" }
 geotools-main = { module = "org.geotools:gt-main", version.ref = "geotools" }
 geotools-shapefile = { module = "org.geotools:gt-shapefile", version.ref = "geotools" }
 geotools-geojson = { module = "org.geotools:gt-geojson", version.ref = "geotools" }


### PR DESCRIPTION
# Expose GeoDataFrame geometry and CRS types to consumers

Fixes #1920.

## Problem
`dataframe-geo` shows JTS and GeoTools types in its public API, but declares those libraries as
`implementation`. Gradle keeps `implementation` off the consumer's compile classpath, so a project that
adds only `dataframe-geo` cannot compile:

```
[MISSING_DEPENDENCY_CLASS] Cannot access class 'org.locationtech.jts.geom.Geometry'
[MISSING_DEPENDENCY_CLASS] Cannot access class 'org.geotools.api.referencing.crs.CoordinateReferenceSystem'
```

Reported in #1920, where the workaround is to re-declare JTS and GeoTools by hand.

## Fix

Move to `api` every artifact whose types appear in our public signatures, and nothing else.

```kt
api(libs.geotools.api) { excludeJaiCore() }         // new entry in libs.versions.toml
api(libs.geotools.main) { excludeJaiCore() }
api(libs.geotools.referencing) { excludeJaiCore() }
api(libs.jts.core)
```

## Why exactly these

We use GeoTools 33.5. Since GeoTools 30 the `org.geotools.api.*` interfaces live in their own artifact,
`org.geotools:gt-api`, so `CoordinateReferenceSystem` does **not** come from `gt-referencing`:

| Type in our public API | Artifact | Where it is used |
| --- | --- | --- |
| `org.geotools.api.referencing.crs.CoordinateReferenceSystem` | **gt-api** | `GeoDataFrame(df, crs)`, `GeoDataFrame.crs`, `applyCrs`, `DEFAULT_CRS`, `AnyFrame.toGeo(crs)` |
| `org.geotools.geometry.jts.ReferencedEnvelope` | **gt-main** | `GeoDataFrame<*>.bounds()` |
| `org.geotools.data.simple.SimpleFeatureCollection` | **gt-main** | `toSimpleFeatureCollection()`, `SimpleFeatureCollection.toGeoDataFrame()` |
| `org.locationtech.jts.geom.*` | **jts-core** | `WithGeometry.geometry` and all of `jts/` |

`gt-api` was reaching consumers only as a three-hop transitive
(`gt-main` → `gt-referencing` → `gt-metadata` → `gt-api`, every hop at `compile` scope). That does work,
so this part is hardening rather than a second bug fix. But it is not something we declare, and it is
fragile: `javax.media:jai_core`, which we already exclude, is a direct dependency of `gt-metadata` — the
very hop that carries `gt-api`. One more `exclude` on these lines, or a GeoTools upgrade that reroutes
`gt-metadata`, would bring #1920 back. So `gt-api` is now declared directly.

`gt-referencing` is a deliberate exception to the "declare what you expose" rule: its `CRS` class is not in
any of our signatures, but consumers need `CRS.decode("EPSG:…")` to build a CRS at all, and the notebook
integration already auto-imports it. Keeping it `api` is a convenience choice, and the comment in the build
file says so.

## Why the rest stay `implementation`

`gt-shapefile`, `gt-geojson`, `gt-epsg-hsql`, `jai-core`, `jts-io-common` and Ktor are used only inside our
own code. `implementation` still puts them in the POM at `runtime` scope, so consumers keep them at run
time — for example `gt-epsg-hsql`, which `CRS.decode` needs. #1920 suggests adding `jai-core` and
`jts-io-common` by hand, but that was a workaround, not a requirement: neither type appears in a signature.

All `excludeJaiCore()` calls are preserved.

## Regression guard

`dataframe-geo-jupyter` no longer declares `implementation(libs.geotools.referencing)`. That line existed
only so `geoDataFrame.crs?.name?.code` would resolve — the module had already hit #1920 inside our own repo
and worked around it with the wrong artifact.

Now this module has no GeoTools or JTS dependency of its own and compiles purely against what
`dataframe-geo` exports. If anyone narrows these scopes again, `:dataframe-geo-jupyter:compileKotlin`
fails. It already runs in CI, because `dataframe-jupyter` has `testImplementation(projects.dataframeGeoJupyter)`.

This is a build-configuration fix, so a unit test cannot cover it. A full "publish and compile a consumer
project" test would need Maven Local, the osgeo repository and network access on every build, which is too
much for a scope change — the compile-time guard above catches the same regression for free.

## Verification

1. **Which artifact holds which class** — opened the 33.5 jars: `CoordinateReferenceSystem` and
   `SimpleFeature` are in `gt-api-33.5.jar`; `ReferencedEnvelope`, `SimpleFeatureCollection` and `JTS` are in
   `gt-main-33.5.jar`; `CRS` is in `gt-referencing-33.5.jar`.
2. **The transitive chain** — read the POMs: `gt-main` → `gt-referencing` → `gt-metadata` → `gt-api`, every
   hop at `compile` scope, and `javax.media:jai_core` is a direct dependency of `gt-metadata`.
3. **In-repo guard** — `:dataframe-geo-jupyter:compileKotlin` is BUILD SUCCESSFUL with no GeoTools
   dependency declared in that module.
4. **Published POM** — `dataframe-core`, `gt-api`, `gt-main`, `gt-referencing`, `jts-core` and
   `kotlin-stdlib` at `compile`; `gt-shapefile`, `gt-geojson`, `gt-epsg-hsql`, `jai-core`, `jts-io-common`
   and the four Ktor artifacts at `runtime`.
5. **Downstream consumer, A/B** — a project whose only dependency is `org.jetbrains.kotlinx:dataframe-geo`
   (attached as a zip):
   - against `1.0.0-dev` from Maven Local it compiles **and runs**, printing the CRS, the bounds and the
     feature count; `CRS.decode("EPSG:4326")` works, so `runtime`-scoped dependencies still reach consumers;
   - against the released `1.0.0-Beta5` the same sources fail with 34 errors, including
     `Cannot access class 'org.locationtech.jts.geom.Envelope'` and
     `Cannot access class 'org.geotools.api.referencing.crs.CoordinateReferenceSystem'`. Beta5 uses the same
     `org.geotools.api.*` layout, so the difference is dependency scope only, not API drift.
6. **Resolution of gt-api** — `dependencyInsight` now shows `gt-api` coming directly from `dataframe-geo`,
   next to the old `gt-metadata` path.

Public Kotlin signatures did not change, so no `apiDump` is needed. Moving `implementation` → `api` only
widens what consumers see, so it is source- and binary-compatible.

## Out of scope

#1920 also mentions `kandy-geo`, which has the same problem in its own repository, and the setup section of
the Kandy geo-plotting guide. This PR fixes the `dataframe-geo` side only, so the issue should stay open.