### PR TITLE
Enable plugin evaluation of String API overloads

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -295,6 +295,12 @@ public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annot
 public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class org/jetbrains/kotlinx/dataframe/annotations/StringApiInterpretable : java/lang/annotation/Annotation {
+	public abstract fun interpreter ()Ljava/lang/String;
+	public abstract fun stringArgument ()Ljava/lang/String;
+	public abstract fun targetArgument ()Ljava/lang/String;
+}
+
 public abstract interface class org/jetbrains/kotlinx/dataframe/api/AddDataRow : org/jetbrains/kotlinx/dataframe/DataRow {
 	public abstract fun newValue (Lorg/jetbrains/kotlinx/dataframe/DataRow;)Ljava/lang/Object;
 }
@@ -6073,6 +6079,7 @@ public final class org/jetbrains/kotlinx/dataframe/io/DataFrameHtmlData$Companio
 
 public final class org/jetbrains/kotlinx/dataframe/io/DisplayConfiguration {
 	public static final field Companion Lorg/jetbrains/kotlinx/dataframe/io/DisplayConfiguration$Companion;
+	public fun <init> ()V
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/functions/Function3;Ljava/lang/String;ZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/functions/Function3;Ljava/lang/String;ZZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Ljava/lang/String;ZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/annotations/Plugin.kt
@@ -85,3 +85,18 @@ internal annotation class AccessApiOverload
  */
 @Target(AnnotationTarget.FUNCTION)
 public annotation class Converter(val klass: KClass<*>, val nullable: Boolean = false)
+
+/**
+ * Marks String API overloads (functions with vararg String parameters) with metadata
+ * to enable automatic delegation to their typed counterparts implementations in the compiler plugin.
+ * This annotation should not have default values for arguments (breaks plugin resolve).
+ * @param interpreter The interpreter name from the corresponding @Interpretable annotation
+ *                    on the typed API function (the one with ColumnSelectionDsl parameter)
+ * @param targetArgument The name of the ColumnSelectionDsl parameter in the typed API function
+ */
+@Target(AnnotationTarget.FUNCTION)
+public annotation class StringApiInterpretable(
+    val interpreter: String,
+    val stringArgument: String,
+    val targetArgument: String,
+)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/Nulls.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.api.Update.UPDATE_OPERATION
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -79,6 +80,7 @@ public fun <T, C> DataFrame<T>.fillNulls(columns: ColumnsSelector<T, C?>): Updat
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetFillNullsOperationArg]}
  * @include [Update.ColumnNamesParam]
  */
+@StringApiInterpretable(interpreter = "FillNulls0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.fillNulls(vararg columns: String): Update<T, Any?> = fillNulls { columns.toColumnSet() }
 
 /**
@@ -209,6 +211,7 @@ public fun <T, C> DataFrame<T>.fillNaNs(columns: ColumnsSelector<T, C>): Update<
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetFillNaNsOperationArg]}
  * @include [Update.ColumnNamesParam]
  */
+@StringApiInterpretable("FillNaNs0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.fillNaNs(vararg columns: String): Update<T, Any?> = fillNaNs { columns.toColumnSet() }
 
 /**
@@ -284,6 +287,7 @@ public fun <T, C> DataFrame<T>.fillNA(columns: ColumnsSelector<T, C?>): Update<T
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetFillNAOperationArg]}
  * @include [Update.ColumnNamesParam]
  */
+@StringApiInterpretable(interpreter = "FillNulls0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.fillNA(vararg columns: String): Update<T, Any?> = fillNA { columns.toColumnSet() }
 
 /**
@@ -419,6 +423,8 @@ public fun <T> DataFrame<T>.dropNulls(vararg columns: KProperty<*>, whereAllNull
  * @include [DropNulls.WhereAllNullParam]
  * @include [DropColumnNamesParam]
  */
+@Refine
+@StringApiInterpretable(interpreter = "DropNulls0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.dropNulls(vararg columns: String, whereAllNull: Boolean = false): DataFrame<T> =
     dropNulls(whereAllNull) { columns.toColumnSet() }
 
@@ -524,6 +530,8 @@ public fun <T> DataFrame<T>.dropNA(vararg columns: KProperty<*>, whereAllNA: Boo
  * @include [DropNA.WhereAllNAParam]
  * @include [DropColumnNamesParam]
  */
+@Refine
+@StringApiInterpretable(interpreter = "DropNa0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.dropNA(vararg columns: String, whereAllNA: Boolean = false): DataFrame<T> =
     dropNA(whereAllNA) { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/all.kt
@@ -407,6 +407,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
     public fun ColumnsSelectionDsl<*>.allAfter(column: ColumnPath): ColumnSet<*> = asSingleColumn().allColsAfter(column)
 
     /** @include [ColumnsSelectionDslAllAfterDocs] {@set [ColumnsSelectionDslAllAfterDocs.Arg] ("myColumn")} */
+    @Interpretable("AllAfterString")
     public fun ColumnsSelectionDsl<*>.allAfter(column: String): ColumnSet<*> = allAfter(pathOf(column))
 
     /** @include [ColumnsSelectionDslAllAfterDocs] {@set [ColumnsSelectionDslAllAfterDocs.Arg] (myColumn)} */
@@ -610,6 +611,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
         allFromInternal { it.path == column } as ColumnSet<C>
 
     /** @include [ColumnSetAllFromDocs] {@set [ColumnSetAllFromDocs.Arg] ("myColumn")} */
+    @Interpretable("AllFromString")
     public fun <C> ColumnSet<C>.allFrom(column: String): ColumnSet<C> = allFrom(pathOf(column))
 
     /** @include [ColumnSetAllFromDocs] {@set [ColumnSetAllFromDocs.Arg] (myColumn)} */
@@ -880,6 +882,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
         asSingleColumn().allColsBefore(column)
 
     /** @include [ColumnsSelectionDslAllBeforeDocs] {@set [ColumnsSelectionDslAllBeforeDocs.Arg] ("myColumn")} */
+    @Interpretable("AllBeforeString")
     public fun ColumnsSelectionDsl<*>.allBefore(column: String): ColumnSet<*> = allBefore(pathOf(column))
 
     /** @include [ColumnsSelectionDslAllBeforeDocs] {@set [ColumnsSelectionDslAllBeforeDocs.Arg] (myColumn)} */
@@ -1114,6 +1117,7 @@ public interface AllColumnsSelectionDsl<out _UNUSED> {
     public fun ColumnsSelectionDsl<*>.allUpTo(column: ColumnPath): ColumnSet<*> = asSingleColumn().allColsUpTo(column)
 
     /** @include [ColumnsSelectionDslAllUpToDocs] {@set [ColumnsSelectionDslAllUpToDocs.Arg] ("myColumn")} */
+    @Interpretable("AllUpToString")
     public fun ColumnsSelectionDsl<*>.allUpTo(column: String): ColumnSet<*> = asSingleColumn().allColsUpTo(column)
 
     /** @include [ColumnsSelectionDslAllUpToDocs] {@set [ColumnsSelectionDslAllUpToDocs.Arg] (myColumn)} */

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlinx.dataframe.annotations.Converter
 import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/convert.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.Converter
 import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.BaseColumn
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cumSum.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.api.Select.SelectSelectingOptions
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -134,6 +135,8 @@ public fun <T, C : Number?> DataFrame<T>.cumSum(
  * {@include [CumSumDocs]}
  * {@set [CumSumDocs.DATA_TYPE] [DataFrame]}
  */
+@Refine
+@StringApiInterpretable(interpreter = "DataFrameCumSum", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.cumSum(vararg columns: String, skipNA: Boolean = defaultCumSumSkipNA): DataFrame<T> =
     cumSum(skipNA) { columns.toColumnSet().cast() }
 
@@ -190,6 +193,8 @@ public fun <T, G, C : Number?> GroupBy<T, G>.cumSum(
  * {@include [CumSumDocs]}
  * {@set [CumSumDocs.DATA_TYPE] [GroupBy]}
  */
+@Refine
+@StringApiInterpretable("GroupByCumSum", stringArgument = "columns", targetArgument = "columns")
 public fun <T, G> GroupBy<T, G>.cumSum(vararg columns: String, skipNA: Boolean = defaultCumSumSkipNA): GroupBy<T, G> =
     cumSum(skipNA) { columns.toColumnSet().cast() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/distinct.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.api.DistinctDocs.DESCRIPTION
 import org.jetbrains.kotlinx.dataframe.api.DistinctDocs.DISTINCT_PARAM
 import org.jetbrains.kotlinx.dataframe.api.DistinctDocs.DISTINCT_RETURN
@@ -98,6 +99,8 @@ public fun <T> DataFrame<T>.distinct(vararg columns: KProperty<*>): DataFrame<T>
  * and to consider for evaluating distinct rows.
  * @set [DISTINCT_RETURN] A new [DataFrame] containing only selected columns and distinct rows.
  */
+@Refine
+@StringApiInterpretable(interpreter = "Distinct0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.distinct(vararg columns: String): DataFrame<T> = distinct { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/explode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/explode.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -136,6 +137,8 @@ public fun <T> DataFrame<T>.explode(
  * @include [ExplodeDocs.ReturnSnippet]
  * @include [ExplodeDocs.ThrowsSnippet]
  */
+@Refine
+@StringApiInterpretable(interpreter = "Explode0", stringArgument = "columns", targetArgument = "selector")
 public fun <T> DataFrame<T>.explode(vararg columns: String, dropEmpty: Boolean = true): DataFrame<T> =
     explode(dropEmpty) { columns.toColumnSet() }
 
@@ -228,6 +231,8 @@ public fun <T> DataRow<T>.explode(
  * @include [ExplodeDataRowDocs.ReturnSnippet]
  * @include [ExplodeDocs.ThrowsSnippet]
  */
+@Refine
+@StringApiInterpretable(interpreter = "ExplodeColumns", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataRow<T>.explode(vararg columns: String, dropEmpty: Boolean = true): DataFrame<T> =
     explode(dropEmpty) { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/flatten.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
@@ -77,6 +78,8 @@ public fun <T, C> DataFrame<T>.flatten(
  * {@include [FlattenDocs]}
  * {@set [FlattenDocs.GROUPS] selected}
  */
+@Refine
+@StringApiInterpretable(interpreter = "Flatten0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.flatten(
     vararg columns: String,
     keepParentNameForColumns: Boolean = false,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/gather.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.RowValueFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.api.GatherDocs.Grammar
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -145,6 +146,7 @@ public fun <T, C> DataFrame<T>.gather(selector: ColumnsSelector<T, C>): Gather<T
  * ```
  * @param [columns] The [Column Names][String] used to select the columns of this [DataFrame] to gather.
  */
+@StringApiInterpretable(interpreter = "Gather0", stringArgument = "columns", targetArgument = "selector")
 public fun <T> DataFrame<T>.gather(vararg columns: String): Gather<T, Any?, String, Any?> =
     gather { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/group.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -112,6 +113,7 @@ public fun <T, C> DataFrame<T>.group(columns: ColumnsSelector<T, C>): GroupClaus
  * ```
  * @param [columns\] The [Column Names][String] used to select the columns of this [DataFrame] to group.
  */
+@StringApiInterpretable(interpreter = "Group0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.group(vararg columns: String): GroupClause<T, Any?> = group { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelectionD
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.api.GroupByDocs.Grammar
 import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -397,6 +398,8 @@ public fun <T> DataFrame<T>.groupBy(vararg cols: KProperty<*>): GroupBy<T, T> = 
  * @return A new [GroupBy] containing the unique combinations of values from the provided [key columns][cols],
  * together with their corresponding groups of rows.
  */
+@Refine
+@StringApiInterpretable(interpreter = "DataFrameGroupBy", stringArgument = "cols", targetArgument = "cols")
 public fun <T> DataFrame<T>.groupBy(vararg cols: String): GroupBy<T, T> = groupBy { cols.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/implode.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/implode.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.implodeImpl
@@ -23,6 +24,8 @@ public fun <T> DataFrame<T>.implode(dropNA: Boolean = false): DataRow<T> = implo
 public fun <T, C> DataFrame<T>.implode(dropNA: Boolean = false, columns: ColumnsSelector<T, C>): DataFrame<T> =
     implodeImpl(dropNA, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Implode", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.implode(vararg columns: String, dropNA: Boolean = false): DataFrame<T> =
     implode(dropNA) { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/join.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/join.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnResolutionContext
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -141,6 +142,8 @@ private typealias JoinStringApiExample = Nothing
  * @param type [JoinType] defining how the resulting rows are constructed.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("Join0", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.join(
     other: DataFrame<B>,
     vararg columns: String,
@@ -193,6 +196,8 @@ public fun <A, B> DataFrame<A>.innerJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("InnerJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.innerJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     innerJoin(other) { columns.toColumnSet() }
 
@@ -242,6 +247,8 @@ public fun <A, B> DataFrame<A>.leftJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("LeftJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.leftJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     leftJoin(other) { columns.toColumnSet() }
 
@@ -291,6 +298,8 @@ public fun <A, B> DataFrame<A>.rightJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("RightJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.rightJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     rightJoin(other) { columns.toColumnSet() }
 
@@ -340,6 +349,8 @@ public fun <A, B> DataFrame<A>.fullJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("FullJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.fullJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     fullJoin(other) { columns.toColumnSet() }
 
@@ -389,6 +400,8 @@ public fun <A, B> DataFrame<A>.filterJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("FilterJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.filterJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     filterJoin(other) { columns.toColumnSet() }
 
@@ -438,6 +451,8 @@ public fun <A, B> DataFrame<A>.excludeJoin(
  * @param columns [Column Names][String] specifying join columns.
  * @return joined [DataFrame].
  */
+@Refine
+@StringApiInterpretable("ExcludeJoin", stringArgument = "columns", targetArgument = "selector")
 public fun <A, B> DataFrame<A>.excludeJoin(other: DataFrame<B>, vararg columns: String): DataFrame<A> =
     excludeJoin(other) { columns.toColumnSet() }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/max.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.CommonMinMaxDocs
@@ -484,6 +485,8 @@ public fun <T, C : Comparable<*>?> DataFrame<T>.maxFor(
  * @include [MaxDocs.SkipNaNParam]
  * @return A single [DataRow] with the maximum of each selected column.
  */
+@Refine
+@StringApiInterpretable(interpreter = "Max1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.maxFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
     maxFor(skipNaN) { columns.toComparableColumns() }
 
@@ -1052,6 +1055,8 @@ public fun <T, C : Comparable<*>?> Grouped<T>.maxFor(
  * @include [MaxDocs.SkipNaNParam]
  * @return A new [DataFrame] with the group keys and the maximum of each selected column per group.
  */
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMax0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.maxFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataFrame<T> =
     maxFor(skipNaN) { columns.toComparableColumns() }
 
@@ -1161,6 +1166,8 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.max(
  * @include [MaxDocs.SkipNaNParam]
  * @return A new [DataFrame] with the group keys and a single maximum per group.
  */
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMax2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.max(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/mean.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.toColumnsSetOf
@@ -72,6 +73,8 @@ public fun <T, C : Number?> DataFrame<T>.meanFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataRow<T> = Aggregators.mean(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Mean1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.meanFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
     meanFor(skipNaN) { columns.toNumberColumns() }
 
@@ -131,6 +134,8 @@ public fun <T, C : Number?> Grouped<T>.meanFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataFrame<T> = Aggregators.mean(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMean0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.meanFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataFrame<T> =
     meanFor(skipNaN) { columns.toNumberColumns() }
 
@@ -156,6 +161,8 @@ public fun <T, C : Number?> Grouped<T>.mean(
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = Aggregators.mean(skipNaN).aggregateAll(this, name, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMean2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.mean(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/median.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators
@@ -144,6 +145,8 @@ public fun <T, C : Comparable<*>?> DataFrame<T>.medianFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataRow<T> = Aggregators.median.invoke(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Median1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.medianFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
     medianFor(skipNaN) { columns.toComparableColumns() }
 
@@ -335,6 +338,8 @@ public fun <T, C : Comparable<*>?> Grouped<T>.medianFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataFrame<T> = Aggregators.median.invoke(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMedian0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.medianFor(vararg columns: String): DataFrame<T> = medianFor { columns.toComparableColumns() }
 
 @Deprecated(DEPRECATED_ACCESS_API)
@@ -359,6 +364,8 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.median(
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = Aggregators.medianCommon<C>(skipNaN).aggregateAll(this, name, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMedian2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.median(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/merge.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -23,6 +24,7 @@ import kotlin.reflect.typeOf
 public fun <T, C> DataFrame<T>.merge(selector: ColumnsSelector<T, C>): Merge<T, C, List<C>> =
     Merge(this, selector, false, { it }, typeOf<Any?>(), Infer.Type)
 
+@StringApiInterpretable(interpreter = "Merge0", stringArgument = "columns", targetArgument = "selector")
 public fun <T> DataFrame<T>.merge(vararg columns: String): Merge<T, Any?, List<Any?>> = merge { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/min.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.CommonMinMaxDocs
@@ -484,6 +485,8 @@ public fun <T, C : Comparable<*>?> DataFrame<T>.minFor(
  * @include [MinDocs.SkipNaNParam]
  * @return A single [DataRow] with the minimum of each selected column.
  */
+@Refine
+@StringApiInterpretable(interpreter = "Min1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.minFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
     minFor(skipNaN) { columns.toComparableColumns() }
 
@@ -1052,6 +1055,8 @@ public fun <T, C : Comparable<*>?> Grouped<T>.minFor(
  * @include [MinDocs.SkipNaNParam]
  * @return A new [DataFrame] with the group keys and the minimum of each selected column per group.
  */
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMin0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.minFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataFrame<T> =
     minFor(skipNaN) { columns.toComparableColumns() }
 
@@ -1161,6 +1166,8 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.min(
  * @include [MinDocs.SkipNaNParam]
  * @return A new [DataFrame] with the group keys and a single minimum per group.
  */
+@Refine
+@StringApiInterpretable(interpreter = "GroupByMin2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.min(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/move.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -134,6 +135,7 @@ public fun <T, C> DataFrame<T>.move(columns: ColumnsSelector<T, C>): MoveClause<
  * ```
  * @param [columns\] The [Column Names][String] used to select the columns of this [DataFrame] to move.
  */
+@StringApiInterpretable(interpreter = "Move0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.move(vararg columns: String): MoveClause<T, Any?> = move { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)
@@ -209,6 +211,8 @@ public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, columns: ColumnsSelector
  * where the selected columns will be moved.
  * @param [columns\] The [Columns Selector][ColumnsSelector] used to select the columns of this [DataFrame] to move.
  */
+@Refine
+@StringApiInterpretable(interpreter = "MoveTo1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.moveTo(newColumnIndex: Int, vararg columns: String): DataFrame<T> =
     moveTo(newColumnIndex) { columns.toColumnSet() }
 
@@ -314,6 +318,8 @@ public fun <T> DataFrame<T>.moveToLeft(vararg columns: String): DataFrame<T> = m
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetMoveToStartOperationArg]}
  * @param [columns\] The [Columns Selector][ColumnsSelector] used to select the columns of this [DataFrame] to move.
  */
+@Refine
+@StringApiInterpretable(interpreter = "MoveToStart1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.moveToStart(vararg columns: String): DataFrame<T> = moveToStart { columns.toColumnSet() }
 
 @Deprecated(MOVE_TO_LEFT, ReplaceWith(MOVE_TO_LEFT_REPLACE), DeprecationLevel.ERROR)
@@ -401,6 +407,8 @@ public fun <T> DataFrame<T>.moveToRight(vararg columns: String): DataFrame<T> = 
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetMoveToEndOperationArg]}
  * @param [columns\] The [Columns Selector][ColumnsSelector] used to select the columns of this [DataFrame] to move.
  */
+@Refine
+@StringApiInterpretable(interpreter = "MoveToEnd1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.moveToEnd(vararg columns: String): DataFrame<T> = moveToEnd { columns.toColumnSet() }
 
 @Deprecated(MOVE_TO_RIGHT, ReplaceWith(MOVE_TO_RIGHT_REPLACE), DeprecationLevel.ERROR)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
-import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/parse.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/percentile.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.aggregation.aggregators.Aggregators
@@ -159,6 +160,8 @@ public fun <T, C : Comparable<*>?> DataFrame<T>.percentileFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataRow<T> = Aggregators.percentile.invoke(percentile, skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Percentile1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.percentileFor(
     percentile: Double,
     vararg columns: String,
@@ -400,6 +403,8 @@ public fun <T, C : Comparable<*>?> Grouped<T>.percentileFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataFrame<T> = Aggregators.percentile.invoke(percentile, skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByPercentile0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.percentileFor(percentile: Double, vararg columns: String): DataFrame<T> =
     percentileFor(percentile) { columns.toComparableColumns() }
 
@@ -428,6 +433,8 @@ public fun <T, C : Comparable<C & Any>?> Grouped<T>.percentile(
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = Aggregators.percentileCommon<C>(percentile, skipNaN).aggregateAll(this, name, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByPercentile2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.percentile(
     percentile: Double,
     vararg columns: String,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/remove.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/remove.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
@@ -60,6 +61,8 @@ public fun <T> DataFrame<T>.remove(columns: ColumnsSelector<T, *>): DataFrame<T>
  * @include [SelectingColumns.ColumnNamesApi.ColumnNamesApiWithExample] {@include [SetRemoveOperationArg]}
  * @param [columns] The [Column Names][String] used to remove the columns of this [DataFrame].
  */
+@Refine
+@StringApiInterpretable(interpreter = "Remove0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.remove(vararg columns: String): DataFrame<T> = remove { columns.toColumnSet() }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/rename.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.HasSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
@@ -161,6 +162,7 @@ public fun <T, C> DataFrame<T>.rename(vararg cols: KProperty<C>): RenameClause<T
  * ```
  * @param [columns\] The [Columns Names][String] used to select the columns of this [DataFrame] to group.
  */
+@StringApiInterpretable(interpreter = "Rename", stringArgument = "cols", targetArgument = "columns")
 public fun <T> DataFrame<T>.rename(vararg cols: String): RenameClause<T, Any?> = rename { cols.toColumnSet() }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reorder.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/reorder.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.Selector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.reorderImpl
@@ -36,6 +37,7 @@ public fun <T, C> DataFrame<T>.reorder(vararg columns: ColumnReference<C>): Reor
 @AccessApiOverload
 public fun <T, C> DataFrame<T>.reorder(vararg columns: KProperty<C>): Reorder<T, C> = reorder { columns.toColumnSet() }
 
+@StringApiInterpretable(interpreter = "Reorder", stringArgument = "columns", targetArgument = "selector")
 public fun <T> DataFrame<T>.reorder(vararg columns: String): Reorder<T, *> = reorder { columns.toColumnSet() }
 
 public fun <T, C, V : Comparable<V>> Reorder<T, C>.by(expression: ColumnExpression<C, V>): DataFrame<T> =

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
@@ -83,6 +84,7 @@ public fun <T> DataFrame<T>.select(vararg columns: KProperty<*>): DataFrame<T> =
  */
 @Refine
 @Interpretable("SelectString")
+@StringApiInterpretable(interpreter = "Select0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.select(vararg columns: String): DataFrame<T> = select { columns.toColumnSet() }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/select.kt
@@ -84,7 +84,6 @@ public fun <T> DataFrame<T>.select(vararg columns: KProperty<*>): DataFrame<T> =
  */
 @Refine
 @Interpretable("SelectString")
-@StringApiInterpretable(interpreter = "Select0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.select(vararg columns: String): DataFrame<T> = select { columns.toColumnSet() }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/split.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.ColumnSet
@@ -30,6 +31,7 @@ import kotlin.reflect.typeOf
 @Interpretable("Split0")
 public fun <T, C> DataFrame<T>.split(columns: ColumnsSelector<T, C?>): Split<T, C> = Split(this, columns)
 
+@StringApiInterpretable(interpreter = "Split0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.split(vararg columns: String): Split<T, Any> = split { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/std.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.toColumnsSetOf
@@ -77,6 +78,8 @@ public fun <T, C : Number?> DataFrame<T>.stdFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataRow<T> = Aggregators.std(skipNaN, ddof).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Std1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.stdFor(
     vararg columns: String,
     skipNaN: Boolean = skipNaNDefault,
@@ -135,6 +138,8 @@ public fun <T, C : Number?> Grouped<T>.stdFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataFrame<T> = Aggregators.std(skipNaN, ddof).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByStd0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.stdFor(
     vararg columns: String,
     skipNaN: Boolean = skipNaNDefault,
@@ -175,6 +180,8 @@ public fun <T, C : Number?> Grouped<T>.std(
     ddof: Int = ddofDefault,
 ): DataFrame<T> = std(name, skipNaN, ddof) { columns.toColumnSet() }
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupByStd2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.std(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/sum.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dataframe.aggregation.ColumnsForAggregateSelector
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.columns.toColumnsSetOf
@@ -137,6 +138,8 @@ public fun <T, C : Number?> DataFrame<T>.sumFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataRow<T> = Aggregators.sum(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "Sum1", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.sumFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataRow<T> =
     sumFor(skipNaN) { columns.toColumnsSetOf() }
 
@@ -244,6 +247,8 @@ public fun <T, C : Number?> Grouped<T>.sumFor(
     columns: ColumnsForAggregateSelector<T, C>,
 ): DataFrame<T> = Aggregators.sum(skipNaN).aggregateFor(this, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupBySum0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.sumFor(vararg columns: String, skipNaN: Boolean = skipNaNDefault): DataFrame<T> =
     sumFor(skipNaN) { columns.toNumberColumns() }
 
@@ -269,6 +274,8 @@ public fun <T, C : Number?> Grouped<T>.sum(
     columns: ColumnsSelector<T, C>,
 ): DataFrame<T> = Aggregators.sum(skipNaN).aggregateAll(this, name, columns)
 
+@Refine
+@StringApiInterpretable(interpreter = "GroupBySum2", stringArgument = "columns", targetArgument = "columns")
 public fun <T> Grouped<T>.sum(
     vararg columns: String,
     name: String? = null,

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/unfold.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.impl.api.unfoldImpl
 import org.jetbrains.kotlinx.dataframe.util.DEPRECATED_ACCESS_API
@@ -26,6 +27,8 @@ public fun <T> DataFrame<T>.unfold(
     columns: ColumnsSelector<T, *>,
 ): DataFrame<T> = replace(columns).with { it.unfoldImpl(it.type()) { properties(roots = roots, maxDepth) } }
 
+@Refine
+@StringApiInterpretable(interpreter = "DataFrameUnfold", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.unfold(vararg columns: String): DataFrame<T> = unfold { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ungroup.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ungroup.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnWithPath
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -89,6 +90,8 @@ public fun <T, C> DataFrame<T>.ungroup(columns: ColumnsSelector<T, C>): DataFram
  * @return A new [DataFrame] with ungrouped columns.
  * @throws IllegalArgumentException if the specified columns are not a [ColumnGroup].
  */
+@Refine
+@StringApiInterpretable(interpreter = "Ungroup0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.ungroup(vararg columns: String): DataFrame<T> = ungroup { columns.toColumnSet() }
 
 @Deprecated(DEPRECATED_ACCESS_API)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/update.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlinx.dataframe.RowValueFilter
 import org.jetbrains.kotlinx.dataframe.annotations.AccessApiOverload
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
@@ -173,6 +174,7 @@ public fun <T, C> DataFrame<T>.update(columns: ColumnsSelector<T, C>): Update<T,
  * @include [UpdateWithNote]
  * @include [Update.ColumnNamesParam]
  */
+@StringApiInterpretable(interpreter = "Update0", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.update(vararg columns: String): Update<T, Any?> = update { columns.toColumnSet() }
 
 /**

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/valueCounts.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.annotations.Interpretable
 import org.jetbrains.kotlinx.dataframe.annotations.Refine
 import org.jetbrains.kotlinx.dataframe.annotations.RequiredByIntellijPlugin
+import org.jetbrains.kotlinx.dataframe.annotations.StringApiInterpretable
 import org.jetbrains.kotlinx.dataframe.columns.toColumnSet
 import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
 import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
@@ -217,6 +218,8 @@ public fun <T> DataFrame<T>.valueCounts(
  * @include [ValueCountsParams]
  * @return A [DataFrame] with the distinct value combinations and their counts.
  */
+@Refine
+@StringApiInterpretable(interpreter = "ValueCounts", stringArgument = "columns", targetArgument = "columns")
 public fun <T> DataFrame<T>.valueCounts(
     vararg columns: String,
     sort: Boolean = true,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ junit = "4.13.2" # Issue #426
 junit-jupiter = "5.11.3"
 # ignoreUpdates
 junit-platform = "1.11.3" # Issue #426
+konsist = "0.17.3"
 kotestAsserions = "6.2.2"
 
 jsoup = "1.22.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinJupyter = "0.19.0-951"
 ktlint-gradle = "14.2.0"
 ktlint = "1.8.0"
 
-kotlin = "2.4.0"
+kotlin = "2.4.20-RC2"
 kotlinpoet = "2.3.0"
 
 # The jvmToolchain version. Gradle should run with this JDK version.
@@ -158,6 +158,7 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 junit-platform-runner = { group = "org.junit.platform", name = "junit-platform-runner", version.ref = "junit-platform" }
 junit-platform-suite-api = { group = "org.junit.platform", name = "junit-platform-suite-api", version.ref = "junit-platform" }
 
+konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 kotestAssertions = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotestAsserions" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 

--- a/plugins/expressions-converter/src/org/jetbrains/kotlinx/dataframe/ExplainerIrTransformer.kt
+++ b/plugins/expressions-converter/src/org/jetbrains/kotlinx/dataframe/ExplainerIrTransformer.kt
@@ -181,7 +181,7 @@ public class ExplainerIrTransformer(public val pluginContext: IrPluginContext) :
         receiver: IrExpression?,
         data: ContainingDeclarations,
     ): IrCall {
-        val result = irCall(alsoReference).also {
+        val result = irCall(alsoReference, expression.type).also {
             it.typeArguments[0] = expression.type
             it.arguments[0] = expression
 

--- a/plugins/expressions-converter/tests/org/jetbrains/kotlinx/dataframe/AbstractExplainerBlackBoxCodegenTest.kt
+++ b/plugins/expressions-converter/tests/org/jetbrains/kotlinx/dataframe/AbstractExplainerBlackBoxCodegenTest.kt
@@ -41,7 +41,7 @@ open class AbstractExplainerBlackBoxCodegenTest : AbstractFirLightTreeBlackBoxCo
             commonFirWithPluginFrontendConfiguration()
             useConfigurators(::PluginAnnotationsProvider)
             useCustomRuntimeClasspathProviders(::MyClasspathProvider)
-            useAfterAnalysisCheckers(::BlackBoxCodegenSuppressor)
+            useFailureSuppressors(::BlackBoxCodegenSuppressor)
             useAdditionalService<TemporaryDirectoryManager>(::TemporaryDirectoryManagerImplFixed)
         }
     }

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     testImplementation(libs.kandy.samples.utils) {
         exclude("org.jetbrains.kotlinx", "dataframe")
     }
+    testImplementation(libs.konsist)
     testImplementation(libs.kotlin.datetimeJvm)
     testImplementation(libs.poi)
     testImplementation(libs.arrow.vector)
@@ -177,6 +178,7 @@ korro {
 }
 
 tasks.test {
+    maxHeapSize = "4g"
     jvmArgs = listOf("--add-opens", "java.base/java.nio=ALL-UNNAMED")
 }
 

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/lint.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/lint.kt
@@ -1,0 +1,257 @@
+package org.jetbrains.kotlinx.dataframe
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import io.kotest.assertions.asClue
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.add
+import org.jetbrains.kotlinx.dataframe.api.at
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.convert
+import org.jetbrains.kotlinx.dataframe.api.count
+import org.jetbrains.kotlinx.dataframe.api.distinct
+import org.jetbrains.kotlinx.dataframe.api.dropNulls
+import org.jetbrains.kotlinx.dataframe.api.explode
+import org.jetbrains.kotlinx.dataframe.api.expr
+import org.jetbrains.kotlinx.dataframe.api.fillNulls
+import org.jetbrains.kotlinx.dataframe.api.filter
+import org.jetbrains.kotlinx.dataframe.api.gather
+import org.jetbrains.kotlinx.dataframe.api.group
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.innerJoin
+import org.jetbrains.kotlinx.dataframe.api.insert
+import org.jetbrains.kotlinx.dataframe.api.into
+import org.jetbrains.kotlinx.dataframe.api.inward
+import org.jetbrains.kotlinx.dataframe.api.leftJoin
+import org.jetbrains.kotlinx.dataframe.api.print
+import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.sortBy
+import org.jetbrains.kotlinx.dataframe.api.sortByCount
+import org.jetbrains.kotlinx.dataframe.api.split
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.api.valuesInto
+import org.jetbrains.kotlinx.dataframe.api.with
+import org.junit.Ignore
+import org.junit.Test
+
+@Ignore
+class TestStringApiInterpretableConsistency {
+    private fun dataFrameApi(): DataFrame<DataFrameApi> {
+        val scope = Konsist.scopeFromDirectories(listOf("core"))
+            .functions()
+            .filter { !it.path.contains("generated") }
+
+        return scope.toDataFrame()
+            .filter { it.hasPublicModifier }
+            .filter { !annotations.any { it.name in setOf("Deprecated", "AccessApiOverload") } }
+            .select {
+                cols(
+                    receiverType,
+                    name,
+                    parameters,
+                    returnType,
+                    annotations,
+                    projectPath,
+                    isTopLevel,
+                    typeParameters,
+                )
+            }
+            .convert { projectPath }.with { it.removePrefix("projectPath: ") }
+            .cast<DataFrameApi>()
+    }
+
+    @DataSchema
+    data class DataFrameApi(
+        val receiverType: KoTypeDeclaration?,
+        val name: String,
+        val parameters: List<KoParameterDeclaration>,
+        val returnType: KoTypeDeclaration?,
+        val annotations: List<KoAnnotationDeclaration>,
+        val projectPath: String,
+        val isTopLevel: Boolean,
+        val typeParameters: List<KoTypeParameterDeclaration>,
+    )
+
+    private fun DataFrame<DataFrameApi>.interpretableFunctions(): DataFrame<InterpretableFunctions> =
+        select {
+            annotations and receiverType and name and parameters and returnType
+        }
+            .filter { annotations.any { it.name == "Interpretable" } }
+            .insert("interpreter") {
+                annotations
+                    .single { it.name == "Interpretable" }
+                    .arguments.single().value
+            }.at(0)
+            .cast<InterpretableFunctions>()
+
+    @DataSchema
+    data class InterpretableFunctions(
+        val interpreter: String?,
+        val annotations: List<KoAnnotationDeclaration>,
+        val receiverType: KoTypeDeclaration?,
+        val name: String,
+        val parameters: List<KoParameterDeclaration>,
+        val returnType: KoTypeDeclaration?,
+    )
+
+    private fun DataFrame<DataFrameApi>.stringApiFunctions(): DataFrame<StringApiFunctions> =
+        insert("annotationArguments") {
+            annotations.singleOrNull { it.name == "StringApiInterpretable" }
+                ?.arguments?.map { it.value }
+        }.at(0)
+            .dropNulls { annotationArguments }
+            .cast<StringApiFunctions>()
+
+    @DataSchema
+    data class StringApiFunctions(
+        val annotationArguments: List<String?>,
+        val receiverType: KoTypeDeclaration?,
+        val name: String,
+        val parameters: List<KoParameterDeclaration>,
+        val returnType: KoTypeDeclaration?,
+        val annotations: List<KoAnnotationDeclaration>,
+        val projectPath: String,
+        val isTopLevel: Boolean,
+        val typeParameters: List<KoTypeParameterDeclaration>,
+    )
+
+    @Test
+    fun `check all StringApiInterpretable match string API overload parameter to valid CS DSL parameter`() {
+        val dataFrameApi = dataFrameApi()
+        val csDslInterpretable = dataFrameApi.interpretableFunctions()
+            .filter {
+                parameters.any {
+                    it.type.name.contains("ColumnsSelector") ||
+                        it.type.name.contains("ColumnsForAggregateSelector") ||
+                        it.type.name.contains("ColumnSelector")
+                }
+            }
+
+        val stringOverloads = dataFrameApi
+            .select { annotations and name and parameters }
+            .cast<DataFrameApi>(verify = false)
+            .stringApiFunctions()
+            .split { annotationArguments }.inward("delegateInterpreter", "stringArgument", "targetArgument")
+            .rename { annotationArguments }.into("adapter")
+
+        val ignore = setOf(
+            "Parse", // own interpreter
+            "Convert0", // own interpreter
+            "DataFrameXs", // no String overload at all
+            "GroupByXs", // no String overload at all
+            "NestedSelect", // no String overload
+            "StringSelect", // no String overload
+            "ColumnPathSelect", // no String overload
+        )
+
+        val stringApiGroup = stringOverloads.group { all() }.into("stringOverload")
+        val remainingInconsistentApis = csDslInterpretable
+            .leftJoin(stringApiGroup) { interpreter.match(right.stringOverload.adapter.delegateInterpreter) }
+            // Default value
+            .fillNulls { stringOverload.adapter.targetArgument }.with { stringOverload.adapter.stringArgument }
+            .also { println(it.size()) }
+            // any invalid mapping?
+            .filter {
+                val parametersOfCslDslOverload = parameters.map { it.name }
+                stringOverload.adapter.targetArgument !in parametersOfCslDslOverload
+            }
+            .filter { interpreter !in ignore }
+
+        remainingInconsistentApis.asClue {
+            remainingInconsistentApis.rowsCount() shouldBe 0
+        }
+    }
+
+    @Test
+    fun `print Interpretable function headers with String API overloads`() {
+        val dataFrameApi = dataFrameApi()
+        val csDslHeaders = dataFrameApi.interpretableFunctions()
+            .add("csDslHeader") {
+                buildString {
+                    receiverType?.name?.let { append("$it.") }
+                    append(name)
+                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
+                    returnType?.name?.let { append(": $it") }
+                }
+            }
+            .select { interpreter and csDslHeader }
+
+        val stringApiHeaders = dataFrameApi.stringApiFunctions()
+            .add("interpreter") {
+                annotations
+                    .single { it.name == "StringApiInterpretable" }
+                    .arguments
+                    .first()
+                    .value
+            }
+            .add("stringApiHeader") {
+                buildString {
+                    receiverType?.name?.let { append("$it.") }
+                    append(name)
+                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
+                    returnType?.name?.let { append(": $it") }
+                }
+            }
+            .select { interpreter and stringApiHeader }
+
+        csDslHeaders
+            .innerJoin(stringApiHeaders) { interpreter }
+            .sortBy { interpreter }
+            .gather { all() }
+            .valuesInto("Interpretable ID / CS DSL header / String API header")
+            .print(rowsLimit = 1000, valueLimit = 1000, rowIndex = false, columnTypes = false, alignLeft = true)
+    }
+
+    @Test
+    fun `print StringApiInterpretable functions without Refine when CS DSL has it`() {
+        val dataFrameApi = dataFrameApi()
+        val csDslInterpretersWithRefine = dataFrameApi.interpretableFunctions()
+            .filter { annotations.any { it.name == "Refine" } }
+            .select { interpreter }
+            .distinct()
+
+        dataFrameApi.stringApiFunctions()
+            .filter { annotations.none { it.name == "Refine" } }
+            .add("interpreter") {
+                annotations
+                    .single { it.name == "StringApiInterpretable" }
+                    .arguments
+                    .first()
+                    .value
+            }
+            .innerJoin(csDslInterpretersWithRefine) { interpreter }
+            .add("stringApiHeader") {
+                buildString {
+                    receiverType?.name?.let { append("$it.") }
+                    append(name)
+                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
+                    returnType?.name?.let { append(": $it") }
+                }
+            }
+            .select { interpreter and stringApiHeader }
+            .sortBy { interpreter }
+            .print(rowsLimit = 1000, valueLimit = 1000, rowIndex = false, columnTypes = false, alignLeft = true)
+    }
+
+    @Test
+    fun print() {
+        val dataFrameApi = dataFrameApi()
+        val trueInterpretable = dataFrameApi.interpretableFunctions()
+        trueInterpretable
+            .convert { parameters }.with { it.map { it.type.name } }
+            .explode { parameters into "parameterName" }
+            .groupBy { parameterName }.sortByCount().count()
+            .sortBy {
+                expr {
+                    parameterName.contains("ColumnsSelector") ||
+                        parameterName.contains("ColumnsForAggregateSelector")
+                }.desc()
+            }
+            .print(rowsLimit = 1000)
+    }
+}

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/lint.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/lint.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.api.sortBy
 import org.jetbrains.kotlinx.dataframe.api.sortByCount
 import org.jetbrains.kotlinx.dataframe.api.split
+import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.api.valuesInto
 import org.jetbrains.kotlinx.dataframe.api.with
@@ -121,7 +122,7 @@ class TestStringApiInterpretableConsistency {
     )
 
     @Test
-    fun `check all StringApiInterpretable match string API overload parameter to valid CS DSL parameter`() {
+    fun `check all StringApiInterpretable map string API overload parameter to valid CS DSL parameter`() {
         val dataFrameApi = dataFrameApi()
         val csDslInterpretable = dataFrameApi.interpretableFunctions()
             .filter {
@@ -137,24 +138,40 @@ class TestStringApiInterpretableConsistency {
             .cast<DataFrameApi>(verify = false)
             .stringApiFunctions()
             .split { annotationArguments }.inward("delegateInterpreter", "stringArgument", "targetArgument")
-            .rename { annotationArguments }.into("adapter")
+            .rename { annotationArguments }.to("adapter")
 
         val ignore = setOf(
             "Parse", // own interpreter
             "Convert0", // own interpreter
+            "Under0", // own interpreter Under4
             "DataFrameXs", // no String overload at all
             "GroupByXs", // no String overload at all
             "NestedSelect", // no String overload
             "StringSelect", // no String overload
             "ColumnPathSelect", // no String overload
+            "CSDslAllExceptSelector", // own interpreter CSDslAllExceptStrings
+            "ColumnGroupAllColsExceptSelector", // own interpreter ColumnGroupAllColsExceptStrings
+            "ColumnGroupExceptSelector", // own interpreter ColumnGroupExceptStrings
+            "StringExceptSelector", // own interpreter StringExceptStrings
+            "ColumnPathExceptSelector", // own interpreter ColumnPathExceptStrings
+            "StringAllColsExceptSelector", // own interpreter StringAllColsExceptStrings
+            "ColumnPathAllColsExceptSelector", // own interpreter ColumnPathAllColsExceptStrings
+            "GroupByCountDistinct0", // no String overload
+            "AllAfter1", // need own interpreter
+            "AllFrom1", // need own interpreter
+            "AllBefore1", // need own interpreter
+            "AllUpTo1", // need own interpreter
+            "MoveAfter0", // need investigate and fix
+            "MoveBefore0", // need investigate and fix
+            "InsertAfter0", // need investigate and fix
+            "InsertBefore0", // need investigate and fix
+            "AsGroupBy", // need investigate and fix
+            "Require0", // no String overload
         )
 
         val stringApiGroup = stringOverloads.group { all() }.into("stringOverload")
         val remainingInconsistentApis = csDslInterpretable
             .leftJoin(stringApiGroup) { interpreter.match(right.stringOverload.adapter.delegateInterpreter) }
-            // Default value
-            .fillNulls { stringOverload.adapter.targetArgument }.with { stringOverload.adapter.stringArgument }
-            .also { println(it.size()) }
             // any invalid mapping?
             .filter {
                 val parametersOfCslDslOverload = parameters.map { it.name }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/RawSchemaOperationsResultCorrectnessTest.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/RawSchemaOperationsResultCorrectnessTest.kt
@@ -1,0 +1,413 @@
+package org.jetbrains.kotlinx.dataframe.plugin.stringApi
+
+import org.jetbrains.kotlinx.dataframe.api.by
+import org.jetbrains.kotlinx.dataframe.api.byName
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.convert
+import org.jetbrains.kotlinx.dataframe.api.cumSum
+import org.jetbrains.kotlinx.dataframe.api.distinct
+import org.jetbrains.kotlinx.dataframe.api.dropNA
+import org.jetbrains.kotlinx.dataframe.api.dropNulls
+import org.jetbrains.kotlinx.dataframe.api.excludeJoin
+import org.jetbrains.kotlinx.dataframe.api.explode
+import org.jetbrains.kotlinx.dataframe.api.fillNA
+import org.jetbrains.kotlinx.dataframe.api.fillNaNs
+import org.jetbrains.kotlinx.dataframe.api.fillNulls
+import org.jetbrains.kotlinx.dataframe.api.filterJoin
+import org.jetbrains.kotlinx.dataframe.api.flatten
+import org.jetbrains.kotlinx.dataframe.api.fullJoin
+import org.jetbrains.kotlinx.dataframe.api.gather
+import org.jetbrains.kotlinx.dataframe.api.group
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.implode
+import org.jetbrains.kotlinx.dataframe.api.innerJoin
+import org.jetbrains.kotlinx.dataframe.api.into
+import org.jetbrains.kotlinx.dataframe.api.join
+import org.jetbrains.kotlinx.dataframe.api.leftJoin
+import org.jetbrains.kotlinx.dataframe.api.max
+import org.jetbrains.kotlinx.dataframe.api.maxFor
+import org.jetbrains.kotlinx.dataframe.api.mean
+import org.jetbrains.kotlinx.dataframe.api.meanFor
+import org.jetbrains.kotlinx.dataframe.api.median
+import org.jetbrains.kotlinx.dataframe.api.medianFor
+import org.jetbrains.kotlinx.dataframe.api.merge
+import org.jetbrains.kotlinx.dataframe.api.min
+import org.jetbrains.kotlinx.dataframe.api.minFor
+import org.jetbrains.kotlinx.dataframe.api.move
+import org.jetbrains.kotlinx.dataframe.api.moveTo
+import org.jetbrains.kotlinx.dataframe.api.moveToEnd
+import org.jetbrains.kotlinx.dataframe.api.moveToStart
+import org.jetbrains.kotlinx.dataframe.api.percentile
+import org.jetbrains.kotlinx.dataframe.api.percentileFor
+import org.jetbrains.kotlinx.dataframe.api.remove
+import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.reorder
+import org.jetbrains.kotlinx.dataframe.api.rightJoin
+import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.split
+import org.jetbrains.kotlinx.dataframe.api.std
+import org.jetbrains.kotlinx.dataframe.api.stdFor
+import org.jetbrains.kotlinx.dataframe.api.sum
+import org.jetbrains.kotlinx.dataframe.api.sumFor
+import org.jetbrains.kotlinx.dataframe.api.to
+import org.jetbrains.kotlinx.dataframe.api.toStart
+import org.jetbrains.kotlinx.dataframe.api.unfold
+import org.jetbrains.kotlinx.dataframe.api.ungroup
+import org.jetbrains.kotlinx.dataframe.api.update
+import org.jetbrains.kotlinx.dataframe.api.valueCounts
+import org.jetbrains.kotlinx.dataframe.api.with
+import org.jetbrains.kotlinx.dataframe.api.withZero
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Making sure compiler evaluation of String API overload on raw dataframe (no schema) is correct
+ * whatever columns appear as a result are "type safe";
+ * no ColumnNotFound or ClassCast exceptions will happen if property is used.
+ * User scenario when df has no schema, some operations are invoked, and as a result we enrich schema
+ */
+@Suppress("FunctionName", "TestFunctionName")
+class RawSchemaOperationsResultCorrectnessTest : CommonTestData() {
+    @Test
+    @Ignore
+    fun DataFrameCumSum() {
+        dfRaw.cumSum("value") matches df.cumSum { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun DataFrameGroupBy() {
+        dfRaw.groupBy("key").toDataFrame() matches df.groupBy { key }.toDataFrame()
+            .convert { group }.with { it.select { key.cast<Any?>() } }
+            .select { key.cast<Any?>() and group }
+    }
+
+    @Test
+    @Ignore
+    fun DataFrameUnfold() {
+        recordsRaw.unfold("ab") matches records.unfold { ab }.select { ab.cast<Any?>() }
+    }
+
+    @Test
+    fun Distinct0() {
+        dfRaw.distinct("key") matches df.distinct { key }.select { key.cast<Any?>() }
+    }
+
+    @Test
+    fun DropNa0() {
+        dfRaw.dropNA("nullable") matches df.dropNA { nullable }.select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun DropNulls0() {
+        dfRaw.dropNulls("nullable") matches df.dropNulls { nullable }.select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun ExcludeJoin() {
+        dfRaw.excludeJoin(otherRaw, "key") matches df.excludeJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Explode0() {
+        listsRaw.explode("values") matches lists.explode { values }.select { values.cast<Any?>() }
+    }
+
+    @Test
+    fun ExplodeColumns() {
+        listsRaw[0].explode("values") matches lists[0].explode { values }.select { values.cast<Any?>() }
+    }
+
+    @Test
+    @Ignore
+    fun FillNaNs0() {
+        dfRaw.fillNaNs("nan").withZero() matches df.fillNaNs { nan }.withZero().select { nan.cast<Any?>() }
+    }
+
+    @Test
+    fun FillNulls0() {
+        dfRaw.fillNulls("nullable").withZero() matches
+            df.fillNulls { nullable }.withZero().select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun `FillNulls0 fillNulls to fillNA`() {
+        dfRaw.fillNA("nullable").withZero() matches df.fillNulls { nullable }.withZero().select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun `FillNulls0 fillNA to fillNulls`() {
+        dfRaw.fillNulls("nullable").withZero() matches df.fillNA { nullable }.withZero().select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun `FillNulls0 fillNA to fillNA`() {
+        dfRaw.fillNA("nullable").withZero() matches df.fillNA { nullable }.withZero().select { nullable.cast<Any>() }
+    }
+
+    @Test
+    fun FilterJoin() {
+        dfRaw.filterJoin(otherRaw, "key") matches df.filterJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Flatten0() {
+        nestedRaw.flatten("group") matches nested.flatten { group }.select { none() }
+    }
+
+    @Test
+    fun FullJoin() {
+        dfRaw.fullJoin(otherRaw, "key") matches df.fullJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Gather0() {
+        dfRaw.gather("value").into("name", "result") matches
+            df.gather { value }.into("name", "result").convert { result }.with { it as Any? }
+                .select { name and result }
+    }
+
+    @Test
+    fun Group0() {
+        dfRaw.group("value").into("values") matches df.group { value }.into("values").select { values }
+            .convert { values.value }.with { it as Any? }
+    }
+
+    @Test
+    fun GroupByCumSum() {
+        dfRaw.groupBy("key").cumSum("value").toDataFrame() matches df.groupBy { key }.cumSum { value }.toDataFrame()
+            .convert { group }.with { it.select { key.cast<Any?>() } }
+            .select { key.cast<Any?>() and group }
+    }
+
+    @Test
+    fun GroupByMax0() {
+        dfRaw.groupBy("key").maxFor("value") matches
+            df.groupBy { key }.maxFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMax2() {
+        dfRaw.groupBy("key").max("value", name = "max") matches
+            df.groupBy { key }.max("max") { value }.select { key.cast<Any?>() and max.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMean0() {
+        dfRaw.groupBy("key").meanFor("value") matches
+            df.groupBy { key }.meanFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMean2() {
+        dfRaw.groupBy("key").mean("value", name = "mean") matches
+            df.groupBy { key }.mean("mean") { value }.select { key.cast<Any?>() and mean.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMedian0() {
+        dfRaw.groupBy("key").medianFor("value") matches
+            df.groupBy { key }.medianFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMedian2() {
+        dfRaw.groupBy("key").median("value", name = "median") matches
+            df.groupBy { key }.median("median") { value }.select { key.cast<Any?>() and median.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMin0() {
+        dfRaw.groupBy("key").minFor("value") matches
+            df.groupBy { key }.minFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByMin2() {
+        dfRaw.groupBy("key").min("value", name = "min") matches
+            df.groupBy { key }.min("min") { value }.select { key.cast<Any?>() and min.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByPercentile0() {
+        dfRaw.groupBy("key").percentileFor(0.5, "value") matches
+            df.groupBy { key }.percentileFor(0.5) { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByPercentile2() {
+        dfRaw.groupBy("key").percentile(0.5, "value", name = "p") matches
+            df.groupBy { key }.percentile(0.5, "p") { value }.select { key.cast<Any?>() and p.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByStd0() {
+        dfRaw.groupBy("key").stdFor("value") matches
+            df.groupBy { key }.stdFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupByStd2() {
+        dfRaw.groupBy("key").std("value", name = "std") matches
+            df.groupBy { key }.std("std") { value }.select { key.cast<Any?>() and std.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupBySum0() {
+        dfRaw.groupBy("key").sumFor("value") matches
+            df.groupBy { key }.sumFor { value }.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun GroupBySum2() {
+        dfRaw.groupBy("key").sum("value", name = "sum") matches
+            df.groupBy { key }.sum("sum") { value }.select { key.cast<Any?>() and sum.cast<Any?>() }
+    }
+
+    @Test
+    fun Implode() {
+        dfRaw.implode("value") matches df.implode { value }.select { value.cast<List<Any?>>() }
+    }
+
+    @Test
+    fun InnerJoin() {
+        dfRaw.innerJoin(otherRaw, "key") matches df.innerJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Join0() {
+        dfRaw.join(otherRaw, "key") matches df.join(other) { key }.select { none() }
+    }
+
+    @Test
+    fun LeftJoin() {
+        dfRaw.leftJoin(otherRaw, "key") matches df.leftJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Max1() {
+        dfRaw.maxFor("value") matches df.maxFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Mean1() {
+        dfRaw.meanFor("value") matches df.meanFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Median1() {
+        dfRaw.medianFor("value") matches df.medianFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Merge0() {
+        dfRaw.merge("key").into("keys") matches
+            df.merge { key }.into("keys").convert { keys }.with { it as List<Any?> }
+                .select { keys }
+    }
+
+    @Test
+    fun Min1() {
+        dfRaw.minFor("value") matches df.minFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Move0() {
+        dfRaw.move("value").toStart() matches df.move { value }.toStart().select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun MoveTo1() {
+        dfRaw.moveTo(0, "value") matches df.moveTo(0) { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun `MoveTo1 inside group`() {
+        dfRaw.moveTo(0, "value") matches df.moveTo(0, false) { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun MoveToEnd1() {
+        dfRaw.moveToEnd("value") matches df.moveToEnd { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun `MoveToEnd1 inside group`() {
+        dfRaw.moveToEnd("value") matches df.moveToEnd(false) { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun MoveToStart1() {
+        dfRaw.moveToStart("value") matches df.moveToStart { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun `MoveToStart1 inside group`() {
+        dfRaw.moveToStart("value") matches df.moveToStart(false) { value }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun Percentile1() {
+        dfRaw.percentileFor(0.5, "value") matches df.percentileFor(0.5) { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Remove0() {
+        dfRaw.remove("other") matches df.remove { other }.select { none() }
+    }
+
+    @Test
+    fun Rename() {
+        dfRaw.rename("other").to("renamed") matches df.rename { other }.to("renamed").select { renamed.cast<Any?>() }
+    }
+
+    @Test
+    fun Reorder() {
+        dfRaw.reorder("other", "value").byName() matches df.reorder { other and value }.byName()
+            .select { other.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun RightJoin() {
+        dfRaw.rightJoin(otherRaw, "key") matches df.rightJoin(other) { key }.select { none() }
+    }
+
+    @Test
+    fun Select0() {
+        dfRaw.select("key", "value") matches df.select { key.cast<Any?>() and value.cast<Any?>() }
+    }
+
+    @Test
+    fun Split0() {
+        dfRaw.split("key").by { listOf("a", "b") }.into("a", "b") matches
+            df.split { key }.by { listOf("a", "b") }.into("a", "b")
+                .select { a and b }
+    }
+
+    @Test
+    fun Std1() {
+        dfRaw.stdFor("value") matches df.stdFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Sum1() {
+        dfRaw.sumFor("value") matches df.sumFor { value }.df().select { value.cast<Any?>() }[0]
+    }
+
+    @Test
+    fun Ungroup0() {
+        dfRaw.group("value").into("values").ungroup("values") matches
+            df.group { value }.into("values")
+                .ungroup { values }.select { value.cast<Any?>() }
+    }
+
+    @Test
+    fun Update0() {
+        dfRaw.update("value").with { (it as Int) + 1 } matches
+            df.update { value }.with { it + 1 }.select { value.cast<Any>() }
+    }
+
+    @Test
+    fun ValueCounts() {
+        dfRaw.valueCounts("key") matches df.valueCounts { key }.select { key.cast<Any?>() and count }
+    }
+}

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/RawSchemaOperationsResultCorrectnessTest.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/RawSchemaOperationsResultCorrectnessTest.kt
@@ -69,7 +69,7 @@ import org.junit.Test
 @Suppress("FunctionName", "TestFunctionName")
 class RawSchemaOperationsResultCorrectnessTest : CommonTestData() {
     @Test
-    @Ignore
+    @Ignore // need to investigate failure on plugin side
     fun DataFrameCumSum() {
         dfRaw.cumSum("value") matches df.cumSum { value }.select { value.cast<Any?>() }
     }
@@ -82,7 +82,7 @@ class RawSchemaOperationsResultCorrectnessTest : CommonTestData() {
     }
 
     @Test
-    @Ignore
+    @Ignore // need to investigate failure on plugin side
     fun DataFrameUnfold() {
         recordsRaw.unfold("ab") matches records.unfold { ab }.select { ab.cast<Any?>() }
     }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
@@ -52,6 +52,7 @@ class StringApiInterpretableConsistencyTests {
         val ignore = setOf(
             "Parse", // own interpreter
             "Convert0", // own interpreter
+            "Select0", // own interpreter
             "Under0", // own interpreter Under4
             "DataFrameXs", // no String overload at all
             "GroupByXs", // no String overload at all

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
@@ -30,6 +30,69 @@ import org.junit.Test
 
 @Ignore
 class StringApiInterpretableConsistencyTests {
+    @Test
+    fun `check all StringApiInterpretable map string API overload parameter to valid CS DSL parameter`() {
+        val dataFrameApi = dataFrameApi()
+        val csDslInterpretable = dataFrameApi.interpretableFunctions()
+            .filter {
+                parameters.any {
+                    it.type.name.contains("ColumnsSelector") ||
+                        it.type.name.contains("ColumnsForAggregateSelector") ||
+                        it.type.name.contains("ColumnSelector")
+                }
+            }
+
+        val stringOverloads = dataFrameApi
+            .select { annotations and name and parameters }
+            .cast<DataFrameApi>(verify = false)
+            .stringApiFunctions()
+            .split { annotationArguments }.inward("delegateInterpreter", "stringArgument", "targetArgument")
+            .rename { annotationArguments }.to("adapter")
+
+        val ignore = setOf(
+            "Parse", // own interpreter
+            "Convert0", // own interpreter
+            "Under0", // own interpreter Under4
+            "DataFrameXs", // no String overload at all
+            "GroupByXs", // no String overload at all
+            "NestedSelect", // no String overload
+            "StringSelect", // no String overload
+            "ColumnPathSelect", // no String overload
+            "CSDslAllExceptSelector", // own interpreter CSDslAllExceptStrings
+            "ColumnGroupAllColsExceptSelector", // own interpreter ColumnGroupAllColsExceptStrings
+            "ColumnGroupExceptSelector", // own interpreter ColumnGroupExceptStrings
+            "StringExceptSelector", // own interpreter StringExceptStrings
+            "ColumnPathExceptSelector", // own interpreter ColumnPathExceptStrings
+            "StringAllColsExceptSelector", // own interpreter StringAllColsExceptStrings
+            "ColumnPathAllColsExceptSelector", // own interpreter ColumnPathAllColsExceptStrings
+            "GroupByCountDistinct0", // no String overload
+            "AllAfter1", // need own interpreter
+            "AllFrom1", // need own interpreter
+            "AllBefore1", // need own interpreter
+            "AllUpTo1", // need own interpreter
+            "MoveAfter0", // need investigate and fix
+            "MoveBefore0", // need investigate and fix
+            "InsertAfter0", // need investigate and fix
+            "InsertBefore0", // need investigate and fix
+            "AsGroupBy", // need investigate and fix
+            "Require0", // no String overload
+        )
+
+        val stringApiGroup = stringOverloads.group { all() }.into("stringOverload")
+        val remainingInconsistentApis = csDslInterpretable
+            .leftJoin(stringApiGroup) { interpreter.match(right.stringOverload.adapter.delegateInterpreter) }
+            // any invalid mapping?
+            .filter {
+                val parametersOfCslDslOverload = parameters.map { it.name }
+                stringOverload.adapter.targetArgument !in parametersOfCslDslOverload
+            }
+            .filter { interpreter !in ignore }
+
+        remainingInconsistentApis.asClue {
+            remainingInconsistentApis.rowsCount() shouldBe 0
+        }
+    }
+
     private fun dataFrameApi(): DataFrame<DataFrameApi> {
         val scope = Konsist.scopeFromDirectories(listOf("core"))
             .functions()
@@ -108,67 +171,4 @@ class StringApiInterpretableConsistencyTests {
         val isTopLevel: Boolean,
         val typeParameters: List<KoTypeParameterDeclaration>,
     )
-
-    @Test
-    fun `check all StringApiInterpretable map string API overload parameter to valid CS DSL parameter`() {
-        val dataFrameApi = dataFrameApi()
-        val csDslInterpretable = dataFrameApi.interpretableFunctions()
-            .filter {
-                parameters.any {
-                    it.type.name.contains("ColumnsSelector") ||
-                        it.type.name.contains("ColumnsForAggregateSelector") ||
-                        it.type.name.contains("ColumnSelector")
-                }
-            }
-
-        val stringOverloads = dataFrameApi
-            .select { annotations and name and parameters }
-            .cast<DataFrameApi>(verify = false)
-            .stringApiFunctions()
-            .split { annotationArguments }.inward("delegateInterpreter", "stringArgument", "targetArgument")
-            .rename { annotationArguments }.to("adapter")
-
-        val ignore = setOf(
-            "Parse", // own interpreter
-            "Convert0", // own interpreter
-            "Under0", // own interpreter Under4
-            "DataFrameXs", // no String overload at all
-            "GroupByXs", // no String overload at all
-            "NestedSelect", // no String overload
-            "StringSelect", // no String overload
-            "ColumnPathSelect", // no String overload
-            "CSDslAllExceptSelector", // own interpreter CSDslAllExceptStrings
-            "ColumnGroupAllColsExceptSelector", // own interpreter ColumnGroupAllColsExceptStrings
-            "ColumnGroupExceptSelector", // own interpreter ColumnGroupExceptStrings
-            "StringExceptSelector", // own interpreter StringExceptStrings
-            "ColumnPathExceptSelector", // own interpreter ColumnPathExceptStrings
-            "StringAllColsExceptSelector", // own interpreter StringAllColsExceptStrings
-            "ColumnPathAllColsExceptSelector", // own interpreter ColumnPathAllColsExceptStrings
-            "GroupByCountDistinct0", // no String overload
-            "AllAfter1", // need own interpreter
-            "AllFrom1", // need own interpreter
-            "AllBefore1", // need own interpreter
-            "AllUpTo1", // need own interpreter
-            "MoveAfter0", // need investigate and fix
-            "MoveBefore0", // need investigate and fix
-            "InsertAfter0", // need investigate and fix
-            "InsertBefore0", // need investigate and fix
-            "AsGroupBy", // need investigate and fix
-            "Require0", // no String overload
-        )
-
-        val stringApiGroup = stringOverloads.group { all() }.into("stringOverload")
-        val remainingInconsistentApis = csDslInterpretable
-            .leftJoin(stringApiGroup) { interpreter.match(right.stringOverload.adapter.delegateInterpreter) }
-            // any invalid mapping?
-            .filter {
-                val parametersOfCslDslOverload = parameters.map { it.name }
-                stringOverload.adapter.targetArgument !in parametersOfCslDslOverload
-            }
-            .filter { interpreter !in ignore }
-
-        remainingInconsistentApis.asClue {
-            remainingInconsistentApis.rowsCount() shouldBe 0
-        }
-    }
 }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.kotlinx.dataframe
+package org.jetbrains.kotlinx.dataframe.plugin.stringApi
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
@@ -7,41 +7,29 @@ import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
-import org.jetbrains.kotlinx.dataframe.api.add
 import org.jetbrains.kotlinx.dataframe.api.at
 import org.jetbrains.kotlinx.dataframe.api.cast
 import org.jetbrains.kotlinx.dataframe.api.convert
-import org.jetbrains.kotlinx.dataframe.api.count
-import org.jetbrains.kotlinx.dataframe.api.distinct
 import org.jetbrains.kotlinx.dataframe.api.dropNulls
-import org.jetbrains.kotlinx.dataframe.api.explode
-import org.jetbrains.kotlinx.dataframe.api.expr
-import org.jetbrains.kotlinx.dataframe.api.fillNulls
 import org.jetbrains.kotlinx.dataframe.api.filter
-import org.jetbrains.kotlinx.dataframe.api.gather
 import org.jetbrains.kotlinx.dataframe.api.group
-import org.jetbrains.kotlinx.dataframe.api.groupBy
-import org.jetbrains.kotlinx.dataframe.api.innerJoin
 import org.jetbrains.kotlinx.dataframe.api.insert
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.inward
 import org.jetbrains.kotlinx.dataframe.api.leftJoin
-import org.jetbrains.kotlinx.dataframe.api.print
 import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.select
-import org.jetbrains.kotlinx.dataframe.api.sortBy
-import org.jetbrains.kotlinx.dataframe.api.sortByCount
 import org.jetbrains.kotlinx.dataframe.api.split
 import org.jetbrains.kotlinx.dataframe.api.to
 import org.jetbrains.kotlinx.dataframe.api.toDataFrame
-import org.jetbrains.kotlinx.dataframe.api.valuesInto
 import org.jetbrains.kotlinx.dataframe.api.with
 import org.junit.Ignore
 import org.junit.Test
 
 @Ignore
-class TestStringApiInterpretableConsistency {
+class StringApiInterpretableConsistencyTests {
     private fun dataFrameApi(): DataFrame<DataFrameApi> {
         val scope = Konsist.scopeFromDirectories(listOf("core"))
             .functions()
@@ -182,93 +170,5 @@ class TestStringApiInterpretableConsistency {
         remainingInconsistentApis.asClue {
             remainingInconsistentApis.rowsCount() shouldBe 0
         }
-    }
-
-    @Test
-    fun `print Interpretable function headers with String API overloads`() {
-        val dataFrameApi = dataFrameApi()
-        val csDslHeaders = dataFrameApi.interpretableFunctions()
-            .add("csDslHeader") {
-                buildString {
-                    receiverType?.name?.let { append("$it.") }
-                    append(name)
-                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
-                    returnType?.name?.let { append(": $it") }
-                }
-            }
-            .select { interpreter and csDslHeader }
-
-        val stringApiHeaders = dataFrameApi.stringApiFunctions()
-            .add("interpreter") {
-                annotations
-                    .single { it.name == "StringApiInterpretable" }
-                    .arguments
-                    .first()
-                    .value
-            }
-            .add("stringApiHeader") {
-                buildString {
-                    receiverType?.name?.let { append("$it.") }
-                    append(name)
-                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
-                    returnType?.name?.let { append(": $it") }
-                }
-            }
-            .select { interpreter and stringApiHeader }
-
-        csDslHeaders
-            .innerJoin(stringApiHeaders) { interpreter }
-            .sortBy { interpreter }
-            .gather { all() }
-            .valuesInto("Interpretable ID / CS DSL header / String API header")
-            .print(rowsLimit = 1000, valueLimit = 1000, rowIndex = false, columnTypes = false, alignLeft = true)
-    }
-
-    @Test
-    fun `print StringApiInterpretable functions without Refine when CS DSL has it`() {
-        val dataFrameApi = dataFrameApi()
-        val csDslInterpretersWithRefine = dataFrameApi.interpretableFunctions()
-            .filter { annotations.any { it.name == "Refine" } }
-            .select { interpreter }
-            .distinct()
-
-        dataFrameApi.stringApiFunctions()
-            .filter { annotations.none { it.name == "Refine" } }
-            .add("interpreter") {
-                annotations
-                    .single { it.name == "StringApiInterpretable" }
-                    .arguments
-                    .first()
-                    .value
-            }
-            .innerJoin(csDslInterpretersWithRefine) { interpreter }
-            .add("stringApiHeader") {
-                buildString {
-                    receiverType?.name?.let { append("$it.") }
-                    append(name)
-                    append(parameters.joinToString(prefix = "(", postfix = ")") { "${it.name}: ${it.type.name}" })
-                    returnType?.name?.let { append(": $it") }
-                }
-            }
-            .select { interpreter and stringApiHeader }
-            .sortBy { interpreter }
-            .print(rowsLimit = 1000, valueLimit = 1000, rowIndex = false, columnTypes = false, alignLeft = true)
-    }
-
-    @Test
-    fun print() {
-        val dataFrameApi = dataFrameApi()
-        val trueInterpretable = dataFrameApi.interpretableFunctions()
-        trueInterpretable
-            .convert { parameters }.with { it.map { it.type.name } }
-            .explode { parameters into "parameterName" }
-            .groupBy { parameterName }.sortByCount().count()
-            .sortBy {
-                expr {
-                    parameterName.contains("ColumnsSelector") ||
-                        parameterName.contains("ColumnsForAggregateSelector")
-                }.desc()
-            }
-            .print(rowsLimit = 1000)
     }
 }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
@@ -49,7 +49,10 @@ class StringApiInterpretableConsistencyTests {
             .split { annotationArguments }.inward("delegateInterpreter", "stringArgument", "targetArgument")
             .rename { annotationArguments }.to("adapter")
 
-        val ignore = setOf(
+        // we try to make sure not to miss String APIs that need @StringApiInterpretable
+        // so, if there's @Interpretable, does it have String API overload?
+        // if yes, maybe annotation there should be added.
+        val doNotNeedStringApiInterpretableAdapter = setOf(
             "Parse", // own interpreter
             "Convert0", // own interpreter
             "Select0", // own interpreter
@@ -87,7 +90,7 @@ class StringApiInterpretableConsistencyTests {
                 val parametersOfCslDslOverload = parameters.map { it.name }
                 stringOverload.adapter.targetArgument !in parametersOfCslDslOverload
             }
-            .filter { interpreter !in ignore }
+            .filter { interpreter !in doNotNeedStringApiInterpretableAdapter }
 
         remainingInconsistentApis.asClue {
             remainingInconsistentApis.rowsCount() shouldBe 0

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/StringApiInterpretableConsistencyTests.kt
@@ -1,21 +1,10 @@
 package org.jetbrains.kotlinx.dataframe.plugin.stringApi
 
-import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
-import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
-import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
-import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
-import org.jetbrains.kotlinx.dataframe.api.at
 import org.jetbrains.kotlinx.dataframe.api.cast
-import org.jetbrains.kotlinx.dataframe.api.convert
-import org.jetbrains.kotlinx.dataframe.api.dropNulls
 import org.jetbrains.kotlinx.dataframe.api.filter
 import org.jetbrains.kotlinx.dataframe.api.group
-import org.jetbrains.kotlinx.dataframe.api.insert
 import org.jetbrains.kotlinx.dataframe.api.into
 import org.jetbrains.kotlinx.dataframe.api.inward
 import org.jetbrains.kotlinx.dataframe.api.leftJoin
@@ -23,8 +12,15 @@ import org.jetbrains.kotlinx.dataframe.api.rename
 import org.jetbrains.kotlinx.dataframe.api.select
 import org.jetbrains.kotlinx.dataframe.api.split
 import org.jetbrains.kotlinx.dataframe.api.to
-import org.jetbrains.kotlinx.dataframe.api.toDataFrame
-import org.jetbrains.kotlinx.dataframe.api.with
+import org.jetbrains.kotlinx.dataframe.util.DataFrameApi
+import org.jetbrains.kotlinx.dataframe.util.annotationArguments
+import org.jetbrains.kotlinx.dataframe.util.annotations
+import org.jetbrains.kotlinx.dataframe.util.dataFrameApi
+import org.jetbrains.kotlinx.dataframe.util.interpretableFunctions
+import org.jetbrains.kotlinx.dataframe.util.interpreter
+import org.jetbrains.kotlinx.dataframe.util.name
+import org.jetbrains.kotlinx.dataframe.util.parameters
+import org.jetbrains.kotlinx.dataframe.util.stringApiFunctions
 import org.junit.Ignore
 import org.junit.Test
 
@@ -96,83 +92,4 @@ class StringApiInterpretableConsistencyTests {
             remainingInconsistentApis.rowsCount() shouldBe 0
         }
     }
-
-    private fun dataFrameApi(): DataFrame<DataFrameApi> {
-        val scope = Konsist.scopeFromDirectories(listOf("core"))
-            .functions()
-            .filter { !it.path.contains("generated") }
-
-        return scope.toDataFrame()
-            .filter { it.hasPublicModifier }
-            .filter { !annotations.any { it.name in setOf("Deprecated", "AccessApiOverload") } }
-            .select {
-                cols(
-                    receiverType,
-                    name,
-                    parameters,
-                    returnType,
-                    annotations,
-                    projectPath,
-                    isTopLevel,
-                    typeParameters,
-                )
-            }
-            .convert { projectPath }.with { it.removePrefix("projectPath: ") }
-            .cast<DataFrameApi>()
-    }
-
-    @DataSchema
-    data class DataFrameApi(
-        val receiverType: KoTypeDeclaration?,
-        val name: String,
-        val parameters: List<KoParameterDeclaration>,
-        val returnType: KoTypeDeclaration?,
-        val annotations: List<KoAnnotationDeclaration>,
-        val projectPath: String,
-        val isTopLevel: Boolean,
-        val typeParameters: List<KoTypeParameterDeclaration>,
-    )
-
-    private fun DataFrame<DataFrameApi>.interpretableFunctions(): DataFrame<InterpretableFunctions> =
-        select {
-            annotations and receiverType and name and parameters and returnType
-        }
-            .filter { annotations.any { it.name == "Interpretable" } }
-            .insert("interpreter") {
-                annotations
-                    .single { it.name == "Interpretable" }
-                    .arguments.single().value
-            }.at(0)
-            .cast<InterpretableFunctions>()
-
-    @DataSchema
-    data class InterpretableFunctions(
-        val interpreter: String?,
-        val annotations: List<KoAnnotationDeclaration>,
-        val receiverType: KoTypeDeclaration?,
-        val name: String,
-        val parameters: List<KoParameterDeclaration>,
-        val returnType: KoTypeDeclaration?,
-    )
-
-    private fun DataFrame<DataFrameApi>.stringApiFunctions(): DataFrame<StringApiFunctions> =
-        insert("annotationArguments") {
-            annotations.singleOrNull { it.name == "StringApiInterpretable" }
-                ?.arguments?.map { it.value }
-        }.at(0)
-            .dropNulls { annotationArguments }
-            .cast<StringApiFunctions>()
-
-    @DataSchema
-    data class StringApiFunctions(
-        val annotationArguments: List<String?>,
-        val receiverType: KoTypeDeclaration?,
-        val name: String,
-        val parameters: List<KoParameterDeclaration>,
-        val returnType: KoTypeDeclaration?,
-        val annotations: List<KoAnnotationDeclaration>,
-        val projectPath: String,
-        val isTopLevel: Boolean,
-        val typeParameters: List<KoTypeParameterDeclaration>,
-    )
 }

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/TypedSchemaOperationsResultConsistencyTest.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/TypedSchemaOperationsResultConsistencyTest.kt
@@ -1,0 +1,380 @@
+package org.jetbrains.kotlinx.dataframe.plugin.stringApi
+
+import org.jetbrains.kotlinx.dataframe.api.by
+import org.jetbrains.kotlinx.dataframe.api.byName
+import org.jetbrains.kotlinx.dataframe.api.convert
+import org.jetbrains.kotlinx.dataframe.api.cumSum
+import org.jetbrains.kotlinx.dataframe.api.distinct
+import org.jetbrains.kotlinx.dataframe.api.dropNA
+import org.jetbrains.kotlinx.dataframe.api.dropNulls
+import org.jetbrains.kotlinx.dataframe.api.excludeJoin
+import org.jetbrains.kotlinx.dataframe.api.explode
+import org.jetbrains.kotlinx.dataframe.api.fillNA
+import org.jetbrains.kotlinx.dataframe.api.fillNaNs
+import org.jetbrains.kotlinx.dataframe.api.fillNulls
+import org.jetbrains.kotlinx.dataframe.api.filterJoin
+import org.jetbrains.kotlinx.dataframe.api.flatten
+import org.jetbrains.kotlinx.dataframe.api.fullJoin
+import org.jetbrains.kotlinx.dataframe.api.gather
+import org.jetbrains.kotlinx.dataframe.api.group
+import org.jetbrains.kotlinx.dataframe.api.groupBy
+import org.jetbrains.kotlinx.dataframe.api.implode
+import org.jetbrains.kotlinx.dataframe.api.innerJoin
+import org.jetbrains.kotlinx.dataframe.api.into
+import org.jetbrains.kotlinx.dataframe.api.join
+import org.jetbrains.kotlinx.dataframe.api.leftJoin
+import org.jetbrains.kotlinx.dataframe.api.max
+import org.jetbrains.kotlinx.dataframe.api.maxFor
+import org.jetbrains.kotlinx.dataframe.api.mean
+import org.jetbrains.kotlinx.dataframe.api.meanFor
+import org.jetbrains.kotlinx.dataframe.api.median
+import org.jetbrains.kotlinx.dataframe.api.medianFor
+import org.jetbrains.kotlinx.dataframe.api.merge
+import org.jetbrains.kotlinx.dataframe.api.min
+import org.jetbrains.kotlinx.dataframe.api.minFor
+import org.jetbrains.kotlinx.dataframe.api.move
+import org.jetbrains.kotlinx.dataframe.api.moveTo
+import org.jetbrains.kotlinx.dataframe.api.moveToEnd
+import org.jetbrains.kotlinx.dataframe.api.moveToStart
+import org.jetbrains.kotlinx.dataframe.api.percentile
+import org.jetbrains.kotlinx.dataframe.api.percentileFor
+import org.jetbrains.kotlinx.dataframe.api.remove
+import org.jetbrains.kotlinx.dataframe.api.rename
+import org.jetbrains.kotlinx.dataframe.api.reorder
+import org.jetbrains.kotlinx.dataframe.api.rightJoin
+import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.split
+import org.jetbrains.kotlinx.dataframe.api.std
+import org.jetbrains.kotlinx.dataframe.api.stdFor
+import org.jetbrains.kotlinx.dataframe.api.sum
+import org.jetbrains.kotlinx.dataframe.api.sumFor
+import org.jetbrains.kotlinx.dataframe.api.to
+import org.jetbrains.kotlinx.dataframe.api.toStart
+import org.jetbrains.kotlinx.dataframe.api.unfold
+import org.jetbrains.kotlinx.dataframe.api.ungroup
+import org.jetbrains.kotlinx.dataframe.api.update
+import org.jetbrains.kotlinx.dataframe.api.valueCounts
+import org.jetbrains.kotlinx.dataframe.api.with
+import org.jetbrains.kotlinx.dataframe.api.withZero
+import org.junit.Test
+
+/**
+ * Making sure compiler evaluates String API overloads same as CS DSL overloads on typed input
+ * User scenario when dataframe itself is typed, but user chose to use String overload for simplicity
+ * => we do not loose information
+ * Sometimes some precision is expected to be lost, see [Merge0]
+ */
+@Suppress("FunctionName", "TestFunctionName")
+class TypedSchemaOperationsResultConsistencyTest : CommonTestData() {
+    @Test
+    fun DataFrameCumSum() {
+        df.cumSum("value") matches df.cumSum { value }
+    }
+
+    @Test
+    fun DataFrameGroupBy() {
+        df.groupBy("key").toDataFrame() matches df.groupBy { key }.toDataFrame()
+    }
+
+    @Test
+    fun DataFrameUnfold() {
+        records.unfold("ab") matches records.unfold { ab }
+    }
+
+    @Test
+    fun Distinct0() {
+        df.distinct("key") matches df.distinct { key }
+    }
+
+    @Test
+    fun DropNa0() {
+        df.dropNA("nullable") matches df.dropNA { nullable }
+    }
+
+    @Test
+    fun DropNulls0() {
+        df.dropNulls("nullable") matches df.dropNulls { nullable }
+    }
+
+    @Test
+    fun ExcludeJoin() {
+        df.excludeJoin(other, "key") matches df.excludeJoin(other) { key }
+    }
+
+    @Test
+    fun Explode0() {
+        lists.explode("values") matches lists.explode { values }
+    }
+
+    @Test
+    fun ExplodeColumns() {
+        lists[0].explode("values") matches lists[0].explode { values }
+    }
+
+    @Test
+    fun FillNaNs0() {
+        df.fillNaNs("nan").withZero() matches df.fillNaNs { nan }.withZero()
+    }
+
+    @Test
+    fun FillNulls0() {
+        df.fillNulls("nullable").withZero() matches df.fillNulls { nullable }.withZero()
+    }
+
+    @Test
+    fun `FillNulls0 fillNulls to fillNA`() {
+        df.fillNA("nullable").withZero() matches df.fillNulls { nullable }.withZero()
+    }
+
+    @Test
+    fun `FillNulls0 fillNA to fillNulls`() {
+        df.fillNulls("nullable").withZero() matches df.fillNA { nullable }.withZero()
+    }
+
+    @Test
+    fun `FillNulls0 fillNA to fillNA`() {
+        df.fillNA("nullable").withZero() matches df.fillNA { nullable }.withZero()
+    }
+
+    @Test
+    fun FilterJoin() {
+        df.filterJoin(other, "key") matches df.filterJoin(other) { key }
+    }
+
+    @Test
+    fun Flatten0() {
+        nested.flatten("group") matches nested.flatten { group }
+    }
+
+    @Test
+    fun FullJoin() {
+        df.fullJoin(other, "key") matches df.fullJoin(other) { key }
+    }
+
+    @Test
+    fun Gather0() {
+        df.gather("value").into("name", "result") matches
+            df.gather { value }.into("name", "result").convert { result }.with { it as Any? }
+    }
+
+    @Test
+    fun Group0() {
+        df.group("value").into("values") matches df.group { value }.into("values")
+    }
+
+    @Test
+    fun GroupByCumSum() {
+        df.groupBy("key").cumSum("value").toDataFrame() matches df.groupBy { key }.cumSum { value }.toDataFrame()
+    }
+
+    @Test
+    fun GroupByMax0() {
+        df.groupBy("key").maxFor("value") matches df.groupBy { key }.maxFor { value }
+    }
+
+    @Test
+    fun GroupByMax2() {
+        df.groupBy("key").max("value", name = "max") matches df.groupBy { key }.max("max") { value }
+    }
+
+    @Test
+    fun GroupByMean0() {
+        df.groupBy("key").meanFor("value") matches df.groupBy { key }.meanFor { value }
+    }
+
+    @Test
+    fun GroupByMean2() {
+        df.groupBy("key").mean("value", name = "mean") matches df.groupBy { key }.mean("mean") { value }
+    }
+
+    @Test
+    fun GroupByMedian0() {
+        df.groupBy("key").medianFor("value") matches df.groupBy { key }.medianFor { value }
+    }
+
+    @Test
+    fun GroupByMedian2() {
+        df.groupBy("key").median("value", name = "median") matches df.groupBy { key }.median("median") { value }
+    }
+
+    @Test
+    fun GroupByMin0() {
+        df.groupBy("key").minFor("value") matches df.groupBy { key }.minFor { value }
+    }
+
+    @Test
+    fun GroupByMin2() {
+        df.groupBy("key").min("value", name = "min") matches df.groupBy { key }.min("min") { value }
+    }
+
+    @Test
+    fun GroupByPercentile0() {
+        df.groupBy("key").percentileFor(0.5, "value") matches df.groupBy { key }.percentileFor(0.5) { value }
+    }
+
+    @Test
+    fun GroupByPercentile2() {
+        df.groupBy("key").percentile(0.5, "value", name = "p") matches df.groupBy { key }.percentile(0.5, "p") { value }
+    }
+
+    @Test
+    fun GroupByStd0() {
+        df.groupBy("key").stdFor("value") matches df.groupBy { key }.stdFor { value }
+    }
+
+    @Test
+    fun GroupByStd2() {
+        df.groupBy("key").std("value", name = "std") matches df.groupBy { key }.std("std") { value }
+    }
+
+    @Test
+    fun GroupBySum0() {
+        df.groupBy("key").sumFor("value") matches df.groupBy { key }.sumFor { value }
+    }
+
+    @Test
+    fun GroupBySum2() {
+        df.groupBy("key").sum("value", name = "sum") matches df.groupBy { key }.sum("sum") { value }
+    }
+
+    @Test
+    fun Implode() {
+        df.implode("value") matches df.implode { value }
+    }
+
+    @Test
+    fun InnerJoin() {
+        df.innerJoin(other, "key") matches df.innerJoin(other) { key }
+    }
+
+    @Test
+    fun Join0() {
+        df.join(other, "key") matches df.join(other) { key }
+    }
+
+    @Test
+    fun LeftJoin() {
+        df.leftJoin(other, "key") matches df.leftJoin(other) { key }
+    }
+
+    @Test
+    fun Max1() {
+        df.maxFor("value") matches df.maxFor { value }
+    }
+
+    @Test
+    fun Mean1() {
+        df.meanFor("value") matches df.meanFor { value }
+    }
+
+    @Test
+    fun Median1() {
+        df.medianFor("value") matches df.medianFor { value }
+    }
+
+    @Test
+    fun Merge0() {
+        df.merge("key").into("keys") matches df.merge { key }.into("keys").convert { keys }.with { it as List<Any?> }
+    }
+
+    @Test
+    fun Min1() {
+        df.minFor("value") matches df.minFor { value }
+    }
+
+    @Test
+    fun Move0() {
+        df.move("value").toStart() matches df.move { value }.toStart()
+    }
+
+    @Test
+    fun MoveTo1() {
+        df.moveTo(0, "value") matches df.moveTo(0) { value }
+    }
+
+    @Test
+    fun `MoveTo1 inside group`() {
+        df.moveTo(0, "value") matches df.moveTo(0, false) { value }
+    }
+
+    @Test
+    fun MoveToEnd1() {
+        df.moveToEnd("value") matches df.moveToEnd { value }
+    }
+
+    @Test
+    fun `MoveToEnd1 inside group`() {
+        df.moveToEnd("value") matches df.moveToEnd(false) { value }
+    }
+
+    @Test
+    fun MoveToStart1() {
+        df.moveToStart("value") matches df.moveToStart { value }
+    }
+
+    @Test
+    fun `MoveToStart1 inside group`() {
+        df.moveToStart("value") matches df.moveToStart(false) { value }
+    }
+
+    @Test
+    fun Percentile1() {
+        df.percentileFor(0.5, "value") matches df.percentileFor(0.5) { value }
+    }
+
+    @Test
+    fun Remove0() {
+        df.remove("other") matches df.remove { other }
+    }
+
+    @Test
+    fun Rename() {
+        df.rename("other").to("renamed") matches df.rename { other }.to("renamed")
+    }
+
+    @Test
+    fun Reorder() {
+        df.reorder("other", "value").byName() matches df.reorder { other and value }.byName()
+    }
+
+    @Test
+    fun RightJoin() {
+        df.rightJoin(other, "key") matches df.rightJoin(other) { key }
+    }
+
+    @Test
+    fun Select0() {
+        df.select("key", "value") matches df.select { key and value }
+    }
+
+    @Test
+    fun Split0() {
+        df.split("key").by { listOf("a", "b") }.into("a", "b") matches
+            df.split { key }.by { listOf("a", "b") }.into("a", "b")
+    }
+
+    @Test
+    fun Std1() {
+        df.stdFor("value") matches df.stdFor { value }
+    }
+
+    @Test
+    fun Sum1() {
+        df.sumFor("value") matches df.sumFor { value }
+    }
+
+    @Test
+    fun Ungroup0() {
+        df.group("value").into("values").ungroup("values") matches df.group { value }.into("values").ungroup { values }
+    }
+
+    @Test
+    fun Update0() {
+        df.update("value").with { (it as Int) + 1 } matches df.update { value }.with { it + 1 }
+    }
+
+    @Test
+    fun ValueCounts() {
+        df.valueCounts("key") matches df.valueCounts { key }
+    }
+}

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/commonTestData.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/commonTestData.kt
@@ -1,0 +1,81 @@
+package org.jetbrains.kotlinx.dataframe.plugin.stringApi
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.columnOf
+import org.jetbrains.kotlinx.dataframe.api.compileTimeSchema
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.first
+
+abstract class CommonTestData {
+    val df: DataFrame<Df> = dataFrameOf("key", "value", "other", "nullable", "nan")(
+        "a",
+        1,
+        10,
+        1,
+        Double.NaN,
+        "a",
+        2,
+        20,
+        null,
+        2.0,
+        "b",
+        3,
+        30,
+        3,
+        Double.NaN,
+    ).cast<Df>()
+    val dfRaw: DataFrame<Any> = df.cast<Any>()
+
+    @DataSchema
+    class Df(
+        val key: String,
+        val value: Int,
+        val other: Int,
+        val nullable: Int?,
+        val nan: Double,
+    )
+
+    val other: DataFrame<Other> = dataFrameOf("key", "label")("a", "first", "c", "third").cast<Other>()
+    val otherRaw: DataFrame<Any> = other.cast<Any>()
+
+    @DataSchema
+    interface Other {
+        val key: String
+        val label: String
+    }
+
+    val nested: DataFrame<Nested> = dataFrameOf("group")(dataFrameOf("value")(1, 2).first()).cast<Nested>()
+    val nestedRaw: DataFrame<Any> = nested.cast<Any>()
+
+    @DataSchema
+    data class Nested(val group: Group) {
+        @DataSchema
+        data class Group(val value: Int)
+    }
+
+    val lists: DataFrame<Lists> = dataFrameOf("values")(listOf(1, 2), emptyList<Int>()).cast<Lists>()
+    val listsRaw: DataFrame<Any> = lists.cast<Any>()
+
+    @DataSchema
+    class Lists(val values: List<Int>)
+
+    val records: DataFrame<RecordsFrame> = dataFrameOf("ab" to columnOf(Record("foo", 42))).cast<RecordsFrame>()
+    val recordsRaw: DataFrame<Any> = records.cast<Any>()
+
+    @DataSchema
+    data class RecordsFrame(val ab: Record)
+
+    class Record(val a: String, val b: Int)
+
+    inline infix fun <reified T, reified T1> DataFrame<T>.matches(other: DataFrame<T1>) {
+        compileTimeSchema() shouldBe other.compileTimeSchema()
+    }
+
+    inline infix fun <reified T, reified T1> DataRow<T>.matches(other: DataRow<T1>) {
+        df().compileTimeSchema() shouldBe other.df().compileTimeSchema()
+    }
+}

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/commonTestData.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/plugin/stringApi/commonTestData.kt
@@ -11,22 +11,11 @@ import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
 import org.jetbrains.kotlinx.dataframe.api.first
 
 abstract class CommonTestData {
+    @Suppress("ktlint:standard:argument-list-wrapping")
     val df: DataFrame<Df> = dataFrameOf("key", "value", "other", "nullable", "nan")(
-        "a",
-        1,
-        10,
-        1,
-        Double.NaN,
-        "a",
-        2,
-        20,
-        null,
-        2.0,
-        "b",
-        3,
-        30,
-        3,
-        Double.NaN,
+        "a", 1, 10, 1, Double.NaN,
+        "a", 2, 20, null, 2.0,
+        "b", 3, 30, 3, Double.NaN,
     ).cast<Df>()
     val dfRaw: DataFrame<Any> = df.cast<Any>()
 

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/schemas/DataSchemasTroubleshooting.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/schemas/DataSchemasTroubleshooting.kt
@@ -43,7 +43,7 @@ class DataSchemasTroubleshooting {
 
     @Test
     fun extensionGeneratedWithAnIncompatibleSchema() {
-        shouldThrow<ClassCastException> {
+        shouldThrow<IllegalStateException> {
             // SampleStart
             val df = DataFrame.readCsv(simpleCsvFile).cast<Schema>()
 

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/util/DataFrameApiAnalysis.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/util/DataFrameApiAnalysis.kt
@@ -1,0 +1,101 @@
+package org.jetbrains.kotlinx.dataframe.util
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.at
+import org.jetbrains.kotlinx.dataframe.api.cast
+import org.jetbrains.kotlinx.dataframe.api.convert
+import org.jetbrains.kotlinx.dataframe.api.dropNulls
+import org.jetbrains.kotlinx.dataframe.api.filter
+import org.jetbrains.kotlinx.dataframe.api.insert
+import org.jetbrains.kotlinx.dataframe.api.select
+import org.jetbrains.kotlinx.dataframe.api.toDataFrame
+import org.jetbrains.kotlinx.dataframe.api.with
+
+/**
+ * Make sure to add `import org.jetbrains.kotlinx.dataframe.util.*` for to use generated properties, if needed.
+ * https://youtrack.jetbrains.com/issue/KTIJ-35709/Compiler-plugin-generated-properties-are-not-recommended-for-import-in-other-packages
+ */
+fun dataFrameApi(): DataFrame<DataFrameApi> {
+    val scope = Konsist.scopeFromDirectories(listOf("core"))
+        .functions()
+        .filter { !it.path.contains("generated") }
+
+    return scope.toDataFrame()
+        .filter { it.hasPublicModifier }
+        .filter { !annotations.any { it.name in setOf("Deprecated", "AccessApiOverload") } }
+        .select {
+            cols(
+                receiverType,
+                name,
+                parameters,
+                returnType,
+                annotations,
+                projectPath,
+                isTopLevel,
+                typeParameters,
+            )
+        }
+        .convert { projectPath }.with { it.removePrefix("projectPath: ") }
+        .cast<DataFrameApi>()
+}
+
+@DataSchema
+data class DataFrameApi(
+    val receiverType: KoTypeDeclaration?,
+    val name: String,
+    val parameters: List<KoParameterDeclaration>,
+    val returnType: KoTypeDeclaration?,
+    val annotations: List<KoAnnotationDeclaration>,
+    val projectPath: String,
+    val isTopLevel: Boolean,
+    val typeParameters: List<KoTypeParameterDeclaration>,
+)
+
+fun DataFrame<DataFrameApi>.interpretableFunctions(): DataFrame<InterpretableFunctions> =
+    select {
+        annotations and receiverType and name and parameters and returnType
+    }
+        .filter { annotations.any { it.name == "Interpretable" } }
+        .insert("interpreter") {
+            annotations
+                .single { it.name == "Interpretable" }
+                .arguments.single().value
+        }.at(0)
+        .cast<InterpretableFunctions>()
+
+@DataSchema
+data class InterpretableFunctions(
+    val interpreter: String?,
+    val annotations: List<KoAnnotationDeclaration>,
+    val receiverType: KoTypeDeclaration?,
+    val name: String,
+    val parameters: List<KoParameterDeclaration>,
+    val returnType: KoTypeDeclaration?,
+)
+
+fun DataFrame<DataFrameApi>.stringApiFunctions(): DataFrame<StringApiFunctions> =
+    insert("annotationArguments") {
+        annotations.singleOrNull { it.name == "StringApiInterpretable" }
+            ?.arguments?.map { it.value }
+    }.at(0)
+        .dropNulls { annotationArguments }
+        .cast<StringApiFunctions>()
+
+@DataSchema
+data class StringApiFunctions(
+    val annotationArguments: List<String?>,
+    val receiverType: KoTypeDeclaration?,
+    val name: String,
+    val parameters: List<KoParameterDeclaration>,
+    val returnType: KoTypeDeclaration?,
+    val annotations: List<KoAnnotationDeclaration>,
+    val projectPath: String,
+    val isTopLevel: Boolean,
+    val typeParameters: List<KoTypeParameterDeclaration>,
+)


### PR DESCRIPTION
This PR enables plugin interpretation for String overloads that have CS DSL counterparts, see 
Plugin.kt:
```
Marks String API overloads (functions with vararg String parameters) with metadata to enable automatic delegation to their typed counterparts implementations in the compiler plugin. This annotation should not have default values for arguments (breaks plugin resolve).
Params:
interpreter - The interpreter name from the corresponding @Interpretable annotation on the typed API function (the one with ColumnSelectionDsl parameter)
targetArgument - The name of the ColumnSelectionDsl parameter in the typed API function
```

RawSchemaOperationsResultCorrectnessTest:
```
Making sure compiler evaluation of String API overload on raw dataframe (no schema) is correct whatever columns appear as a result are "type safe"; 
no ColumnNotFound or ClassCast exceptions will happen if property is used. 
```
**User scenario** when df has no schema, some string operations are invoked, and as a result we enrich schema

TypedSchemaOperationsResultConsistencyTest:
```
Making sure compiler evaluates String API overloads same as CS DSL overloads on typed input.
Sometimes some precision is expected to be lost, see Merge0
```
**User scenario** when dataframe itself is typed, but user chose to use String overload for simplicity => we do not loose information

I had to update kotlin to 2.4.20-RC2 so that compiler plugin understands StringApiInterpretable, to have these tests in this repo, i think it's better for visibility in this case

I plan to update this PR: clean up lint.kt and add annotations to a few remaining functions. 
Check the overall idea, clarity of tests, etc. 