### PR TITLE
Defined `append`s behavior on some corner cases and added tests

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
@@ -9,8 +9,13 @@ import org.jetbrains.kotlinx.dataframe.nrow
 // region DataFrame
 
 public fun <T> DataFrame<T>.append(vararg values: Any?): DataFrame<T> {
+    if (values.isEmpty()) return this
+
     val ncol = ncol
-    check(values.size % ncol == 0) {
+    require(ncol > 0) {
+        "Cannot append values to a DataFrame with no columns"
+    }
+    require(values.size % ncol == 0) {
         "Invalid number of arguments. Multiple of $ncol is expected, but actual was: ${values.size}"
     }
     val newRows = values.size / ncol

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
@@ -123,7 +123,9 @@ internal fun <T, C> DataColumn<C>.updateImpl(
 }
 
 /**
- * Replaces all values in column asserting that new values are compatible with current column kind
+ * Replaces all values in column asserting that new values are compatible with current column kind.
+ *
+ * For a [FrameColumn], `null` values are replaced by empty dataframes with the column's schema.
  */
 internal fun <T> DataColumn<T>.updateWith(values: List<T>): DataColumn<T> =
     when (this) {

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
@@ -128,10 +128,14 @@ internal fun <T, C> DataColumn<C>.updateImpl(
 internal fun <T> DataColumn<T>.updateWith(values: List<T>): DataColumn<T> =
     when (this) {
         is FrameColumn<*> -> {
-            values.forEach {
-                require(it is AnyFrame) { "Can not add value '$it' to FrameColumn" }
+            val frameSchema by schema
+            val groups = values.map {
+                when (it) {
+                    null -> DataFrame.empty(frameSchema)
+                    is AnyFrame -> it
+                    else -> throw IllegalArgumentException("Can not add value '$it' to FrameColumn")
+                }
             }
-            val groups = (values as List<AnyFrame>)
             DataColumn.createFrameColumn(name, groups) as DataColumn<T>
         }
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/impl/api/update.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlinx.dataframe.columns.size
 import org.jetbrains.kotlinx.dataframe.impl.columns.AddDataRowImpl
 import org.jetbrains.kotlinx.dataframe.impl.createDataCollector
 import org.jetbrains.kotlinx.dataframe.index
+import org.jetbrains.kotlinx.dataframe.nrow
 import org.jetbrains.kotlinx.dataframe.type
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.withNullability
@@ -123,7 +124,7 @@ internal fun <T, C> DataColumn<C>.updateImpl(
 }
 
 /**
- * Replaces all values in column asserting that new values are compatible with current column kind.
+ * Replaces all values in the column asserting that new values are compatible with the current column kind.
  *
  * For a [FrameColumn], `null` values are replaced by empty dataframes with the column's schema.
  */
@@ -138,7 +139,7 @@ internal fun <T> DataColumn<T>.updateWith(values: List<T>): DataColumn<T> =
                     else -> throw IllegalArgumentException("Can not add value '$it' to FrameColumn")
                 }
             }
-            DataColumn.createFrameColumn(name, groups) as DataColumn<T>
+            DataColumn.createFrameColumn(name, groups, schema.takeIf { groups.all { it.nrow == 0 } }) as DataColumn<T>
         }
 
         is ColumnGroup<*> -> {

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
@@ -12,8 +14,6 @@ import kotlin.reflect.typeOf
 class AppendTests {
 
     // region append
-
-    private data class Person(val name: String, val age: Int) : DataRowSchema
 
     @Test
     fun `append adds one row assigning values by column order`() {
@@ -68,20 +68,17 @@ class AppendTests {
         val df = dataFrameOf(columnOf(frame) named "col")
 
         val result = df.append(null)
+        val resultColumn = result.getFrameColumn("col")
 
         result.nrow shouldBe 2
-        result["col"].kind() shouldBe ColumnKind.Frame
-        result["col"].type() shouldBe typeOf<DataFrame<*>>()
-        result["col"].values() shouldBe listOf(frame, DataFrame.empty(frame.schema()))
-    }
-
-    @Test
-    fun `append uses the DataRowSchema overload`() {
-        val df = dataFrameOf(Person("Alice", 20))
-
-        val result = df.append(Person("Bill", 30))
-
-        result shouldBe dataFrameOf("name", "age")("Alice", 20, "Bill", 30)
+        resultColumn.kind() shouldBe ColumnKind.Frame
+        resultColumn.type() shouldBe typeOf<DataFrame<*>>()
+        resultColumn.values() shouldBe listOf(frame, DataFrame.empty(frame.schema()))
+        resultColumn.values().toList() shouldForAll {
+            shouldNotThrowAny {
+                it["value"]
+            }
+        }
     }
 
     @Test
@@ -160,15 +157,21 @@ class AppendTests {
         val df = dataFrameOf(columnOf(frame) named "col")
 
         val result = df.appendNulls(2)
+        val resultColumn = result.getFrameColumn("col")
 
         result.nrow shouldBe 3
-        result["col"].kind() shouldBe ColumnKind.Frame
-        result["col"].type() shouldBe typeOf<DataFrame<*>>()
-        result["col"].values() shouldBe listOf(
+        resultColumn.kind() shouldBe ColumnKind.Frame
+        resultColumn.type() shouldBe typeOf<DataFrame<*>>()
+        resultColumn.values() shouldBe listOf(
             frame,
             DataFrame.empty(frame.schema()),
             DataFrame.empty(frame.schema()),
         )
+        resultColumn.values().toList() shouldForAll {
+            shouldNotThrowAny {
+                it["value"]
+            }
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
@@ -1,16 +1,69 @@
 package org.jetbrains.kotlinx.dataframe.api
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 import org.junit.Test
 import kotlin.reflect.typeOf
 
 class AppendTests {
 
+    // region append
+
+    private data class Person(val name: String, val age: Int) : DataRowSchema
+
     @Test
-    fun `append null to frame column replaces it with schema-aware empty dataframe`() {
+    fun `append adds one row assigning values by column order`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.append("Bill", 30)
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, "Bill", 30)
+    }
+
+    @Test
+    fun `append adds multiple rows interpreting values row-wise`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.append("Mike", 15, "John", 17, "Bill", 30)
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, "Mike", 15, "John", 17, "Bill", 30)
+    }
+
+    @Test
+    fun `append rejects wrong number of arguments`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            df.append("Bill")
+        }
+
+        exception.message shouldBe "Invalid number of arguments. Multiple of 2 is expected, but actual was: 1"
+    }
+
+    @Test
+    fun `append zero rows`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.append()
+
+        (result === df) shouldBe true
+    }
+
+    @Test
+    fun `append adds null as a value to a value column`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.append(null, 30)
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, null, 30)
+    }
+
+    @Test
+    fun `append null to frame column replaces null with empty dataframe with schema`() {
         val frame = dataFrameOf("value")(1)
         val df = dataFrameOf(columnOf(frame) named "col")
 
@@ -21,4 +74,120 @@ class AppendTests {
         result["col"].type() shouldBe typeOf<DataFrame<*>>()
         result["col"].values() shouldBe listOf(frame, DataFrame.empty(frame.schema()))
     }
+
+    @Test
+    fun `append uses the DataRowSchema overload`() {
+        val df = dataFrameOf(Person("Alice", 20))
+
+        val result = df.append(Person("Bill", 30))
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, "Bill", 30)
+    }
+
+    @Test
+    fun `append zero rows for a dataframe with no columns`() {
+        val df = DataFrame.empty(nrow = 2)
+
+        val result = df.append()
+
+        (result === df) shouldBe true
+    }
+
+    @Test
+    fun `append rejects values for a dataframe with no columns`() {
+        val df = DataFrame.empty(nrow = 2)
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            df.append(1)
+        }
+
+        exception.message shouldBe "Cannot append values to a DataFrame with no columns"
+    }
+
+    // endregion
+
+    // region appendNulls
+
+    @Test
+    fun `appendNulls adds one row by default`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.appendNulls()
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, null, null)
+    }
+
+    @Test
+    fun `appendNulls adds the requested number of rows`() {
+        val df = dataFrameOf("name", "age")("Alice", 20)
+
+        val result = df.appendNulls(3)
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, null, null, null, null, null, null)
+    }
+
+    @Test
+    fun `appendNulls with zero rows returns the original dataframe`() {
+        val df = dataFrameOf("value")(1)
+
+        val result = df.appendNulls(0)
+
+        (result === df) shouldBe true
+    }
+
+    @Test
+    fun `appendNulls rejects a negative number of rows`() {
+        val df = dataFrameOf("value")(1)
+
+        shouldThrow<IllegalArgumentException> {
+            df.appendNulls(-1)
+        }
+    }
+
+    @Test
+    fun `appendNulls adds rows to a dataframe with no columns`() {
+        val df = DataFrame.empty(nrow = 2)
+
+        val result = df.appendNulls(3)
+
+        result.ncol shouldBe 0
+        result.nrow shouldBe 5
+    }
+
+    @Test
+    fun `appendNulls adds to a frame column empty dataframes`() {
+        val frame = dataFrameOf("value")(1)
+        val df = dataFrameOf(columnOf(frame) named "col")
+
+        val result = df.appendNulls(2)
+
+        result.nrow shouldBe 3
+        result["col"].kind() shouldBe ColumnKind.Frame
+        result["col"].type() shouldBe typeOf<DataFrame<*>>()
+        result["col"].values() shouldBe listOf(
+            frame,
+            DataFrame.empty(frame.schema()),
+            DataFrame.empty(frame.schema()),
+        )
+    }
+
+    @Test
+    fun `appendNulls with a column group`() {
+        val df = dataFrameOf(
+            "person" to columnOf(
+                "name" to columnOf("Alice"),
+                "age" to columnOf(20),
+            ),
+        )
+
+        val result = df.appendNulls()
+        val resultGroup = result["person"].asColumnGroup()
+
+        result.nrow shouldBe 2
+        resultGroup.kind() shouldBe ColumnKind.Group
+        resultGroup["name"].values() shouldBe listOf("Alice", null)
+        resultGroup["age"].values() shouldBe listOf(20, null)
+    }
+
+    // endregion
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
@@ -82,6 +82,24 @@ class AppendTests {
     }
 
     @Test
+    fun `append null preserves frame column schema across repeated calls`() {
+        val frame = dataFrameOf("value")(1)
+        val schema = dataFrameOf(columnOf(frame) named "col").schema()
+        val df = DataFrame.empty(schema)
+
+        val result = df.append(null).append(null)
+        val resultColumn = result.getFrameColumn("col")
+
+        result.nrow shouldBe 2
+        result.schema() shouldBe schema
+        resultColumn.values().toList() shouldForAll {
+            shouldNotThrowAny {
+                it["value"]
+            }
+        }
+    }
+
+    @Test
     fun `append zero rows for a dataframe with no columns`() {
         val df = DataFrame.empty(nrow = 2)
 
@@ -167,6 +185,24 @@ class AppendTests {
             DataFrame.empty(frame.schema()),
             DataFrame.empty(frame.schema()),
         )
+        resultColumn.values().toList() shouldForAll {
+            shouldNotThrowAny {
+                it["value"]
+            }
+        }
+    }
+
+    @Test
+    fun `appendNulls preserves frame column schema across repeated calls`() {
+        val frame = dataFrameOf("value")(1)
+        val schema = dataFrameOf(columnOf(frame) named "col").schema()
+        val df = DataFrame.empty(schema)
+
+        val result = df.appendNulls().appendNulls()
+        val resultColumn = result.getFrameColumn("col")
+
+        result.nrow shouldBe 2
+        result.schema() shouldBe schema
         resultColumn.values().toList() shouldForAll {
             shouldNotThrowAny {
                 it["value"]

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/append.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.kotlinx.dataframe.api
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.nrow
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class AppendTests {
+
+    @Test
+    fun `append null to frame column replaces it with schema-aware empty dataframe`() {
+        val frame = dataFrameOf("value")(1)
+        val df = dataFrameOf(columnOf(frame) named "col")
+
+        val result = df.append(null)
+
+        result.nrow shouldBe 2
+        result["col"].kind() shouldBe ColumnKind.Frame
+        result["col"].type() shouldBe typeOf<DataFrame<*>>()
+        result["col"].values() shouldBe listOf(frame, DataFrame.empty(frame.schema()))
+    }
+}

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/testSets/person/DataFrameTests.kt
@@ -1780,27 +1780,6 @@ class DataFrameTests : BaseTest() {
     }
 
     @Test
-    fun `append many`() {
-        val res = typed.append(
-            "John", 22,
-            "New York", 46,
-            "Philip", 25,
-            "Chelyabinsk", 36,
-        )
-        res.nrow shouldBe typed.nrow + 2
-    }
-
-    @Test
-    fun `append wrong number of arguments`() {
-        shouldThrow<IllegalStateException> {
-            dataFrameOf("name", "age")(
-                "Alice", 15,
-                "Bob", 20,
-            ).append("John")
-        }
-    }
-
-    @Test
     fun `first last`() {
         typed.first() shouldBe typed[0]
         typed.last() shouldBe typed[typed.nrow - 1]

--- a/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Append.kt
+++ b/samples/src/test/kotlin/org/jetbrains/kotlinx/dataframe/samples/api/Append.kt
@@ -1,0 +1,22 @@
+package org.jetbrains.kotlinx.dataframe.samples.api
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.api.append
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.junit.Test
+
+class Append {
+
+    @DataSchema
+    data class Person(val name: String, val age: Int)
+
+    @Test
+    fun `append uses the compiler plugin overload`() {
+        val df = dataFrameOf(Person("Alice", 20))
+
+        val result = df.append(Person("Bill", 30))
+
+        result shouldBe dataFrameOf("name", "age")("Alice", 20, "Bill", 30)
+    }
+}


### PR DESCRIPTION
Fixes #1952
Fixes #1927 

- Currently `append` fails when one appends a `null` to a `FrameColumn`. Changes from this PR make `append` add an empty frame instead of `null`, keeping the type of the column `FrameColumn`.
- Make `append` return the original dataframe early when `append` does not have any arguments.
- Make `append` with arguments fail with an informative message when the receiver dataframe has no columns.
- Add tests for `append`