### PR TITLE
Add KDocs, tests, and a docs page for `isEmpty` / `isNotEmpty`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
@@ -1,13 +1,99 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
+import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
+import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
 import org.jetbrains.kotlinx.dataframe.ncol
 import org.jetbrains.kotlinx.dataframe.nrow
 
+@ExcludeFromSources
+internal interface IsEmptyDocs {
+
+    /**
+     * Removing all columns with [remove][DataFrame.remove] keeps the number of rows,
+     * so a [DataFrame] can have rows and no columns.
+     * Such a [DataFrame] holds no values, so it counts as empty as well as one without rows.
+     *
+     * A [ColumnGroup] is a [DataFrame] too, and both cases apply to it:
+     * a column group is empty when it has no nested columns,
+     * or when the [DataFrame] that holds it has no rows.
+     *
+     * Nested [DataFrame]s of a [FrameColumn] are not taken into account:
+     * a [DataFrame] whose frame column holds only empty [DataFrame]s is not empty itself.
+     */
+    @ExcludeFromSources
+    typealias EmptinessSnippet = Nothing
+
+    /**
+     * {@comment The input of every `isEmpty` / `isNotEmpty` example. KDoc-snippet.
+     *    Every result that follows it is an expected value in `IsEmptyTests`.}
+     *
+     * The examples below use this [DataFrame], the same data as the
+     * [`isEmpty` page on the documentation website]({@include [DocumentationUrls.Url]}/isempty.html):
+     *
+     * | name    | age |
+     * | :------ | :-- |
+     * | Alice   | 15  |
+     * | Charlie | 40  |
+     */
+    @ExcludeFromSources
+    typealias ExampleDataSnippet = Nothing
+}
+
 // region DataFrame
 
+/**
+ * Returns `true` if this [DataFrame] has no rows or no columns.
+ *
+ * @include [IsEmptyDocs.EmptinessSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.IsEmpty]}
+ *
+ * See also:
+ * - [isNotEmpty][DataFrame.isNotEmpty] — the opposite check.
+ * - [rowsCount][DataFrame.rowsCount] and [columnsCount][DataFrame.columnsCount] — the two numbers behind it.
+ * - [DataFrame.Empty], [DataFrame.empty] and [emptyDataFrame] — create an empty [DataFrame].
+ *
+ * ### Example
+ *
+ * @include [IsEmptyDocs.ExampleDataSnippet]
+ *
+ * ```kotlin
+ * df.isEmpty() // false
+ * df.filter { age > 100 }.isEmpty() // true: no row is left
+ * df.remove { all() }.isEmpty() // true: no column is left, while both rows are still there
+ * ```
+ *
+ * @return `true` if this [DataFrame] has no rows or no columns, `false` otherwise.
+ */
 public fun DataFrame<*>.isEmpty(): Boolean = ncol == 0 || nrow == 0
 
+/**
+ * Returns `true` if this [DataFrame] has at least one row and at least one column,
+ * that is, if it is not empty.
+ *
+ * @include [IsEmptyDocs.EmptinessSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.IsNotEmpty]}
+ *
+ * See also:
+ * - [isEmpty][DataFrame.isEmpty] — the opposite check.
+ * - [rowsCount][DataFrame.rowsCount] and [columnsCount][DataFrame.columnsCount] — the two numbers behind it.
+ * - [DataFrame.Empty], [DataFrame.empty] and [emptyDataFrame] — create an empty [DataFrame].
+ *
+ * ### Example
+ *
+ * @include [IsEmptyDocs.ExampleDataSnippet]
+ *
+ * ```kotlin
+ * df.isNotEmpty() // true
+ * df.filter { age > 100 }.isNotEmpty() // false: no row is left
+ * ```
+ *
+ * @return `true` if this [DataFrame] has at least one row and at least one column, `false` otherwise.
+ */
 public fun DataFrame<*>.isNotEmpty(): Boolean = !isEmpty()
 
 // endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
@@ -239,6 +239,12 @@ public interface DocumentationUrls {
     /** [See `countDistinct` on the documentation website.]({@include [Url]}/countdistinct.html) */
     public typealias CountDistinct = Nothing
 
+    /** [See `isEmpty` on the documentation website.]({@include [Url]}/isempty.html) */
+    public typealias IsEmpty = Nothing
+
+    /** [See `isNotEmpty` on the documentation website.]({@include [Url]}/isempty.html#isnotempty) */
+    public typealias IsNotEmpty = Nothing
+
     /** [See `valueCounts` on the documentation website.]({@include [Url]}/valuecounts.html) */
     public typealias ValueCounts = Nothing
 

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/isEmpty.kt
@@ -1,0 +1,137 @@
+package org.jetbrains.kotlinx.dataframe.api
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.AnyFrame
+import org.jetbrains.kotlinx.dataframe.DataColumn
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
+import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.junit.Test
+
+class IsEmptyTests {
+
+    /** The dataframe from the `isEmpty` / `isNotEmpty` KDoc examples and from the `isEmpty` documentation page. */
+    private val df = dataFrameOf(
+        "name" to columnOf("Alice", "Charlie"),
+        "age" to columnOf(15, 40),
+    )
+
+    @Test
+    fun `dataframe with rows and columns is not empty`() {
+        df.isEmpty() shouldBe false
+        df.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `dataframe with columns but no rows is empty`() {
+        val noRows = df.filter { "age"<Int>() > 100 }
+        // the columns are still there, only the rows are gone
+        noRows.columnsCount() shouldBe 2
+        noRows.rowsCount() shouldBe 0
+
+        noRows.isEmpty() shouldBe true
+        noRows.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `dataframe with rows but no columns is empty`() {
+        val noColumns = df.remove { all() }
+        // removing all columns keeps the number of rows
+        noColumns.columnsCount() shouldBe 0
+        noColumns.rowsCount() shouldBe 2
+
+        noColumns.isEmpty() shouldBe true
+        noColumns.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `dataframe created with rows but no columns is empty`() {
+        val rowsOnly = DataFrame.empty(nrow = 5)
+        rowsOnly.columnsCount() shouldBe 0
+        rowsOnly.rowsCount() shouldBe 5
+
+        rowsOnly.isEmpty() shouldBe true
+        rowsOnly.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `dataframe without rows and columns is empty`() {
+        DataFrame.Empty.columnsCount() shouldBe 0
+        DataFrame.Empty.rowsCount() shouldBe 0
+
+        DataFrame.Empty.isEmpty() shouldBe true
+        DataFrame.Empty.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `column group with nested columns and rows is not empty`() {
+        // the explicit type makes sure the call resolves to the DataFrame extension
+        val group: ColumnGroup<*> = df.group { all() }.into("person")["person"].asColumnGroup()
+        group.isEmpty() shouldBe false
+        group.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `column group without nested columns is empty`() {
+        val group: ColumnGroup<*> = DataColumn.createColumnGroup("person", DataFrame.Empty)
+        group.columnsCount() shouldBe 0
+
+        group.isEmpty() shouldBe true
+        group.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `column group in a dataframe without rows is empty`() {
+        val group: ColumnGroup<*> = df
+            .group { all() }.into("person")
+            .filter { false }["person"].asColumnGroup()
+        // the nested columns are still there, the group just has no rows
+        group.columnsCount() shouldBe 2
+        group.rowsCount() shouldBe 0
+
+        group.isEmpty() shouldBe true
+        group.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `dataframe whose only column is an empty column group is empty`() {
+        val group = DataColumn.createColumnGroup("person", DataFrame.Empty)
+        val withEmptyGroup = dataFrameOf(group.asDataColumn())
+        // the column is there, but an empty group has no rows, so the dataframe has none either
+        withEmptyGroup.columnsCount() shouldBe 1
+        withEmptyGroup.rowsCount() shouldBe 0
+
+        withEmptyGroup.isEmpty() shouldBe true
+        withEmptyGroup.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `dataframe with empty nested dataframes is not empty`() {
+        val emptiedGroups = df
+            .groupBy { "name"<String>() }.into("groups")
+            .convert { "groups"<AnyFrame>() }.with { it.filter { false } }
+
+        // every value of the frame column is an empty dataframe
+        val groups: FrameColumn<*> = emptiedGroups["groups"].asFrameColumn()
+        groups.values().map { it.isEmpty() } shouldBe listOf(true, true)
+
+        // the outer dataframe keeps its own two columns and two rows, so it is not empty
+        emptiedGroups.columnsCount() shouldBe 2
+        emptiedGroups.rowsCount() shouldBe 2
+        emptiedGroups.isEmpty() shouldBe false
+        emptiedGroups.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `KDoc example isEmpty`() {
+        df.isEmpty() shouldBe false
+        df.filter { "age"<Int>() > 100 }.isEmpty() shouldBe true
+        df.remove { all() }.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `KDoc example isNotEmpty`() {
+        df.isNotEmpty() shouldBe true
+        df.filter { "age"<Int>() > 100 }.isNotEmpty() shouldBe false
+    }
+}

--- a/docs/StardustDocs/d.tree
+++ b/docs/StardustDocs/d.tree
@@ -82,6 +82,7 @@
         <toc-element topic="info.md">
             <toc-element topic="columnsCount.md"/>
             <toc-element topic="rowsCount.md"/>
+            <toc-element topic="isEmpty.md"/>
             <toc-element topic="countDistinct.md"/>
             <toc-element topic="columnNames.md"/>
             <toc-element topic="columnTypes.md"/>

--- a/docs/StardustDocs/topics/info.md
+++ b/docs/StardustDocs/topics/info.md
@@ -6,6 +6,7 @@ General information about [`DataFrame`](DataFrame.md):
 * [`count`](count.md) / [`rowsCount()`](rowsCount.md) — number of rows
 * [`countDistinct()`](countDistinct.md) — number of distinct rows
 * [`columnsCount()`](columnsCount.md) — number of columns
+* [`isEmpty()`](isEmpty.md) / [`isNotEmpty()`](isEmpty.md#isnotempty) — whether there are no rows or no columns
 * [`columnNames()`](columnNames.md) — list of column names
 * [`columnTypes()`](columnTypes.md) — list of column types
 * [`head(n)`](head.md) — first n rows (default 5)

--- a/docs/StardustDocs/topics/isEmpty.md
+++ b/docs/StardustDocs/topics/isEmpty.md
@@ -1,0 +1,50 @@
+[//]: # (title: isEmpty)
+
+Returns `true` if [`DataFrame`](DataFrame.md) has no rows or no columns.
+
+```kotlin
+isEmpty()
+```
+
+Removing all columns with [`remove`](remove.md) keeps the number of rows,
+so a [`DataFrame`](DataFrame.md) can have rows and no columns.
+Such a dataframe holds no values, so it counts as empty as well as one without rows.
+
+A [`ColumnGroup`](DataColumn.md#columngroup) is a [`DataFrame`](DataFrame.md) too, and both cases apply to it:
+a column group is empty when it has no nested columns, or when the dataframe that holds it has no rows.
+
+Nested dataframes of a [`FrameColumn`](DataColumn.md#framecolumn) are not taken into account: a dataframe
+whose frame column holds only empty dataframes — after [`groupBy`](groupBy.md), for example — is not empty
+itself.
+
+The examples below use this [`DataFrame`](DataFrame.md):
+
+| name    | age |
+|---------|-----|
+| Alice   | 15  |
+| Charlie | 40  |
+
+```kotlin
+df.isEmpty() // false
+df.filter { age > 100 }.isEmpty() // true: no row is left
+df.remove { all() }.isEmpty() // true: no column is left, while both rows are still there
+```
+
+## isNotEmpty
+
+Returns `true` if [`DataFrame`](DataFrame.md) has at least one row and at least one column,
+that is, if it is not empty.
+
+```kotlin
+isNotEmpty()
+```
+
+With the same two-row `df` as above:
+
+```kotlin
+df.isNotEmpty() // true
+df.filter { age > 100 }.isNotEmpty() // false: no row is left
+```
+
+See also [`rowsCount()`](rowsCount.md) and [`columnsCount()`](columnsCount.md) — the two numbers behind these
+checks, and [`emptyDataFrame()`](createDataFrame.md#emptydataframe) for creating an empty dataframe.

--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -2,7 +2,7 @@
 
 Kotlin DataFrame library's documentation is built from `.md` files in `docs/StardustDocs/topics`. 
 If you want to contribute to the documentation, find a suitable topic or create a new one.  
-Newly created topic must be added to a `docs/StardustDocs/topics/d.tree` to become visible in a navigation tree.
+Newly created topic must be added to a `docs/StardustDocs/d.tree` to become visible in a navigation tree.
 
 Some topics include code snippets in the text. 
 1. To add a snippet, find tests associated with topic. 


### PR DESCRIPTION
# Add KDocs, tests, and a docs page for `isEmpty` / `isNotEmpty`

Fixes #1968 

`DataFrame.isEmpty()` had no KDoc, no test, and no page on the website. The hard part is the word
"empty". A dataframe is empty when it has no rows **or** no columns, so there are two shapes to know
about, and the second one is easy to miss: `remove` keeps the row count, so `df.remove { all() }` gives
you rows without columns, and that dataframe is empty. Two more things are invisible in the signature.
A `ColumnGroup` is a `DataFrame`, so you can call both checks on a column group. 

And the check is not recursive: after `groupBy`, a frame column can hold only empty dataframes while the outer dataframe is
still not empty. Note that `DataRow` has two deprecated functions with the same names and a different
meaning; this PR does not link to them.

| File | What changed |
| :--- | :--- |
| `core/…/api/isEmpty.kt` | KDoc for both functions. The shared text and the example data live in two KoDEx snippets inside `IsEmptyDocs` |
| `core/…/documentation/DocumentationUrls.kt` | website URLs `IsEmpty` and `IsNotEmpty` |
| `core/src/test/…/api/isEmpty.kt` | new test class, 12 tests |
| `docs/StardustDocs/topics/isEmpty.md` | new page; `isNotEmpty` is a section on it |
| `docs/StardustDocs/d.tree` | page added under "General info" |
| `docs/StardustDocs/topics/info.md` | both functions listed |
| `docs/contributions.md` | fixed path: a new topic goes to `docs/StardustDocs/d.tree`, not to `topics/d.tree` |

## Examples

The KDoc, the page, and the tests use the same two-row dataframe and the same calls. The third call,
`df.remove { all() }.isEmpty()`, shows the "rows but no columns" rule.

## Tests

Nothing covered these two functions before.

| Test | What it pins down |
| :--- | :--- |
| `dataframe with rows and columns is not empty` | the plain case |
| `dataframe with columns but no rows is empty` | zero rows is enough |
| `dataframe with rows but no columns is empty` | `remove { all() }` keeps 2 rows, and the result is still empty |
| `dataframe created with rows but no columns is empty` | the same shape from the public factory `DataFrame.empty(nrow)` |
| `dataframe without rows and columns is empty` | `DataFrame.Empty` |
| `dataframe whose only column is an empty column group is empty` | the only case where the column count is not zero and the result is still `true` |
| `dataframe with empty nested dataframes is not empty` | the check is not recursive: all groups are empty, the outer dataframe is not |
| three `column group …` tests | a column group is empty when it has no nested columns, or when the dataframe around it has no rows |
| `KDoc example isEmpty`, `KDoc example isNotEmpty` | the documented calls, so the docs cannot drift from the behavior |

Expected values are written out, not computed. This matters here: a test like
`a.isNotEmpty() shouldBe !a.isEmpty()` would pass on any code, because one function is defined as the
other. Column-group receivers use an explicit `ColumnGroup<*>` type, so the call cannot resolve
somewhere else.