### PR TITLE
Add KDoc and tests for `ColumnAccessor.nullable()`

### DIFF
--- a/KDOC_GUIDELINES.md
+++ b/KDOC_GUIDELINES.md
@@ -420,18 +420,19 @@ For complex operations, write a **complete** example with all steps.
 
 For methods with Columns Selection DSL, add several examples with different CS DSL selection methods.
 
-Keep deprecated API out of the examples, even when documenting a legacy function. Around the Column
-Accessors API, for instance, almost everything that reads through an accessor (`df[accessor]`,
-`row[accessor]`, `accessor()`) is deprecated, while `accessor.getValue(row)` is not — check the
-annotations before copying a call from an old test. The deprecation messages are constants in
-[`util/deprecationMessages.kt`](./core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt)
-(`DEPRECATED_ACCESS_API`, `DEPRECATED_DATA_ROW_COLUMN_REFERENCE_GET`), so a grep for the constant
-shows the whole affected surface at once.
+Keep deprecated API out of the examples, even when documenting a legacy function — check for
+`@Deprecated` before copying a call from an old test.
 
 Start the section with
 
 ```
 ### Examples
+```
+
+or, when the KDoc has exactly one example, with
+
+```
+### Example
 ```
 
 #### Data tables in examples

--- a/KDOC_GUIDELINES.md
+++ b/KDOC_GUIDELINES.md
@@ -420,6 +420,14 @@ For complex operations, write a **complete** example with all steps.
 
 For methods with Columns Selection DSL, add several examples with different CS DSL selection methods.
 
+Keep deprecated API out of the examples, even when documenting a legacy function. Around the Column
+Accessors API, for instance, almost everything that reads through an accessor (`df[accessor]`,
+`row[accessor]`, `accessor()`) is deprecated, while `accessor.getValue(row)` is not — check the
+annotations before copying a call from an old test. The deprecation messages are constants in
+[`util/deprecationMessages.kt`](./core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/util/deprecationMessages.kt)
+(`DEPRECATED_ACCESS_API`, `DEPRECATED_DATA_ROW_COLUMN_REFERENCE_GET`), so a grep for the constant
+shows the whole affected surface at once.
+
 Start the section with
 
 ```

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
  * [ColumnAccessor] is covariant in its value type, so a `ColumnAccessor<Double>` is already
  * accepted where a `ColumnAccessor<Double?>` is expected; what changes here is the declared type
  * of the accessor itself. Reading a value with `getValue(row)` then gives `T?` instead of `T`.
- * Without this cast, a `null` from the column arrives as a `null` in the non-nullable type `T`
- * and fails later, at the first use of the value.
+ *
+ * Without this cast, a `null` from the column arrives typed as the non-nullable `T`, so the compiler
+ * cannot require a null check. The value then travels on until something uses it as a `T`, and that
+ * use may throw a [NullPointerException] — for a primitive type such as `Double` it always does.
  *
  * See also [castToNullable][ColumnReference.castToNullable], which marks any [ColumnReference]
  * as nullable but returns a [ColumnReference] instead of a [ColumnAccessor],
@@ -24,13 +26,17 @@ import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
  * ```kotlin
  * // `other` has no "score" column, so after `concat` the score of its rows is `null`:
  * val df = scores.concat(other)
+ * val row = df.last()
  *
  * // the accessor for the "score" column, and the same accessor typed as `Double?`:
  * val score by column<Double>()
  * val scoreOrNull = score.nullable()
  *
- * // the missing scores can now be handled instead of failing later:
- * df.filter { scoreOrNull.getValue(this) != null }
+ * // typed as `Double`, the `null` is invisible to the compiler and throws when the value is used:
+ * score.getValue(row) > 0.0 // NullPointerException
+ *
+ * // typed as `Double?`, the same `null` has to be handled:
+ * scoreOrNull.getValue(row)?.let { it > 0.0 } == true // false
  * ```
  *
  * @param [T] The value type of the column this accessor points to.

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
@@ -1,5 +1,39 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
+import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 
+/**
+ * Returns this [ColumnAccessor] with its value type marked as nullable.
+ *
+ * The cast exists only at compile time: no column is looked up and no value is read,
+ * the accessor keeps its name and its path, and there is no check that a column with this name
+ * exists or that it really contains `null`s.
+ *
+ * [ColumnAccessor] is covariant in its value type, so a `ColumnAccessor<Double>` is already
+ * accepted where a `ColumnAccessor<Double?>` is expected; what changes here is the declared type
+ * of the accessor itself. Reading a value with `getValue(row)` then gives `T?` instead of `T`.
+ * Without this cast, a `null` from the column arrives as a `null` in the non-nullable type `T`
+ * and fails later, at the first use of the value.
+ *
+ * See also [castToNullable][ColumnReference.castToNullable], which marks any [ColumnReference]
+ * as nullable but returns a [ColumnReference] instead of a [ColumnAccessor],
+ * and [castToNotNullable][ColumnReference.castToNotNullable] for the opposite direction.
+ *
+ * ### Example
+ * ```kotlin
+ * // `other` has no "score" column, so after `concat` the score of its rows is `null`:
+ * val df = scores.concat(other)
+ *
+ * // the accessor for the "score" column, and the same accessor typed as `Double?`:
+ * val score by column<Double>()
+ * val scoreOrNull = score.nullable()
+ *
+ * // the missing scores can now be handled instead of failing later:
+ * df.filter { scoreOrNull.getValue(this) != null }
+ * ```
+ *
+ * @param [T] The value type of the column this accessor points to.
+ * @return This accessor, typed as [ColumnAccessor]`<T?>`.
+ */
 public inline fun <reified T> ColumnAccessor<T>.nullable(): ColumnAccessor<T?> = cast()

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
@@ -3,12 +3,13 @@ package org.jetbrains.kotlinx.dataframe.api
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
-import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
 import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
 import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
 import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
 import org.junit.Test
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class ColumnAccessorApiTests {
 
@@ -17,8 +18,17 @@ class ColumnAccessorApiTests {
 
     private val dfWithoutNulls = dataFrameOf("score")(1.0, 0.5)
 
-    private fun DataFrame<*>.countScores(accessor: ColumnAccessor<Double?>) =
-        filter { accessor.getValue(this) != null }.rowsCount()
+    /**
+     * The value type of this accessor, exactly as the compiler infers it here.
+     *
+     * A type annotation would not do: [ColumnAccessor] is covariant, so `ColumnAccessor<Double?>` also
+     * accepts a `ColumnAccessor<Double>` and such an assertion would hold without [nullable] as well.
+     * `reified` captures the type argument itself, which is the only thing [nullable] changes.
+     */
+    private inline fun <reified T> ColumnAccessor<T>.valueType(): KType = typeOf<T>()
+
+    /** The static type of this expression, as opposed to the class of the object behind it. */
+    private inline fun <reified R> R.staticType(): KType = typeOf<R>()
 
     @Test
     fun `KDoc example nullable`() {
@@ -26,15 +36,20 @@ class ColumnAccessorApiTests {
         // no "score" column here, so `concat` fills it with `null` for this row
         val other = dataFrameOf("name")("Charlie")
         val df = scores.concat(other)
+        val row = df.last()
 
         val score by column<Double>()
         val scoreOrNull = score.nullable()
 
-        df.countScores(scoreOrNull) shouldBe 2
+        // typed as `Double`, the `null` is invisible to the compiler and throws when the value is used
+        shouldThrow<NullPointerException> { score.getValue(row) > 0.0 }
+
+        // typed as `Double?`, the same `null` has to be handled
+        (scoreOrNull.getValue(row)?.let { it > 0.0 } == true) shouldBe false
     }
 
     @Test
-    fun `a null read through a non-nullable accessor fails only at the first use`() {
+    fun `a null read through a non-nullable Double accessor throws when the value is used as a Double`() {
         val score = column<Double>("score")
         val row = dfWithNulls[1]
 
@@ -47,13 +62,18 @@ class ColumnAccessorApiTests {
     }
 
     @Test
-    fun `nullable returns the same accessor with a nullable value type`() {
+    fun `nullable widens the value type of the accessor`() {
         val score = column<Double>("score")
 
-        // the return type is the contract here, so it is written down explicitly
-        val scoreOrNull: ColumnAccessor<Double?> = score.nullable()
+        score.valueType() shouldBe typeOf<Double>()
+        score.nullable().valueType() shouldBe typeOf<Double?>()
+    }
 
-        scoreOrNull shouldBeSameInstanceAs score
+    @Test
+    fun `nullable returns the very same accessor`() {
+        val score = column<Double>("score")
+
+        score.nullable() shouldBeSameInstanceAs score
     }
 
     @Test
@@ -66,43 +86,46 @@ class ColumnAccessorApiTests {
 
     @Test
     fun `nullable keeps the name of a column group accessor`() {
-        val group: ColumnAccessor<DataRow<*>?> = columnGroup("group").nullable()
+        val group = columnGroup("group").nullable()
 
         group.name() shouldBe "group"
+        group.valueType() shouldBe typeOf<DataRow<*>?>()
     }
 
     @Test
     fun `nullable does not require the column to exist`() {
         // there is no column with this name anywhere, and still nothing fails
-        val missing: ColumnAccessor<Double?> = column<Double>("missing").nullable()
+        val missing = column<Double>("missing").nullable()
 
         missing.name() shouldBe "missing"
+        missing.valueType() shouldBe typeOf<Double?>()
     }
 
     @Test
     fun `nullable is allowed for a column without nulls`() {
         val scoreOrNull = column<Double>("score").nullable()
 
-        dfWithoutNulls.countScores(scoreOrNull) shouldBe 2
+        scoreOrNull.getValue(dfWithoutNulls[0]) shouldBe 1.0
+        scoreOrNull.getValue(dfWithoutNulls[1]) shouldBe 0.5
     }
 
     @Test
     fun `nullable on an already nullable accessor changes nothing`() {
         val score = column<Double?>("score")
 
-        val twice: ColumnAccessor<Double?> = score.nullable()
+        val twice = score.nullable()
 
         twice shouldBeSameInstanceAs score
+        twice.valueType() shouldBe typeOf<Double?>()
     }
 
     @Test
     fun `castToNullable on an accessor returns a ColumnReference`() {
         val score = column<Double>("score")
 
-        // the declared type is `ColumnReference`, so the `ColumnAccessor` members are gone,
-        // even though the object itself is still the very same accessor
-        val scoreOrNull: ColumnReference<Double?> = score.castToNullable()
-
-        scoreOrNull shouldBeSameInstanceAs score
+        // the `ColumnAccessor` members are gone from the result, even though the object itself
+        // is still the very same accessor
+        score.castToNullable().staticType() shouldBe typeOf<ColumnReference<Double?>>()
+        score.castToNullable() shouldBeSameInstanceAs score
     }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/ColumnAccessorApi.kt
@@ -1,0 +1,108 @@
+package org.jetbrains.kotlinx.dataframe.api
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.columns.ColumnAccessor
+import org.jetbrains.kotlinx.dataframe.columns.ColumnPath
+import org.jetbrains.kotlinx.dataframe.columns.ColumnReference
+import org.junit.Test
+
+class ColumnAccessorApiTests {
+
+    // the second row has no score
+    private val dfWithNulls = dataFrameOf("score")(1.0, null, 0.5)
+
+    private val dfWithoutNulls = dataFrameOf("score")(1.0, 0.5)
+
+    private fun DataFrame<*>.countScores(accessor: ColumnAccessor<Double?>) =
+        filter { accessor.getValue(this) != null }.rowsCount()
+
+    @Test
+    fun `KDoc example nullable`() {
+        val scores = dataFrameOf("name", "score")("Alice", 1.0, "Bob", 0.5)
+        // no "score" column here, so `concat` fills it with `null` for this row
+        val other = dataFrameOf("name")("Charlie")
+        val df = scores.concat(other)
+
+        val score by column<Double>()
+        val scoreOrNull = score.nullable()
+
+        df.countScores(scoreOrNull) shouldBe 2
+    }
+
+    @Test
+    fun `a null read through a non-nullable accessor fails only at the first use`() {
+        val score = column<Double>("score")
+        val row = dfWithNulls[1]
+
+        // the value arrives as `null`, even though the accessor is typed as `Double`
+        val raw: Any? = score.getValue(row)
+        raw shouldBe null
+
+        // the failure happens later, when the value is used as a `Double`
+        shouldThrow<NullPointerException> { score.getValue(row) > 0.0 }
+    }
+
+    @Test
+    fun `nullable returns the same accessor with a nullable value type`() {
+        val score = column<Double>("score")
+
+        // the return type is the contract here, so it is written down explicitly
+        val scoreOrNull: ColumnAccessor<Double?> = score.nullable()
+
+        scoreOrNull shouldBeSameInstanceAs score
+    }
+
+    @Test
+    fun `nullable keeps the name and the path`() {
+        val nested = column<Int>(ColumnPath(listOf("group", "value"))).nullable()
+
+        nested.name() shouldBe "value"
+        nested.path() shouldBe ColumnPath(listOf("group", "value"))
+    }
+
+    @Test
+    fun `nullable keeps the name of a column group accessor`() {
+        val group: ColumnAccessor<DataRow<*>?> = columnGroup("group").nullable()
+
+        group.name() shouldBe "group"
+    }
+
+    @Test
+    fun `nullable does not require the column to exist`() {
+        // there is no column with this name anywhere, and still nothing fails
+        val missing: ColumnAccessor<Double?> = column<Double>("missing").nullable()
+
+        missing.name() shouldBe "missing"
+    }
+
+    @Test
+    fun `nullable is allowed for a column without nulls`() {
+        val scoreOrNull = column<Double>("score").nullable()
+
+        dfWithoutNulls.countScores(scoreOrNull) shouldBe 2
+    }
+
+    @Test
+    fun `nullable on an already nullable accessor changes nothing`() {
+        val score = column<Double?>("score")
+
+        val twice: ColumnAccessor<Double?> = score.nullable()
+
+        twice shouldBeSameInstanceAs score
+    }
+
+    @Test
+    fun `castToNullable on an accessor returns a ColumnReference`() {
+        val score = column<Double>("score")
+
+        // the declared type is `ColumnReference`, so the `ColumnAccessor` members are gone,
+        // even though the object itself is still the very same accessor
+        val scoreOrNull: ColumnReference<Double?> = score.castToNullable()
+
+        scoreOrNull shouldBeSameInstanceAs score
+    }
+}


### PR DESCRIPTION
# Add KDoc for `ColumnAccessor.nullable()`

Closes #1996

`ColumnAccessor<T>.nullable()` was the only public declaration in `ColumnAccessorApi.kt`
and had no documentation at all.

The function is easy to misread as a data operation. It is a plain unchecked cast: it
returns the very same accessor object with the value type widened to `T?`, looks up no
column and reads no value. Two things are worth knowing and were not written down anywhere:

- `ColumnAccessor` is covariant, so a `ColumnAccessor<Double>` is already accepted where a
  `ColumnAccessor<Double?>` is expected. What the call changes is the declared type of the
  accessor itself.
- Without the cast, a `null` from the column arrives as a `null` in the non-nullable type
  `T` and only fails later, at the first use of the value. That is the reason the function
  exists, so the KDoc now says it.

## Files

`core/.../api/ColumnAccessorApi.kt` — the KDoc, following the structure of `first.kt`.

`core/.../test/.../api/ColumnAccessorApi.kt` — new `ColumnAccessorApiTests`, one test per
documented claim.

`KDOC_GUIDELINES.md` — a note in the "Examples section": keep deprecated API out of KDoc
examples, and where to find the deprecation constants.

## Example

The example shows a `concat` with a frame that has no `score` column, because that is how
the nulls appear in practice. The same scenario is asserted by the test named
`KDoc example nullable`, so the example cannot silently rot.

## Tests

`nullable()` had no test of its own before; its only usage was incidental, inside a `concat`
test.

Nine tests, one per claim: the KDoc example; a `null` read through a non-nullable accessor
(it returns `null` and throws `NullPointerException` only at the first use); the return type
and object identity; the name and the path for a plain, a nested and a column-group
accessor; a missing column and a column without nulls; an already nullable accessor; and the
return type of `castToNullable` on an accessor, which the "See also" section refers to.

Where the return type *is* the contract, it is pinned by an explicit type annotation, so the
compiler is the assertion. All expected values are written out literally.

## Open questions

**Should this function be deprecated instead?** Almost everything that reads through an
accessor is already `@Deprecated(DEPRECATED_ACCESS_API)`: `df[accessor]`, `row[accessor]`,
`accessor()`, `df.getColumn(accessor)`. The only supported reading path left is
`accessor.getValue(row)`, which is why the example uses it. If the Column Accessors API is
going away, `nullable()` should probably go with it, and this KDoc documents an API on its
way out. Please tell me which way you want it.

**`inline` / `reified` look unnecessary.** `cast()` here resolves to the non-reified
`ColumnAccessor<*>.cast()`, and a plain `fun <T> ColumnAccessor<T>.nullable()` compiles
fine, call sites included. I left the signature untouched, because it is public and out of
scope for a KDoc issue.

**`@param [T]`.** The guidelines ask to document type parameters, so I did, but this one is
fully implied by the receiver type. If we do not want such `@param`s, the rule in
`KDOC_GUIDELINES.md` should be changed as well — today, the rule and the practice disagree
(16 uses across `api/`).