### PR TITLE
Rework plugin-core shadow jar publishing to completely avoid dependencies in pom; fix source dependency on :core in :samples

### DIFF
--- a/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
+++ b/build-logic/src/main/kotlin/dfbuild.kotlinJvmCommon.gradle.kts
@@ -23,7 +23,3 @@ artifacts {
         builtBy(tasks.jar)
     }
 }
-
-dependencies {
-    testImplementation(project(":common-test-utils"))
-}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     testImplementation(libs.kotestAssertions) {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     }
-
+    testImplementation(projects.commonTestUtils)
     // kotest shouldBe forcefully escapes newlines when content is identical except additional newlines
     // which makes diff very hard to perceive. CodeGenerationTests.kt suffers from it a lot. using assertEquals there for working diff.
     testImplementation(kotlin("test"))

--- a/dataframe-arrow/build.gradle.kts
+++ b/dataframe-arrow/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     }
     testImplementation(libs.arrow.c.data)
     testImplementation(libs.duckdb.jdbc)
+    testImplementation(projects.commonTestUtils)
 }
 
 kotlinPublications {

--- a/dataframe-compiler-plugin-core/AGENTS.md
+++ b/dataframe-compiler-plugin-core/AGENTS.md
@@ -18,8 +18,8 @@ disabled legacy copy — see the root `AGENTS.md`.)
 
 ## Structure
 
-- **No `main` sources of its own.** The module is a repackaging (`ShadowJar`) of `:core`:
-  `implementation(projects.core)` plus a shadow config that strips what the interpreters don't need
+- **No `main` sources of its own.** The module is a repackaging (`ShadowJar`) of `:core`: 
+  shadow config that strips what the interpreters don't need
   (`jupyter/**`, `io/**`, `documentation/**`, `impl/io/**`, `kotlin-reflect`/`kotlin-stdlib`, kotlinpoet,
   serialization, …). The surviving packages are the `:core` `api`, `impl/api`, `columns`, `schema`, `codeGen`,
   and `annotations` code.

--- a/dataframe-compiler-plugin-core/build.gradle.kts
+++ b/dataframe-compiler-plugin-core/build.gradle.kts
@@ -13,8 +13,13 @@ plugins {
 
 group = "org.jetbrains.kotlinx.dataframe"
 
+val shadowCore = configurations.create("shadowCore") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
-    implementation(projects.core) {
+    shadowCore(projects.core) {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-datetime-jvm")
@@ -22,26 +27,28 @@ dependencies {
         exclude(group = "commons-io", module = "commons-csv")
         exclude(group = "org.apache.commons", module = "commons-csv")
         exclude(group = "org.slf4j", module = "slf4j-api")
-        exclude(group = "io.github.microutils", module = "kotlin-logging-jvm")
+        exclude(group = "io.github.oshai", module = "kotlin-logging")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core-jvm")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json-jvm")
         exclude(group = "commons-codec", module = "commons-codec")
-        exclude(group = "com.squareup", module = "kotlinpoet-jvm")
+        exclude(group = "com.squareup", module = "kotlinpoet")
         exclude(group = "ch.randelshofer", module = "fastdoubleparser")
-        exclude(group = "io.github.oshai", module = "kotlin-logging-jvm")
         exclude(group = "org.jetbrains", module = "annotations")
     }
 
     // we assume Kotlin plugin has reflect dependency - we're not bringing our own version
     testImplementation(libs.kotlin.reflect)
     testImplementation(libs.kotlin.test.junit5)
+    testImplementation(files(tasks.named<ShadowJar>("shadowJar")))
 }
 
 tasks.test {
+    dependsOn(tasks.named<ShadowJar>("shadowJar"))
     useJUnitPlatform()
 }
 
 tasks.withType<ShadowJar> {
+    configurations = listOf(shadowCore)
     dependencies {
         exclude(dependency("org.jetbrains.kotlin:kotlin-reflect:.*"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib:.*"))
@@ -50,13 +57,12 @@ tasks.withType<ShadowJar> {
         exclude(dependency("commons-io:commons-csv:.*"))
         exclude(dependency("org.apache.commons:commons-csv:.*"))
         exclude(dependency("org.slf4j:slf4j-api:.*"))
-        exclude(dependency("io.github.microutils:kotlin-logging-jvm:.*"))
+        exclude(dependency("io.github.oshai:kotlin-logging:.*"))
         exclude(dependency("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:.*"))
         exclude(dependency("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:.*"))
         exclude(dependency("commons-codec:commons-codec:.*"))
-        exclude(dependency("com.squareup:kotlinpoet-jvm:.*"))
+        exclude(dependency("com.squareup:kotlinpoet:.*"))
         exclude(dependency("ch.randelshofer:fastdoubleparser:.*"))
-        exclude(dependency("io.github.oshai:kotlinlogging:.*"))
         exclude(dependency("org.jetbrains:annotations:.*"))
     }
     exclude("org/jetbrains/kotlinx/dataframe/jupyter/**")
@@ -88,5 +94,12 @@ kotlinPublications {
         publicationName = "shadowed"
         artifactId = "dataframe-compiler-plugin-core"
         packageName = artifactId
+        composeOf {
+            artifact(tasks.named<ShadowJar>("shadowJar")) {
+                classifier = null
+            }
+            artifact(tasks.named("sourcesJar"))
+            artifact(tasks.named("javadocJar"))
+        }
     }
 }

--- a/dataframe-csv/build.gradle.kts
+++ b/dataframe-csv/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     testImplementation(libs.kotestAssertions) {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     }
+    testImplementation(projects.commonTestUtils)
 }
 
 benchmark {

--- a/dataframe-excel/build.gradle.kts
+++ b/dataframe-excel/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testImplementation(libs.kotestAssertions) {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     }
+    testImplementation(projects.commonTestUtils)
 }
 
 kotlinPublications {

--- a/dataframe-geo/build.gradle.kts
+++ b/dataframe-geo/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(projects.dataframeJson)
+    testImplementation(projects.commonTestUtils)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/dataframe-jdbc/build.gradle.kts
+++ b/dataframe-jdbc/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     }
     testImplementation(libs.hikaricp)
+    testImplementation(projects.commonTestUtils)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.mysql)

--- a/dataframe-json/build.gradle.kts
+++ b/dataframe-json/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     }
     testImplementation(libs.sl4jsimple)
+    testImplementation(projects.commonTestUtils)
 }
 
 tasks.withType<KotlinCompile> {

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.github.devcrocod.korro.KorroGenerateTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.kotlin.dsl.libs
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Files
@@ -46,6 +48,50 @@ val dependentProjectJarPaths = dependentProjects.map {
         .artifacts.single()
         .file.absolutePath
         .replace(File.separatorChar, '/')
+}
+
+val coreProjectPath = projects.core.path
+
+val compilerPluginClasspaths = configurations.matching {
+    it.name in setOf("compileClasspath", "testCompileClasspath")
+}
+
+val configurationsThatAffectCompilerPluginResolve = setOf("api", "implementation", "compileOnly", "compileOnlyApi")
+
+fun Configuration.coreDependencyPath(visited: MutableSet<Configuration> = mutableSetOf()): List<String>? {
+    if (!visited.add(this)) return null
+
+    dependencies.filterIsInstance<ProjectDependency>().forEach { dependency ->
+        if (dependency.path == coreProjectPath) return listOf(coreProjectPath)
+
+        rootProject.project(dependency.path).configurations
+            .filter { it.name in configurationsThatAffectCompilerPluginResolve }
+            .forEach { configuration ->
+                configuration.coreDependencyPath(visited)?.let {
+                    return listOf("${dependency.path}:${configuration.name}") + it
+                }
+            }
+    }
+
+    extendsFrom.forEach { configuration ->
+        configuration.coreDependencyPath(visited)?.let {
+            return listOf("${project.path}:${configuration.name}") + it
+        }
+    }
+
+    return null
+}
+
+gradle.projectsEvaluated {
+    compilerPluginClasspaths.forEach {
+        val dependencyPath = it.coreDependencyPath()
+        require(dependencyPath == null) {
+            val fullDependencyPath = listOf("${project.path}:${it.name}") + dependencyPath.orEmpty()
+            "Module ${project.path} with DataFrame compiler plugin cannot use source dependency $coreProjectPath " +
+                "on $it. Dependency path: ${fullDependencyPath.joinToString(" -> ")}. " +
+                "Depend on the prebuilt instrumentedJars artifact instead."
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Before, the problem was that even though dependency is excluded and actually no files are bundled, Gradle dependency verification still picks up that core dependency brings slf4j-api (we exclude it).

diff of gradle/verification-metadata.xml in Kotlin after update to 1.0.0-dev-11225
<img width="1528" height="334" alt="image" src="https://github.com/user-attachments/assets/bc066aa4-54e7-48f9-96c2-d5809a2bd5ad" />


Also, i had to rollback common-test-utils to opt in basis. I decided to do it in this PR because solution to original problem also required to exclude core dependency from testImplementation of dataframe-plugin-core. But we also have 2nd similar problem. I thought since 2 modules require to remove it, it'd be reasonable to resolve both tasks here.

So, 2nd problem: convention plugin turned out to bring source dependency on :core in :samples, which causes all sorts of lazy resolve problems in IDE. DataFrame compiler plugin cannot work with source :core dependency, it requires fully resolved binary of it. Adding safe guard to prevent misconfiguration: 

<img width="3510" height="684" alt="image" src="https://github.com/user-attachments/assets/cfa47c00-2c00-4fbf-b7ba-956e364fdb58" />
(what now happens if someone adds it by accident)


