### PR TITLE
Support `get` as alias to `cols` in CSL DSL in compiler plugin

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/cols.kt
@@ -421,6 +421,7 @@ public interface ColsColumnsSelectionDsl<out _UNUSED> {
     ): ColumnSet<C> = asSingleColumn().cols(firstCol, *otherCols)
 
     /** @include [ColumnsSelectionDslColsVarargColumnReferenceDocs] */
+    @Interpretable("Cols0")
     public operator fun <C> ColumnsSelectionDsl<*>.get(
         firstCol: ColumnReference<C>,
         vararg otherCols: ColumnReference<C>,


### PR DESCRIPTION
<img width="1222" height="686" alt="image" src="https://github.com/user-attachments/assets/6af3e19b-335b-4b98-a288-c4c79cb19ec7" />
They are exactly the same, so i mirrored the interpetable