### PR TITLE
Added KDocs for `api/schema.kt` 

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/groupBy.kt
@@ -626,6 +626,8 @@ public interface GroupBy<out T, out G> : Grouped<G> {
      *
      * For more information: {@include [DocumentationUrls.GroupByAggregation]}
      *
+     * See also [schema][GroupBy.schema] — the schema of this [GroupBy] as a [DataFrame].
+     *
      * @param groupedColumnName The name of the column in which to store grouped data;
      * if `null`, a default name will be used.
      * @return A new [DataFrame] that includes the grouping key columns together

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -17,16 +17,11 @@ import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 internal interface SchemaDocs {
 
     /**
-     * A [DataFrame] has two schemas that do not have to agree.
-     * [schema][DataFrame.schema] gives the **runtime** one, read from the columns the [DataFrame]
-     * holds; [compileTimeSchema][DataFrame.compileTimeSchema] gives the **compile-time** one,
+     * A [DataFrame] has two schemas that do not have to agree:
+     * the **runtime** one, read from the columns it holds, and the **compile-time** one,
      * read from the type argument `T` of `DataFrame<T>`.
-     * The two differ when the type of a [DataFrame] does not fit its columns,
-     * for example after a [cast] to a schema the data does not have;
-     * comparing the two is how you notice.
-     *
-     * The runtime schema is also reachable from a [DataRow] — [schema][DataRow.schema] —
-     * and from a [GroupBy] — [schema][GroupBy.schema].
+     * They differ when the type does not fit the columns, for example after a [cast]
+     * to a schema the data does not have; comparing them is how you notice.
      *
      * Use [print][DataFrameSchema.print] to write a schema out as a tree,
      * and [compare][DataFrameSchema.compare] to relate two schemas to each other.
@@ -37,8 +32,7 @@ internal interface SchemaDocs {
     /**
      * {@comment The input of the `schema` examples below. KDoc-snippet.
      *    Every output that follows it is an expected value in `SchemaKDocExampleTests`.}
-     * The examples below use the [DataFrame] from the
-     * [`schema` page on the documentation website]({@include [DocumentationUrls.Url]}/schema.html):
+     * The examples below use the same [DataFrame] as the `schema` page on the documentation website:
      * a `name` [column group][ColumnGroup] holding `firstName` and `lastName`,
      * and the columns `age`, `city`, `weight` and `isHappy`.
      */
@@ -60,7 +54,6 @@ internal interface SchemaDocs {
  * For more information: {@include [DocumentationUrls.Schema]}
  *
  * ### Example
- *
  * @include [SchemaDocs.ExampleDataSnippet]
  *
  * ```kotlin
@@ -69,6 +62,8 @@ internal interface SchemaDocs {
  * ```
  *
  * @return The [DataFrameSchema] of the [DataFrame] this row is part of.
+ * @see [DataFrame.schema]
+ * @see [DataFrame.compileTimeSchema]
  */
 public fun DataRow<*>.schema(): DataFrameSchema = owner.schema()
 
@@ -90,7 +85,6 @@ public fun DataRow<*>.schema(): DataFrameSchema = owner.schema()
  * For more information: {@include [DocumentationUrls.Schema]}
  *
  * ### Example
- *
  * @include [SchemaDocs.ExampleDataSnippet]
  *
  * ```kotlin
@@ -110,6 +104,9 @@ public fun DataRow<*>.schema(): DataFrameSchema = owner.schema()
  * ```
  *
  * @return The [DataFrameSchema] of this [DataFrame].
+ * @see [DataFrame.compileTimeSchema]
+ * @see [DataRow.schema]
+ * @see [GroupBy.schema]
  */
 @RequiredByIntellijPlugin
 public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
@@ -130,7 +127,6 @@ public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
  * For more information: {@include [DocumentationUrls.Schema]}
  *
  * ### Example
- *
  * @include [SchemaDocs.ExampleDataSnippet]
  *
  * ```kotlin
@@ -152,6 +148,8 @@ public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
  * ```
  *
  * @return The [DataFrameSchema] of this [GroupBy] as a [DataFrame].
+ * @see [GroupBy.toDataFrame]
+ * @see [DataFrame.schema]
  */
 public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
 
@@ -165,7 +163,7 @@ public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
  *
  * [T] is a schema marker — a [DataSchema] declaration you wrote yourself,
  * or the one the compiler plugin produced for the result of an operation.
- * When [T] declares no properties, as in `DataFrame<*>`, the returned schema has no columns.
+ * When [T] is not a schema marker, as in `DataFrame<*>`, the returned schema has no columns.
  *
  * @include [SchemaDocs.SchemaSourcesSnippet]
  *
@@ -174,8 +172,7 @@ public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
  * On schema markers and the plugin that writes them: {@include [DocumentationUrls.CompilerPlugin]}
  *
  * ### Example
- *
- * {@comment Both outputs below are expected values in `SchemaTests`.}
+ * {@comment Both outputs below are expected values in `SchemaKDocExampleTests`.}
  * ```kotlin
  * @DataSchema
  * interface Person {
@@ -188,15 +185,18 @@ public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
  * // name: String, age: Int — sorted like the columns of df
  * df.compileTimeSchema()
  *
- * // age: Int, name: String — the order T gives them in, which here is not the order of df
+ * // age: Int, name: String — the compiler-plugin representation order, not the order of df
  * df.compileTimeSchema(ordered = false)
  * ```
  *
- * @param [T] The schema marker of this [DataFrame]; its properties become the columns of the result.
  * @param [ordered] If `true` (the default), the columns are sorted to match the order of the
- *   [runtime schema][DataFrame.schema], so that the two schemas are easy to compare.
- *   If `false`, the order comes from [T] and does not have to match the [DataFrame].
+ *   [runtime schema][DataFrame.schema], so that the two schemas are easy to compare;
+ *   a column the runtime schema does not have comes first.
+ *   If `false`, the columns are ordered as they are represented in the compiler plugin:
+ *   by the primary constructor for a `data class` marker, and otherwise in the order
+ *   reflection reports the properties of [T] in — which is not their declaration order.
  * @return The [DataFrameSchema] that follows from the type argument [T] of this [DataFrame].
+ * @see [DataFrame.schema]
  */
 public inline fun <reified T> DataFrame<T>.compileTimeSchema(ordered: Boolean = true): DataFrameSchema =
     compileTimeSchemaImpl(if (ordered) schema() else null, T::class)

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -2,20 +2,115 @@ package org.jetbrains.kotlinx.dataframe.api
 
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
 import org.jetbrains.kotlinx.dataframe.annotations.RequiredByIntellijPlugin
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
+import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.jetbrains.kotlinx.dataframe.documentation.DocumentationUrls
+import org.jetbrains.kotlinx.dataframe.documentation.ExcludeFromSources
 import org.jetbrains.kotlinx.dataframe.impl.api.compileTimeSchemaImpl
 import org.jetbrains.kotlinx.dataframe.impl.owner
 import org.jetbrains.kotlinx.dataframe.impl.schema.extractSchema
 import org.jetbrains.kotlinx.dataframe.schema.DataFrameSchema
 
+@ExcludeFromSources
+internal interface SchemaDocs {
+
+    /**
+     * A [DataFrame] has two schemas that do not have to agree.
+     * [schema][DataFrame.schema] gives the **runtime** one, read from the columns the [DataFrame]
+     * holds; [compileTimeSchema][DataFrame.compileTimeSchema] gives the **compile-time** one,
+     * read from the type argument `T` of `DataFrame<T>`.
+     * The two differ when the type of a [DataFrame] does not fit its columns,
+     * for example after a [cast] to a schema the data does not have;
+     * comparing the two is how you notice.
+     *
+     * The runtime schema is also reachable from a [DataRow] — [schema][DataRow.schema] —
+     * and from a [GroupBy] — [schema][GroupBy.schema].
+     *
+     * Use [print][DataFrameSchema.print] to write a schema out as a tree,
+     * and [compare][DataFrameSchema.compare] to relate two schemas to each other.
+     */
+    @ExcludeFromSources
+    typealias SchemaSourcesSnippet = Nothing
+
+    /**
+     * {@comment The input of the `schema` examples below. KDoc-snippet.
+     *    Every output that follows it is an expected value in `SchemaKDocExampleTests`.}
+     * The examples below use the [DataFrame] from the
+     * [`schema` page on the documentation website]({@include [DocumentationUrls.Url]}/schema.html):
+     * a `name` [column group][ColumnGroup] holding `firstName` and `lastName`,
+     * and the columns `age`, `city`, `weight` and `isHappy`.
+     */
+    @ExcludeFromSources
+    typealias ExampleDataSnippet = Nothing
+}
+
 // region DataRow
 
+/**
+ * Returns the runtime [DataFrameSchema] of the [DataFrame] this row is part of.
+ *
+ * The result describes all columns of that [DataFrame], not just the values of this one row,
+ * so every row of the same [DataFrame] gives the same schema.
+ * For a row taken out of a [column group][ColumnGroup], it is the schema of that group.
+ *
+ * @include [SchemaDocs.SchemaSourcesSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.Schema]}
+ *
+ * ### Example
+ *
+ * @include [SchemaDocs.ExampleDataSnippet]
+ *
+ * ```kotlin
+ * // the columns of df, not the values of the single row
+ * df.first().schema().columns.keys // [name, age, city, weight, isHappy]
+ * ```
+ *
+ * @return The [DataFrameSchema] of the [DataFrame] this row is part of.
+ */
 public fun DataRow<*>.schema(): DataFrameSchema = owner.schema()
 
 // endregion
 
 // region DataFrame
 
+/**
+ * Returns the runtime [DataFrameSchema] of this [DataFrame], read from the columns it holds.
+ *
+ * Because it comes from the columns and not from the type argument of this [DataFrame],
+ * it always fits the data.
+ * A [column group][ColumnGroup] contributes the schema of its nested columns;
+ * a [frame column][FrameColumn] contributes only the columns that all of its
+ * non-empty dataframes have.
+ *
+ * @include [SchemaDocs.SchemaSourcesSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.Schema]}
+ *
+ * ### Example
+ *
+ * @include [SchemaDocs.ExampleDataSnippet]
+ *
+ * ```kotlin
+ * df.schema()
+ * ```
+ *
+ * Written out, a column group is shown by indentation and a frame column by `*`:
+ *
+ * ```text
+ * name:
+ *     firstName: String
+ *     lastName: String
+ * age: Int
+ * city: String?
+ * weight: Int?
+ * isHappy: Boolean
+ * ```
+ *
+ * @return The [DataFrameSchema] of this [DataFrame].
+ */
 @RequiredByIntellijPlugin
 public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
 
@@ -23,13 +118,87 @@ public fun DataFrame<*>.schema(): DataFrameSchema = extractSchema()
 
 // region GroupBy
 
+/**
+ * Returns the runtime [DataFrameSchema] of this [GroupBy] seen as a [DataFrame]:
+ * the key columns, followed by a [frame column][FrameColumn] named `group` holding the groups.
+ *
+ * This is the schema of [toDataFrame][GroupBy.toDataFrame], which is why the group column
+ * carries its default name here.
+ *
+ * @include [SchemaDocs.SchemaSourcesSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.Schema]}
+ *
+ * ### Example
+ *
+ * @include [SchemaDocs.ExampleDataSnippet]
+ *
+ * ```kotlin
+ * df.groupBy { city }.schema()
+ * ```
+ *
+ * The key column comes first, and the groups keep every column of `df`:
+ *
+ * ```text
+ * city: String?
+ * group: *
+ *     name:
+ *         firstName: String
+ *         lastName: String
+ *     age: Int
+ *     city: String?
+ *     weight: Int?
+ *     isHappy: Boolean
+ * ```
+ *
+ * @return The [DataFrameSchema] of this [GroupBy] as a [DataFrame].
+ */
 public fun GroupBy<*, *>.schema(): DataFrameSchema = toDataFrame().schema()
 
 // endregion
 
+// region compileTimeSchema
+
 /**
- * [ordered] - if true, columns are ordered the same as in runtime schema for easier diff between the two.
- * if false, columns are ordered as they are represented in the compiler plugin
+ * Returns the compile-time [DataFrameSchema] of this [DataFrame]:
+ * the schema that follows from its type argument [T], not from the columns it holds.
+ *
+ * [T] is a schema marker — a [DataSchema] declaration you wrote yourself,
+ * or the one the compiler plugin produced for the result of an operation.
+ * When [T] declares no properties, as in `DataFrame<*>`, the returned schema has no columns.
+ *
+ * @include [SchemaDocs.SchemaSourcesSnippet]
+ *
+ * For more information: {@include [DocumentationUrls.Schema]}
+ *
+ * On schema markers and the plugin that writes them: {@include [DocumentationUrls.CompilerPlugin]}
+ *
+ * ### Example
+ *
+ * {@comment Both outputs below are expected values in `SchemaTests`.}
+ * ```kotlin
+ * @DataSchema
+ * interface Person {
+ *     val name: String
+ *     val age: Int
+ * }
+ *
+ * val df = dataFrameOf("name", "age")("Alice", 15).cast<Person>()
+ *
+ * // name: String, age: Int — sorted like the columns of df
+ * df.compileTimeSchema()
+ *
+ * // age: Int, name: String — the order T gives them in, which here is not the order of df
+ * df.compileTimeSchema(ordered = false)
+ * ```
+ *
+ * @param [T] The schema marker of this [DataFrame]; its properties become the columns of the result.
+ * @param [ordered] If `true` (the default), the columns are sorted to match the order of the
+ *   [runtime schema][DataFrame.schema], so that the two schemas are easy to compare.
+ *   If `false`, the order comes from [T] and does not have to match the [DataFrame].
+ * @return The [DataFrameSchema] that follows from the type argument [T] of this [DataFrame].
  */
 public inline fun <reified T> DataFrame<T>.compileTimeSchema(ordered: Boolean = true): DataFrameSchema =
     compileTimeSchemaImpl(if (ordered) schema() else null, T::class)
+
+// endregion

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/documentation/DocumentationUrls.kt
@@ -254,6 +254,9 @@ public interface DocumentationUrls {
     /** [See `Data Schemas/Data Classes Generation` on the documentation website.]({@include [Url]}/dataschemagenerationmethods.html) */
     public typealias DataSchemaGeneration = Nothing
 
+    /** [See `schema` on the documentation website.]({@include [Url]}/schema.html) */
+    public typealias Schema = Nothing
+
     /** [See `format` on the documentation website.]({@include [Url]}/format.html) */
     public typealias Format = Nothing
 

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchema.kt
@@ -4,7 +4,10 @@ import org.jetbrains.kotlinx.dataframe.AnyFrame
 import org.jetbrains.kotlinx.dataframe.AnyRow
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.columns.ColumnGroup
 import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.jetbrains.kotlinx.dataframe.columns.FrameColumn
+import org.jetbrains.kotlinx.dataframe.columns.ValueColumn
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.LENIENT
 import org.jetbrains.kotlinx.dataframe.schema.ComparisonMode.STRICT
 import kotlin.reflect.KType
@@ -12,6 +15,16 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.isSupertypeOf
 import kotlin.reflect.typeOf
 
+/**
+ * Describes a single column of a [DataFrameSchema]: what [kind] of column it is, what [type] it holds,
+ * and, for the two nested kinds, the schema of what is inside it.
+ *
+ * There is one subclass per [column kind][ColumnKind]:
+ *
+ * - [Value] — a [value column][ValueColumn], described by the common [type] of its values.
+ * - [Group] — a [column group][ColumnGroup], described by the [schema][Group.schema] of its nested columns.
+ * - [Frame] — a [frame column][FrameColumn], described by the [schema][Frame.schema] of the dataframes it holds.
+ */
 public sealed class ColumnSchema {
 
     /** Either [Value] or [Group] or [Frame]. */
@@ -36,6 +49,7 @@ public sealed class ColumnSchema {
      */
     public abstract val contentType: KType?
 
+    /** The schema of a [value column][ValueColumn]. */
     public class Value(public override val type: KType) : ColumnSchema() {
         override val kind: ColumnKind = ColumnKind.Value
         override val nullable: Boolean = type.isMarkedNullable
@@ -51,6 +65,11 @@ public sealed class ColumnSchema {
             }
     }
 
+    /**
+     * The schema of a [column group][ColumnGroup].
+     *
+     * @property [schema] The [DataFrameSchema] of the columns nested in the group.
+     */
     public class Group(public val schema: DataFrameSchema, override val contentType: KType?) : ColumnSchema() {
         override val kind: ColumnKind = ColumnKind.Group
 
@@ -65,6 +84,11 @@ public sealed class ColumnSchema {
             )
     }
 
+    /**
+     * The schema of a [frame column][FrameColumn].
+     *
+     * @property [schema] The [DataFrameSchema] of the dataframes held by the column.
+     */
     public class Frame(
         public val schema: DataFrameSchema,
         override val nullable: Boolean,
@@ -92,6 +116,22 @@ public sealed class ColumnSchema {
         }
     }
 
+    /**
+     * Compares this column schema with the [other] column schema.
+     *
+     * Column schemas of different [kinds][kind] are never comparable: the result is then
+     * [CompareResult.None], whatever the [comparisonMode] is.
+     *
+     * For [Value] the [types][type] are compared, for [Group] and [Frame] their
+     * [DataFrameSchema]s. How strict that comparison is, is decided by the [comparisonMode];
+     * see [ComparisonMode] for what each mode means.
+     *
+     * @param [other] The column schema to compare this one with.
+     * @param [comparisonMode] The [mode][ComparisonMode] to compare the column schemas by.
+     * @return a [CompareResult] that indicates whether this column schema compared to [other] is
+     *   [matching][CompareResult.Matches], [derived][CompareResult.IsDerived],
+     *   [superset][CompareResult.IsSuper], or [incomparable][CompareResult.None].
+     */
     public fun compare(other: ColumnSchema, comparisonMode: ComparisonMode = LENIENT): CompareResult {
         if (kind != other.kind) return CompareResult.None
         if (this === other) return CompareResult.Matches

--- a/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
+++ b/core/src/main/kotlin/org/jetbrains/kotlinx/dataframe/schema/DataFrameSchema.kt
@@ -53,6 +53,11 @@ public interface DataFrameSchema {
  * - For column groups, it contains the [DataFrameSchema] of the nested columns.
  * - For frame columns, it contains the [DataFrameSchema] of the contained dataframes.
  *
+ * Use [schema][org.jetbrains.kotlinx.dataframe.DataFrame.schema] to read the schema of a
+ * [DataFrame][org.jetbrains.kotlinx.dataframe.DataFrame] from its columns, and
+ * [compileTimeSchema][org.jetbrains.kotlinx.dataframe.DataFrame.compileTimeSchema] to get the one
+ * that follows from its type.
+ *
  * Use [compare][org.jetbrains.kotlinx.dataframe.impl.schema.DataFrameSchemaImpl.compare]
  * to compare this schema with another schema using different [comparison modes][ComparisonMode].
  * The comparison ignores column order and can report how the schemas are related.

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -1,15 +1,134 @@
 package org.jetbrains.kotlinx.dataframe.api
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.DataRow
+import org.jetbrains.kotlinx.dataframe.annotations.DataSchema
+import org.jetbrains.kotlinx.dataframe.samples.api.TestBase
+import org.jetbrains.kotlinx.dataframe.samples.api.city
 import org.junit.Test
 
 class SchemaTests {
+
+    // the schema marker of the `compileTimeSchema` KDoc example, annotated exactly as it is there
+    @DataSchema
+    interface Person {
+        val name: String
+        val age: Int
+    }
+
     @Test
     fun `columns order test`() {
         val row = dataFrameOf("c", "b")(4, 5).first()
         val df = dataFrameOf("abc", "a", "a123", "nested")(1, 2, 3, row).cast<Schema>()
         df.schema().toString() shouldBe df.compileTimeSchema().toString()
+    }
+
+    @Test
+    fun `schema is read from the columns, not from the type argument`() {
+        // the type argument declares `b` and `c`, while the columns are `name` and `age`
+        val df = dataFrameOf("name", "age")("Alice", 15).cast<Nested>()
+        df.schema().toString() shouldBe
+            """
+            |name: String
+            |age: Int
+            """.trimMargin()
+    }
+
+    @Test
+    fun `frame column schema keeps only the columns all its dataframes have`() {
+        val outer = dataFrameOf("g")(
+            dataFrameOf("a", "b")(1, 2),
+            dataFrameOf("a", "c")(3, 4),
+        )
+        // only `a` is in both, so neither `b` nor `c` is in the schema
+        outer.schema().toString() shouldBe
+            """
+            |g: *
+            |    a: Int
+            |
+            """.trimMargin()
+    }
+
+    @Test
+    fun `empty dataframes in a frame column are left out of the schema`() {
+        val outer = dataFrameOf("g")(
+            dataFrameOf("a", "b")(1, 2),
+            DataFrame.empty(),
+        )
+        // the empty dataframe does not take `a` and `b` away
+        outer.schema().toString() shouldBe
+            """
+            |g: *
+            |    a: Int
+            |    b: Int
+            |
+            """.trimMargin()
+    }
+
+    @Test
+    fun `row schema describes the whole dataframe and is the same for every row`() {
+        val df = dataFrameOf("name", "age")("Alice", 15, "Bob", 20)
+        val expected =
+            """
+            |name: String
+            |age: Int
+            """.trimMargin()
+        df[0].schema().toString() shouldBe expected
+        df[1].schema().toString() shouldBe expected
+    }
+
+    @Test
+    fun `row of a column group has the schema of that group`() {
+        val df = dataFrameOf("name", "age")("Alice", 15).group("name", "age").into("g")
+        val groupRow = df.first()["g"] as DataRow<*>
+        groupRow.schema().toString() shouldBe
+            """
+            |name: String
+            |age: Int
+            """.trimMargin()
+    }
+
+    @Test
+    fun `groupBy schema has the key columns and a frame column named group`() {
+        val df = dataFrameOf("city", "age")("London", 1, "Paris", 2)
+        df.groupBy("city").schema().toString() shouldBe
+            """
+            |city: String
+            |group: *
+            |    city: String
+            |    age: Int
+            |
+            """.trimMargin()
+    }
+
+    @Test
+    fun `KDoc example -- compile-time schema comes from the type argument`() {
+        val df = dataFrameOf("name", "age")("Alice", 15).cast<Person>()
+        df.compileTimeSchema().toString() shouldBe
+            """
+            |name: String
+            |age: Int
+            """.trimMargin()
+        // without ordering, the order comes from the type argument and not from the columns
+        df.compileTimeSchema(ordered = false).toString() shouldBe
+            """
+            |age: Int
+            |name: String
+            """.trimMargin()
+    }
+
+    @Test
+    fun `compile-time and runtime schema differ when the type does not fit the columns`() {
+        val df = dataFrameOf("name")("Alice").cast<Person>()
+        df.schema().columns.keys shouldBe setOf("name")
+        df.compileTimeSchema().columns.keys shouldBe setOf("age", "name")
+    }
+
+    @Test
+    fun `compile-time schema of a dataframe without a schema marker has no columns`() {
+        val untyped = dataFrameOf("a")(1)
+        untyped.compileTimeSchema().columns.keys shouldBe emptySet()
     }
 }
 
@@ -23,4 +142,46 @@ private interface Schema {
 private interface Nested {
     val b: Int
     val c: Int
+}
+
+class SchemaKDocExampleTests : TestBase() {
+
+    @Test
+    fun `KDoc example -- schema of a row`() {
+        // the row gives the columns of df, not the single row it stands for
+        df.first().schema().columns.keys.toList() shouldBe
+            listOf("name", "age", "city", "weight", "isHappy")
+    }
+
+    @Test
+    fun `KDoc example -- schema of a dataframe`() {
+        df.schema().toString() shouldBe
+            """
+            |name:
+            |    firstName: String
+            |    lastName: String
+            |age: Int
+            |city: String?
+            |weight: Int?
+            |isHappy: Boolean
+            """.trimMargin()
+    }
+
+    @Test
+    fun `KDoc example -- schema of a groupBy`() {
+        // the frame column holding the groups carries the default name `group`
+        df.groupBy { city }.schema().toString() shouldBe
+            """
+            |city: String?
+            |group: *
+            |    name:
+            |        firstName: String
+            |        lastName: String
+            |    age: Int
+            |    city: String?
+            |    weight: Int?
+            |    isHappy: Boolean
+            |
+            """.trimMargin()
+    }
 }

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/api/schema.kt
@@ -10,13 +10,6 @@ import org.junit.Test
 
 class SchemaTests {
 
-    // the schema marker of the `compileTimeSchema` KDoc example, annotated exactly as it is there
-    @DataSchema
-    interface Person {
-        val name: String
-        val age: Int
-    }
-
     @Test
     fun `columns order test`() {
         val row = dataFrameOf("c", "b")(4, 5).first()
@@ -110,7 +103,8 @@ class SchemaTests {
             |name: String
             |age: Int
             """.trimMargin()
-        // without ordering, the order comes from the type argument and not from the columns
+        // unordered, the marker is an interface, so the order is the one reflection reports
+        // the properties in — neither the declaration order nor the order of the columns
         df.compileTimeSchema(ordered = false).toString() shouldBe
             """
             |age: Int
@@ -123,6 +117,20 @@ class SchemaTests {
         val df = dataFrameOf("name")("Alice").cast<Person>()
         df.schema().columns.keys shouldBe setOf("name")
         df.compileTimeSchema().columns.keys shouldBe setOf("age", "name")
+    }
+
+    @Test
+    fun `a column the runtime schema does not have comes first when ordered`() {
+        // `age` has no counterpart among the columns, so it has no position to be sorted into
+        val df = dataFrameOf("name")("Alice").cast<Person>()
+        df.compileTimeSchema().columns.keys.toList() shouldBe listOf("age", "name")
+    }
+
+    @Test
+    fun `unordered, a data class marker keeps its primary constructor order`() {
+        // the marker has a primary constructor, so that order wins over the reflection order
+        val df = dataFrameOf("name", "age")("Alice", 15).cast<PersonRecord>()
+        df.compileTimeSchema(ordered = false).columns.keys.toList() shouldBe listOf("name", "age")
     }
 
     @Test
@@ -144,6 +152,19 @@ private interface Nested {
     val c: Int
 }
 
+// the schema marker of the `compileTimeSchema` KDoc example, annotated exactly as it is there
+@DataSchema
+private interface Person {
+    val name: String
+    val age: Int
+}
+
+// same properties, but as a marker that has a primary constructor to take the column order from
+@DataSchema
+private data class PersonRecord(val name: String, val age: Int)
+
+// `SchemaKDocExampleTests` cannot host the `compileTimeSchema` example: it extends `TestBase`,
+// which brings its own sample `Person` schema into scope and shadows the marker declared here.
 class SchemaKDocExampleTests : TestBase() {
 
     @Test

--- a/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchemaTests.kt
+++ b/core/src/test/kotlin/org/jetbrains/kotlinx/dataframe/schema/ColumnSchemaTests.kt
@@ -1,0 +1,61 @@
+package org.jetbrains.kotlinx.dataframe.schema
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.jetbrains.kotlinx.dataframe.api.dataFrameOf
+import org.jetbrains.kotlinx.dataframe.api.first
+import org.jetbrains.kotlinx.dataframe.api.schema
+import org.jetbrains.kotlinx.dataframe.columns.ColumnKind
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class ColumnSchemaTests {
+
+    // one column of each kind: a value column, a column group (from a DataRow value)
+    // and a frame column (from a DataFrame value)
+    private val df = dataFrameOf("age", "name", "g")(
+        15,
+        dataFrameOf("first")("Alice").first(),
+        dataFrameOf("x")(1, 2),
+    )
+
+    @Test
+    fun `there is one column schema subclass per column kind`() {
+        val columns = df.schema().columns
+        columns.getValue("age").shouldBeInstanceOf<ColumnSchema.Value>().kind shouldBe ColumnKind.Value
+        columns.getValue("name").shouldBeInstanceOf<ColumnSchema.Group>().kind shouldBe ColumnKind.Group
+        columns.getValue("g").shouldBeInstanceOf<ColumnSchema.Frame>().kind shouldBe ColumnKind.Frame
+    }
+
+    @Test
+    fun `a column group schema holds the schema of its nested columns`() {
+        val group = df.schema().columns.getValue("name").shouldBeInstanceOf<ColumnSchema.Group>()
+        group.schema.toString() shouldBe "first: String"
+    }
+
+    @Test
+    fun `a frame column schema holds the schema of the dataframes in the column`() {
+        val frame = df.schema().columns.getValue("g").shouldBeInstanceOf<ColumnSchema.Frame>()
+        frame.schema.toString() shouldBe "x: Int"
+    }
+
+    @Test
+    fun `column schemas of different kinds are never comparable`() {
+        val value = df.schema().columns.getValue("age")
+        val group = df.schema().columns.getValue("name")
+        // the mode cannot make schemas of different kinds match
+        value.compare(group, ComparisonMode.LENIENT) shouldBe CompareResult.None
+        value.compare(group, ComparisonMode.STRICT) shouldBe CompareResult.None
+    }
+
+    @Test
+    fun `a value column schema is compared by its type`() {
+        val int = ColumnSchema.Value(typeOf<Int>())
+        val number = ColumnSchema.Value(typeOf<Number>())
+        // Int is a Number, so leniently the Int schema is derived from the Number one
+        int.compare(number, ComparisonMode.LENIENT) shouldBe CompareResult.IsDerived
+        // strictly, only the very same type matches
+        int.compare(number, ComparisonMode.STRICT) shouldBe CompareResult.None
+        int.compare(ColumnSchema.Value(typeOf<Int>()), ComparisonMode.STRICT) shouldBe CompareResult.Matches
+    }
+}

--- a/docs/StardustDocs/topics/schema.md
+++ b/docs/StardustDocs/topics/schema.md
@@ -2,7 +2,7 @@
 
 <!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Analyze-->
 
-Returns [`DataFrameSchema`](schemas.md) object with [`DataFrame`](DataFrame.md) schema description. It can be printed to see column structure.
+Returns a `DataFrameSchema` object with the [`DataFrame`](DataFrame.md) schema description. It can be printed to see column structure.
 
 [`ColumnGroups`](DataColumn.md#columngroup) are marked by indentation:
 

--- a/docs/StardustDocs/topics/schema.md
+++ b/docs/StardustDocs/topics/schema.md
@@ -2,7 +2,7 @@
 
 <!---IMPORT org.jetbrains.kotlinx.dataframe.samples.api.Analyze-->
 
-Returns a `DataFrameSchema` object with the [`DataFrame`](DataFrame.md) schema description. It can be printed to see column structure.
+Returns a [`DataFrameSchema`](schemas.md) object with the [`DataFrame`](DataFrame.md) schema description. It can be printed to see column structure.
 
 [`ColumnGroups`](DataColumn.md#columngroup) are marked by indentation:
 


### PR DESCRIPTION
Closes #1981.

`api/schema.kt` exposes four schema-inspection functions and none of them had a KDoc.

The thing that is easy to get wrong is that a `DataFrame` carries **two** schemas that do
not have to agree: the runtime one, read from the columns it holds, and the compile-time
one, read from the type argument `T` — they drift apart after a `cast` to a schema the data
does not have. 

The second trap is the `ordered` parameter of `compileTimeSchema`: with
`ordered = false` the column order is *not* the declaration order of `T`, it is the primary
constructor order for a `data class` marker and the reflection order otherwise.

## Files

| File | What changed |
|---|---|
| `core/…/api/schema.kt` | KDocs for the four functions; two `@ExcludeFromSources` KoDEx snippets for the shared runtime-vs-compile-time text and the shared example dataset |
| `core/…/schema/ColumnSchema.kt` | KDocs for the sealed class, its three per-kind subclasses and `compare` |
| `core/…/documentation/DocumentationUrls.kt` | new `Schema` entry for the `schema` page |
| `core/…/api/groupBy.kt`, `core/…/schema/DataFrameSchema.kt` | cross-links to the schema functions |
| `core/src/test/…/api/schema.kt` | tests for all four functions |
| `core/src/test/…/schema/ColumnSchemaTests.kt` | new — tests for `ColumnSchema` |
| `docs/StardustDocs/topics/schema.md` | one sentence reworded |

## Examples

The dataset and the calls are taken from the `schema` page on the website, so the page, the
KDocs and the tests all show the same example. Every expected output in the KDocs is an
asserted value in a `KDoc example …` test.

## Tests

Only `columns order test` existed before, and it compared the two schemas against each other
without pinning either. Expected values are explicit literals, never one implementation
compared to another.

| Behaviour | What it pins down |
|---|---|
| Runtime schema source | It comes from the columns and ignores `T` |
| Frame columns | Only the columns all the nested dataframes share; empty dataframes take nothing away |
| Row schema | Describes the whole dataframe, is equal for every row, and is the group's schema for a group row |
| `GroupBy` schema | Key columns first, then a frame column named `group` |
| `compileTimeSchema` order | `ordered = true` follows the columns and puts a column the runtime schema lacks first; `ordered = false` follows the constructor for a `data class` marker and reflection for an interface |
| `compileTimeSchema` source | Follows `T`, differs from runtime when `T` does not fit, and is empty without a marker |
| `ColumnSchema` | One subclass per column kind, nested schemas, and `compare` across kinds and by type |

## Note for the reviewer

- Scope: the ticket names only `api/schema.kt`. `ColumnSchema.kt`, `DataFrameSchema.kt`,
  `groupBy.kt` and `ColumnSchemaTests.kt` go beyond it (~105 of 465 added lines). 
- Outside this PR: `docs/StardustDocs/topics/schema.md` covers only `DataFrame.schema()` and
  `GroupBy.schema()`. It says nothing about the compile-time schema, `DataRow.schema()` or
  `compileTimeSchema()`, yet all four KDocs now point at it with "For more information".
- Outside this PR: that page links `DataFrameSchema` to `schemas.md`, which documents the
  `@DataSchema` annotation, not the `DataFrameSchema` type. Pre-existing; link left as it was.
